### PR TITLE
Synchronize krnlmon and stratum threads

### DIFF
--- a/krnlmon_main.c
+++ b/krnlmon_main.c
@@ -1,27 +1,37 @@
 // Copyright 2022 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdio.h>
-
 #include "krnlmon_main.h"
 
-extern void *switchlink_main(void *);
+#if !defined(_GNU_SOURCE)
+#define __USE_GNU
+#endif
+#include <pthread.h>
+#include <stdio.h>
 
-static pthread_t krnlmon_tid;	
+extern void *switchlink_main(void *);
+extern void *switchlink_stop(void *);
+
+static pthread_t krnlmon_start_tid;
+static pthread_t krnlmon_stop_tid;
 
 int krnlmon_init(void) {
-     int rc = pthread_create(&krnlmon_tid, NULL, switchlink_main, NULL);
+     int rc = pthread_create(&krnlmon_start_tid, NULL, switchlink_main, NULL);
      if (rc) {
         printf("Switchlink thread creation failed, error: %d", rc);
         return -1;
      }
-     pthread_setname_np(krnlmon_tid, "krnlmon_main");
-     printf("krnlmon thread with ID %lu spawned", krnlmon_tid);
+     pthread_setname_np(krnlmon_start_tid, "switchlink_main");
 
   return 0;
 }
 
-void krnlmon_shutdown(void)
+int krnlmon_shutdown(void)
 {
-    pthread_cancel(krnlmon_tid);
+     int rc = pthread_create(&krnlmon_stop_tid, NULL, switchlink_stop, NULL);
+     if (rc) {
+        printf("Switchlink thread stop failed, error: %d", rc);
+        return -1;
+     }
+     pthread_setname_np(krnlmon_stop_tid, "switchlink_stop");
 }

--- a/krnlmon_main.h
+++ b/krnlmon_main.h
@@ -4,16 +4,13 @@
 #ifndef KRNLMON_MAIN_H_
 #define KRNLMON_MAIN_H_
 
-#if !defined(_GNU_SOURCE)
-#define _GNU_SOURCE
-#endif
-#include <pthread.h>
-
 #ifdef __cplusplus
 extern "C" {
-#endif	
+#endif
+
 int krnlmon_init(void);
-void krnlmon_shutdown(void);
+int krnlmon_shutdown(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/switchlink/switchlink.h
+++ b/switchlink/switchlink.h
@@ -50,7 +50,7 @@ extern switchlink_handle_t g_cpu_rx_nhop_h;
 struct nl_sock *switchlink_get_nl_sock(void);
 
 /* P4-OVS: Define a flag for P4-OVS ?*/
-int switchlink_stop(void);
+void *switchlink_stop(void *);
 void *switchlink_main(void *);
 
 typedef enum switchlink_entry_type {


### PR DESCRIPTION
Start krnlmon init and shutdown thread after receiving appropriate signal from stratum thread signaling that P4RT servers are started
Signed-off-by: Nupur Uttarwar <nupur.uttarwar@intel.com>