### PR TITLE
fix `stringop-overread` error on `switchapi/switch_table.c`

### DIFF
--- a/switchapi/switch_table.c
+++ b/switchapi/switch_table.c
@@ -279,14 +279,6 @@ static const char *switch_table_id_to_string(switch_table_id_t table_id) {
   }
 }
 
-static void set_table_name(char *dest, size_t destsize, const char *src) {
-  size_t nchars = strnlen(src, destsize);
-  if (nchars >= destsize)
-    nchars = destsize - 1;
-  strncpy(dest, src, nchars);
-  dest[nchars] = 0;
-}
-
 switch_status_t switch_table_init(switch_device_t device,
                                   switch_size_t *table_sizes) {
   switch_table_t *table_info = NULL;
@@ -307,9 +299,12 @@ switch_status_t switch_table_init(switch_device_t device,
     table_info[index].num_entries = 0;
     if (table_sizes[index]) {
       table_info[index].valid = TRUE;
-      set_table_name(table_info[index].table_name,
-                     sizeof(table_info[0].table_name),
-                     switch_table_id_to_string(index));
+      strncpy(
+        table_info[index].table_name,
+        switch_table_id_to_string(index),
+        sizeof(table_info[0].table_name));
+      // ensures that table_name is null terminated
+      table_info[index].table_name[sizeof(table_info[index].table_name) - 1] = 0;
     }
   }
 


### PR DESCRIPTION
i got errors trying to compile the IPDK [Networking Recipe](https://github.com/ipdk-io/networking-recipe). i've just spotted the culprit being CGG 12 giving this error when compiling `krnlmon`:
```
In function ‘set_table_name’,
    inlined from ‘switch_table_init’ at /home/arthur/Documents/k8s-infra-offload/ipdk.recipe/krnlmon/krnlmon/switchapi/switch_table.c:310:7:
/home/arthur/Documents/k8s-infra-offload/ipdk.recipe/krnlmon/krnlmon/switchapi/switch_table.c:283:19: error: ‘strnlen’ specified bound 30 exceeds source size 26 [-Werror=stringop-overread]
  283 |   size_t nchars = strnlen(src, destsize);
      |                   ^~~~~~~~~~~~~~~~~~~~~~
```

i've narrowed down the problem to [this](https://github.com/ipdk-io/krnlmon/commit/dae0352bd4aad3fdd46a9e3c907a6cc285f3b92e#diff-4a83272c8f30506cbd4a7e306f920f988ea749204ea066b1520fbe62a14ba1caR282-R312) commit. basically:
```c
static void set_table_name(char *dest, size_t destsize, const char *src) {
  size_t nchars = strnlen(src, destsize);
  if (nchars >= destsize)
    nchars = destsize - 1;
  strncpy(dest, src, nchars);
  dest[nchars] = 0;
}

switch_status_t switch_table_init(switch_device_t device,
                                  switch_size_t *table_sizes) {
  // ...
  for (index = 0; index < SWITCH_TABLE_MAX; index++) {
    // ...
      set_table_name(table_info[index].table_name,
                     sizeof(table_info[0].table_name),
                     switch_table_id_to_string(index));
  }

  return status;
}
```

the compiler infers the size of each string returned by `switch_table_id_to_string` given the `index`, then it just found that some string is smaller than `destsize` (`sizeof(table_info[0].table_name)`, which is equals to `#define SWITCH_MAX_STRING_SIZE 30`), givin the error that `strnlen(src, destsize)` will overrun `src` if it's not null terminated (because we gave the size of `table_info[0].table_name` not `switch_table_id_to_string(index)`).

TBH this will _never_ (?) happen because in this case `src` (`switch_table_id_to_string(index)`) is _always_ null terminated, but for the sake of fix it/follow the compiler tips, here comes my PR...
