### PR TITLE
Fix compiler warning in switchlink_utils.c

### DIFF
--- a/switchlink/switchlink_utils.c
+++ b/switchlink/switchlink_utils.c
@@ -17,6 +17,8 @@
 
 #include "switchlink_utils.h"
 
+#include <string.h>
+
 uint32_t ipv4_prefix_len_to_mask(uint32_t prefix_len) {
   return (prefix_len ? (((uint32_t)0xFFFFFFFF) << (32 - prefix_len)) : 0);
 }


### PR DESCRIPTION
- Added #include <string.h> to define memset library function.

Signed-off-by: Derek G Foster <derek.foster@intel.com>