### PR TITLE
Fix compiler warning

### DIFF
--- a/krnlmon_main.c
+++ b/krnlmon_main.c
@@ -3,9 +3,7 @@
 
 #include "krnlmon_main.h"
 
-#if !defined(_GNU_SOURCE)
-#define __USE_GNU
-#endif
+#define _GNU_SOURCE
 #include <pthread.h>
 #include <stdio.h>
 


### PR DESCRIPTION
- Set _GNU_SOURCE instead of __USE_GNU to enable the pthread_setname_np declaration in <pthread.h>.

Signed-off-by: Derek G Foster <derek.foster@intel.com>