### PR TITLE
KW fix for pthread_cond_wait return val

### DIFF
--- a/switchlink/switchlink_main.c
+++ b/switchlink/switchlink_main.c
@@ -323,17 +323,18 @@ struct nl_sock *switchlink_get_nl_sock(void) {
 void *switchlink_main(void *args) {
   int rc;
   rc = pthread_mutex_lock(&rpc_start_lock);
-  assert_perror(rc);
+  krnlmon_assert_perror(rc);
   while (!rpc_start_cookie) {
-    pthread_cond_wait(&rpc_start_cond, &rpc_start_lock);
+    rc = pthread_cond_wait(&rpc_start_cond, &rpc_start_lock);
+    krnlmon_assert_perror(rc);
   }
   rc = pthread_mutex_unlock(&rpc_start_lock);
-  assert_perror(rc);
+  krnlmon_assert_perror(rc);
 
   krnlmon_log_debug("switchlink main started");
   pthread_mutex_init(&cookie_mutex, NULL);
   rc = pthread_cond_init(&cookie_cv, NULL);
-  assert_perror(rc);
+  krnlmon_assert_perror(rc);
 
   switchlink_init_db();
   switchlink_init_api();
@@ -347,11 +348,11 @@ void *switchlink_main(void *args) {
   }
 
   rc = pthread_mutex_lock(&cookie_mutex);
-  assert_perror(rc);
+  krnlmon_assert_perror(rc);
   cookie = 1;
   pthread_cond_signal(&cookie_cv);
   rc = pthread_mutex_unlock(&cookie_mutex);
-  assert_perror(rc);
+  krnlmon_assert_perror(rc);
 
   return NULL;
 }
@@ -359,12 +360,13 @@ void *switchlink_main(void *args) {
 void *switchlink_stop(void *args) {
   int rc;
   rc = pthread_mutex_lock(&rpc_stop_lock);
-  assert_perror(rc);
+  krnlmon_assert_perror(rc);
   while (!rpc_stop_cookie) {
-    pthread_cond_wait(&rpc_stop_cond, &rpc_stop_lock);
+    rc = pthread_cond_wait(&rpc_stop_cond, &rpc_stop_lock);
+    krnlmon_assert_perror(rc);
   }
   rc = pthread_mutex_unlock(&rpc_stop_lock);
-  assert_perror(rc);
+  krnlmon_assert_perror(rc);
   rc = pthread_cancel(switchlink_thread);
   if (rc == 0) {
     pthread_join(switchlink_thread, NULL);

--- a/switchutils/switch_utils.h
+++ b/switchutils/switch_utils.h
@@ -23,5 +23,6 @@
 
 #define krnlmon_assert                  assert
 #define krnlmon_snprintf                snprintf
+#define krnlmon_assert_perror           assert_perror
 
 #endif /* __KRNLMON_UTILS_H__*/


### PR DESCRIPTION
Fix for KW issues for pthread_cond_wait return value check wrt 0 (success) or failure 
