### PR TITLE
Address use of unsafe functions in krnlmon

### DIFF
--- a/switchapi/switch_config_int.h
+++ b/switchapi/switch_config_int.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright (c) 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 #define __SWITCH_CONFIG_INT_H__
 
 #include "switch_config.h"
+
 #define SWITCH_DEFAULT_VRF 1
 
 #define SWITCH_DEFAULT_VLAN 1
@@ -89,7 +90,8 @@ extern switch_config_info_t config_info;
 #define SWITCH_CONFIG_CPU_ETH_INTF() config_info.api_switch_config.cpu_interface
 
 #define SWITCH_CONFIG_CPU_ETH_INTF_LEN() \
-  strlen(config_info.api_switch_config.cpu_interface)
+  strnlen(config_info.api_switch_config.cpu_interface, \
+          sizeof(config_info.api_switch_config.cpu_interface))
 
 #define SWITCH_CONFIG_SMAC_PROGRAM() config_info.api_switch_config.program_smac
 #define SWITCH_CONFIG_ACL_OPTIMIZATION() \

--- a/switchapi/switch_table.c
+++ b/switchapi/switch_table.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright (c) 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ extern "C" {
 
 #define __FILE_ID__ SWITCH_TABLE
 
-static char *switch_table_id_to_string(switch_table_id_t table_id) {
+static const char *switch_table_id_to_string(switch_table_id_t table_id) {
   switch (table_id) {
     case SWITCH_TABLE_INGRESS_PORT_MAPPING:
       return "ingress port mapping";
@@ -279,12 +279,19 @@ static char *switch_table_id_to_string(switch_table_id_t table_id) {
   }
 }
 
+static void set_table_name(char *dest, size_t destsize, const char *src) {
+  size_t nchars = strnlen(src, destsize);
+  if (nchars >= destsize)
+    nchars = destsize - 1;
+  strncpy(dest, src, nchars);
+  dest[nchars] = 0;
+}
+
 switch_status_t switch_table_init(switch_device_t device,
                                   switch_size_t *table_sizes) {
   switch_table_t *table_info = NULL;
   switch_uint32_t index = 0;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
-  switch_char_t *table_str = NULL;
 
   status = switch_device_table_get(device, &table_info);
   if (status != SWITCH_STATUS_SUCCESS) {
@@ -300,9 +307,9 @@ switch_status_t switch_table_init(switch_device_t device,
     table_info[index].num_entries = 0;
     if (table_sizes[index]) {
       table_info[index].valid = TRUE;
-      table_str = switch_table_id_to_string(index);
-      SWITCH_MEMCPY(
-          &table_info[index].table_name, table_str, strlen(table_str));
+      set_table_name(table_info[index].table_name,
+                     sizeof(table_info[0].table_name),
+                     switch_table_id_to_string(index));
     }
   }
 

--- a/switchapi/switch_types_int.h
+++ b/switchapi/switch_types_int.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright (c) 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,8 @@ typedef struct switch_list_ {
   switch_size_t num_entries;
 } switch_list_t;
 
-static inline char *switch_macaddress_to_string(const switch_mac_addr_t *mac) {
+static inline const char *switch_macaddress_to_string(
+    const switch_mac_addr_t *mac) {
   static char mac_str[18];
   snprintf(mac_str,
            sizeof(mac_str),
@@ -91,19 +92,21 @@ static inline char *switch_macaddress_to_string(const switch_mac_addr_t *mac) {
   return mac_str;
 }
 
-static inline char *switch_ipaddress_to_string(
+static inline const char *switch_ipaddress_to_string(
     const switch_ip_addr_t *ip_addr) {
   static char ipv4_str[INET_ADDRSTRLEN + 10];
   static char ipv6_str[INET6_ADDRSTRLEN + 10];
   int len = 0;
   if (ip_addr->type == SWITCH_API_IP_ADDR_V4) {
     uint32_t v4addr = htonl(ip_addr->ip.v4addr);
-    len = strlen(inet_ntop(AF_INET, &v4addr, ipv4_str, INET_ADDRSTRLEN));
+    len = strnlen(inet_ntop(AF_INET, &v4addr, ipv4_str, INET_ADDRSTRLEN),
+                  INET_ADDRSTRLEN);
     snprintf(ipv4_str + len, 10, "/%d", ip_addr->prefix_len);
     return ipv4_str;
   } else {
-    len = strlen(
-        inet_ntop(AF_INET6, &ip_addr->ip.v6addr, ipv6_str, INET6_ADDRSTRLEN));
+    len = strnlen(
+        inet_ntop(AF_INET6, &ip_addr->ip.v6addr, ipv6_str, INET6_ADDRSTRLEN),
+        INET6_ADDRSTRLEN);
     snprintf(ipv6_str + len, 10, "/%d", ip_addr->prefix_len);
     return ipv6_str;
   }

--- a/switchapi/switchapi_utils.c
+++ b/switchapi/switchapi_utils.c
@@ -772,8 +772,8 @@ switch_status_t switch_ipv4_to_string(switch_ip4_t ip4,
 
   char tmp_buffer[SWITCH_API_BUFFER_SIZE];
   switch_ip4_t v4addr = htonl(ip4);
-  inet_ntop(AF_INET, &v4addr, tmp_buffer, SWITCH_API_BUFFER_SIZE);
-  *length = (switch_int32_t)strlen(tmp_buffer);
+  inet_ntop(AF_INET, &v4addr, tmp_buffer, sizeof(tmp_buffer));
+  *length = (switch_int32_t)strnlen(tmp_buffer, sizeof(tmp_buffer));
   SWITCH_MEMCPY(buffer, tmp_buffer, *length);
   return SWITCH_STATUS_SUCCESS;
 }
@@ -785,8 +785,8 @@ switch_status_t switch_ipv6_to_string(switch_ip6_t ip6,
   SWITCH_ASSERT(buffer != NULL);
 
   char tmp_buffer[SWITCH_API_BUFFER_SIZE];
-  inet_ntop(AF_INET6, &ip6, tmp_buffer, SWITCH_API_BUFFER_SIZE);
-  *length = (switch_int32_t)strlen(tmp_buffer);
+  inet_ntop(AF_INET6, &ip6, tmp_buffer, sizeof(tmp_buffer));
+  *length = (switch_int32_t)strnlen(tmp_buffer, sizeof(tmp_buffer));
   SWITCH_MEMCPY(buffer, tmp_buffer, *length);
   return SWITCH_STATUS_SUCCESS;
 }

--- a/switchsai/saiutils.c
+++ b/switchsai/saiutils.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright (c) 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ sai_ipv6_to_string(_In_ sai_ip6_t ip6,
                    _Out_ int *entry_length)
 {
   inet_ntop(AF_INET6, &ip6, entry_string, max_length);
-  *entry_length = (int)strlen(entry_string);
+  *entry_length = (int)strnlen(entry_string, max_length);
   return SAI_STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
- Replaced instances of strlen() (which is considered unsafe because it is unbounded) with strnlen().
- Changed a few instances of char * to const char *, to enforce the immutability of the data.

Signed-off-by: Derek G Foster <derek.foster@intel.com>