### PR TITLE
Fix CMake variable name

### DIFF
--- a/switchlink/sai/CMakeLists.txt
+++ b/switchlink/sai/CMakeLists.txt
@@ -17,10 +17,10 @@ add_library(switchlink_sai_o OBJECT
 )
 
 target_include_directories(switchlink_sai_o PRIVATE
-    ${SDE_INSTALL_PREFIX}/include/target-utils/third-party  # judy
-    ${SDE_INSTALL_PREFIX}/include/target-utils/third-party/tommyds
-    ${SDE_INSTALL_PREFIX}/include/target-utils/third-party/xxHash
-    ${SDE_INSTALL_PREFIX}/include/target-sys
+    ${SDE_INSTALL_DIR}/include/target-utils/third-party  # judy
+    ${SDE_INSTALL_DIR}/include/target-utils/third-party/tommyds
+    ${SDE_INSTALL_DIR}/include/target-utils/third-party/xxHash
+    ${SDE_INSTALL_DIR}/include/target-sys
     ${SAI_SOURCE_DIR}/inc
 )
 

--- a/switchutils/CMakeLists.txt
+++ b/switchutils/CMakeLists.txt
@@ -12,5 +12,5 @@ add_library(switchutils_o OBJECT
 )
 
 target_include_directories(switchutils_o PRIVATE
-    ${SDE_INSTALL_PREFIX}/include/target-sys # zlog
+    ${SDE_INSTALL_DIR}/include/target-sys # zlog
 )


### PR DESCRIPTION
- Corrected SDE_INSTALL_PREFIX to SDE_INSTALL_DIR.

Signed-off-by: Derek G Foster <derek.foster@intel.com>