### PR TITLE
Remove libkrnlmon.sym file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake build file for Kernel Monitor
 #
-# Copyright 2022 Intel Corporation
+# Copyright 2022-2023 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
 
@@ -29,14 +29,6 @@ add_library(krnlmon SHARED
 )
 
 target_link_libraries(krnlmon nl-route-3 nl-3)
-
-configure_file(libkrnlmon.sym.in
-               ${CMAKE_CURRENT_BINARY_DIR}/libkrnlmon.sym @ONLY)
-
-set_target_properties(krnlmon PROPERTIES
-    LINK_OPTIONS -Wl,--version-script=libkrnlmon.sym
-    LINK_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libkrnlmon.sym
-)
 
 # Version number for .pc file.
 set(VERSION 1.0)

--- a/libkrnlmon.sym.in
+++ b/libkrnlmon.sym.in
@@ -1,4 +1,0 @@
-libkrnlmon_@LT_CURRENT@ {
-global:
-        *;
-};


### PR DESCRIPTION
- Removed CMake support for the libkrnlmon.sym file. This file is an artifact of the original implementation under P4-OVS, and serves no useful purpose.

Signed-off-by: Derek G Foster <derek.foster@intel.com>