### PR TITLE
Fix compiler warnings in krnlmon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,10 @@
 # TODO: Make Kernel Monitor a package.
 cmake_minimum_required(VERSION 3.5)
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+add_compile_options(-Werror)
+
 include_directories(.)
 
 add_subdirectory(switchapi)
@@ -33,8 +37,6 @@ set_target_properties(krnlmon PROPERTIES
     LINK_OPTIONS -Wl,--version-script=libkrnlmon.sym
     LINK_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libkrnlmon.sym
 )
-
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Version number for .pc file.
 set(VERSION 1.0)

--- a/switchapi/switch_nhop_int.h
+++ b/switchapi/switch_nhop_int.h
@@ -75,12 +75,8 @@ extern "C" {
   })
 
 #define switch_nhop_get_group(_device, _handle, _info)                    \
-  ({                                                                \
-    switch_nhop_info_t *_tmp_nhop_info = NULL;                      \
-    (void)(_tmp_nhop_info == *_info);                               \
     switch_handle_get(                                              \
-        _device, SWITCH_HANDLE_TYPE_NHOP_GROUP, _handle, (void **)_info); \
-  })
+        _device, SWITCH_HANDLE_TYPE_NHOP_GROUP, _handle, (void **)_info)
 
 #define switch_nhop_group_delete_handle(_device, _handle) \
   switch_handle_delete(_device, SWITCH_HANDLE_TYPE_NHOP_GROUP, _handle)

--- a/switchapi/switch_pd_routing.c
+++ b/switchapi/switch_pd_routing.c
@@ -1046,7 +1046,7 @@ switch_status_t switch_pd_handle_group(switch_device_t device,
         krnlmon_log_info("Populate nhop member in selector table for "
                   "NHOP group handle %x",
                   (unsigned int) nhop_group_pd_info->nhop_group_handle);
-        tommy_node* node = tommy_list_head(&(nhop_group_pd_info->members));
+        tommy_node* node = tommy_list_head(&nhop_group_pd_info->members.list);
 
         while (node) {
             switch_nhop_member_t *nhop_member = NULL;

--- a/switchsai/sainexthopgroup.c
+++ b/switchsai/sainexthopgroup.c
@@ -17,6 +17,7 @@
 
 #include "sainexthopgroup.h"
 #include "saiinternal.h"
+#include "switchapi/switch_device.h"
 #include "switchapi/switch_nhop.h"
 
 /*


### PR DESCRIPTION
1) Addressed compiler warnings in krnlmon.

2) Enabled -Werror for krnlmon as a mitigation against developers
   checking in changes that generate compiler warnings.

Signed-off-by: Derek G Foster <derek.foster@intel.com>