### PR TITLE
Fix path injection weakness in switchlink

### DIFF
--- a/switchlink/switchlink_link.c
+++ b/switchlink/switchlink_link.c
@@ -106,6 +106,7 @@ void process_link_msg(struct nlmsghdr *nlmsg, int type) {
       case IFLA_IFNAME:
         snprintf(intf_info.ifname,
                  SWITCHLINK_INTERFACE_NAME_LEN_MAX,
+                 "%s",
                  nla_get_string(attr));
         krnlmon_log_debug("Interface name is %s\n", intf_info.ifname);
         break;
@@ -199,6 +200,7 @@ void process_link_msg(struct nlmsghdr *nlmsg, int type) {
       case SWITCHLINK_LINK_TYPE_VXLAN: {
         snprintf(tnl_intf_info.ifname,
                  SWITCHLINK_INTERFACE_NAME_LEN_MAX,
+                 "%s",
                  intf_info.ifname);
         tnl_intf_info.dst_ip = remote_ip_addr;
         tnl_intf_info.src_ip = src_ip_addr;


### PR DESCRIPTION
- The switchlink code issues a couple of snprintfs to format the string returned by a function. They pass the return value in place of the format parameter, which which could potentially make the call site vulnerable to path injection. Addressed this weakness by adding a "%s" format string.

Signed-off-by: Derek G Foster <derek.foster@intel.com>