### PR TITLE
Addressed Klocwork issues in krnlmon

### DIFF
--- a/krnlmon_main.c
+++ b/krnlmon_main.c
@@ -1,10 +1,12 @@
-// Copyright 2022 Intel Corporation
+// Copyright 2022-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "krnlmon_main.h"
 
+// Enable pthread_setname_np()
 #define _GNU_SOURCE
 #include <pthread.h>
+
 #include <stdio.h>
 
 extern void *switchlink_main(void *);
@@ -14,22 +16,22 @@ static pthread_t krnlmon_start_tid;
 static pthread_t krnlmon_stop_tid;
 
 int krnlmon_init(void) {
-     int rc = pthread_create(&krnlmon_start_tid, NULL, switchlink_main, NULL);
-     if (rc) {
+    int rc = pthread_create(&krnlmon_start_tid, NULL, switchlink_main, NULL);
+    if (rc) {
         printf("Switchlink thread creation failed, error: %d", rc);
         return -1;
-     }
-     pthread_setname_np(krnlmon_start_tid, "switchlink_main");
-
-  return 0;
+    }
+    pthread_setname_np(krnlmon_start_tid, "switchlink_main");
+    return 0;
 }
 
 int krnlmon_shutdown(void)
 {
-     int rc = pthread_create(&krnlmon_stop_tid, NULL, switchlink_stop, NULL);
-     if (rc) {
+    int rc = pthread_create(&krnlmon_stop_tid, NULL, switchlink_stop, NULL);
+    if (rc) {
         printf("Switchlink thread stop failed, error: %d", rc);
         return -1;
-     }
-     pthread_setname_np(krnlmon_stop_tid, "switchlink_stop");
+    }
+    pthread_setname_np(krnlmon_stop_tid, "switchlink_stop");
+    return 0;
 }

--- a/switchapi/switchapi_utils.c
+++ b/switchapi/switchapi_utils.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +33,7 @@ static switch_uint32_t MurmurHash(const void *key,
 #define r 24
 
   // Initialize the hash to a 'random' value
-  switch_uint32_t h = seed ^ (switch_uint32_t)length;
+  switch_uint32_t h = seed ^ length;
 
   // Mix 4 bytes at a time into the hash
   const unsigned char *data = (const unsigned char *)key;
@@ -60,7 +61,7 @@ static switch_uint32_t MurmurHash(const void *key,
       h ^= data[1] << 8;
     /* fall through */
     case 1:
-      h ^= data[0];
+      h ^= (switch_uint32_t)data[0];
       h *= m;
   };
 


### PR DESCRIPTION
- Added return status in krnlmon_shutdown() happy path.
- Added return value checks to pthreads calls in krnlmon.
- Cleaned up some aberrant indentation.

Signed-off-by: Derek G Foster <derek.foster@intel.com>