### PR TITLE
switchlink_neighbor.cc UT

### DIFF
--- a/switchlink/switchlink_neigh.c
+++ b/switchlink/switchlink_neigh.c
@@ -24,6 +24,9 @@
 #include "switchlink_neigh.h"
 #include "switchlink_handle.h"
 
+switchlink_handle_t g_default_vrf_h;
+switchlink_handle_t g_default_bridge_h;
+
 /*
  * Routine Description:
  *    Process neighbor netlink messages
@@ -105,7 +108,6 @@ void switchlink_process_neigh_msg(const struct nlmsghdr *nlmsg, int msgtype) {
         break;
       }
       default:
-        krnlmon_log_debug("neigh: skipping attr %d\n", attr_type);
         break;
     }
     attr = nla_next(attr, &attrlen);

--- a/switchlink/switchlink_neigh_test.cc
+++ b/switchlink/switchlink_neigh_test.cc
@@ -252,7 +252,7 @@ TEST_F(SwitchlinkNeighborTest, verifyInvalidNeighborState) {
   switchlink_process_neigh_msg(nlmsg, nlmsg->nlmsg_type);
 
   // Assert
-  EXPECT_EQ(results.size(), 0);
+  ASSERT_EQ(results.size(), 0);
 }
 
 /*
@@ -285,7 +285,7 @@ TEST_F(SwitchlinkNeighborTest, verifyInvalidInterfaceInfo) {
   switchlink_process_neigh_msg(nlmsg, nlmsg->nlmsg_type);
 
   // Assert
-  EXPECT_EQ(results.size(), 0);
+  ASSERT_EQ(results.size(), 0);
 }
 
 /*

--- a/switchlink/switchlink_neigh_test.cc
+++ b/switchlink/switchlink_neigh_test.cc
@@ -1,0 +1,517 @@
+#include <arpa/inet.h>
+#include <memory.h>
+#include <vector>
+
+#include "netlink/msg.h"
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "switchlink/switchlink_handle.h"
+#include "switchlink/switchlink_int.h"
+#include "switchlink/switchlink_neigh.h"
+}
+
+using namespace std;
+
+#define IPV4_ADDR(a, b, c, d) (((a) << 24) | ((b) << 16) | ((c) << 8) | (d))
+
+// enum for diff operation types
+enum operation_type {
+  CREATE_MAC = 1,
+  CREATE_NEIGHBOR = 2,
+  DELETE_NEIGHBOR = 3,
+};
+
+/*
+ * Result variables.
+ */
+struct test_results {
+  // Parameter values
+  switchlink_mac_addr_t mac_addr;
+  switchlink_ip_addr_t ipaddr;
+  switchlink_handle_t bridge_h;
+  switchlink_handle_t intf_h;
+  switchlink_handle_t vrf_h;
+  // Handler tracking
+  enum operation_type opType;
+  int num_handler_calls;
+};
+
+// Value to return for the switch interface and bridge handle.
+const switchlink_handle_t TEST_INTF_H = 0x10001;
+const switchlink_handle_t TEST_BRIDGE_H = 0x20002;
+
+vector<test_results> results(2);
+
+/*
+ * Dummy function for switchlink_create_mac(). This function is
+ * invoked by switchlink_process_neigh_msg() when the msgtype is
+ * RTM_NEWNEIGH. The actual method creates a MAC entry.
+ *
+ * Since this is dummy method, here the objective is to validate
+ * the invocation of this method with correct arguments. All the
+ * input params are stored in the test results structure and
+ * validated against each test case.
+ */
+void switchlink_create_mac(switchlink_mac_addr_t mac_addr,
+                           switchlink_handle_t bridge_h,
+                           switchlink_handle_t intf_h) {
+
+  struct test_results temp = {};
+  if (mac_addr) {
+    memcpy(temp.mac_addr, mac_addr, sizeof(switchlink_mac_addr_t));
+  }
+  if (bridge_h) {
+    temp.bridge_h = bridge_h;
+  }
+  if (intf_h) {
+    temp.intf_h = intf_h;
+  }
+  temp.opType = CREATE_MAC;
+  temp.num_handler_calls++;
+  results.push_back(temp);
+}
+
+/*
+ * Dummy function for switchlink_create_neigh(). This function is
+ * invoked by switchlink_process_neigh_msg() when the msgtype is
+ * RTM_NEWNEIGH. The actual method creates neighbor, nexthop and
+ * route entry.
+ *
+ * Since this is dummy method, here the objective is to validate
+ * the invocation of this method with correct arguments. All the
+ * input params are stored in the test results structure and
+ * validated against each test case.
+ */
+void switchlink_create_neigh(switchlink_handle_t vrf_h,
+                             const switchlink_ip_addr_t *ipaddr,
+                             switchlink_mac_addr_t mac_addr,
+                             switchlink_handle_t intf_h) {
+  struct test_results temp = {};
+  if (ipaddr) {
+    temp.ipaddr = *ipaddr;
+  }
+  if (mac_addr) {
+    memcpy(temp.mac_addr, mac_addr, sizeof(switchlink_mac_addr_t));
+  }
+  if (intf_h) {
+    temp.intf_h = intf_h;
+  }
+  temp.opType = CREATE_NEIGHBOR;
+  temp.num_handler_calls++;
+  results.push_back(temp);
+}
+
+/*
+ * Dummy function for switchlink_delete_neigh(). This function is
+ * invoked by switchlink_process_neigh_msg() when the msgtype is
+ * RTM_DELNEIGH. The actual method deletes neighbor, nexthop and
+ * route entry.
+ *
+ * Since this is dummy method, here the objective is to validate
+ * the invocation of this method with correct arguments. All the
+ * input params are stored in the test results structure and
+ * validated against each test case.
+ */
+void switchlink_delete_neigh(switchlink_handle_t vrf_h,
+                             const switchlink_ip_addr_t *addr,
+                             switchlink_handle_t intf_h) {
+  struct test_results temp = {};
+  if (addr) {
+    temp.ipaddr = *addr;
+  }
+  if (intf_h) {
+    temp.intf_h = intf_h;
+  }
+  temp.opType = DELETE_NEIGHBOR;
+  temp.num_handler_calls++;
+  results.push_back(temp);
+}
+
+/*
+ * Dummy function for switchlink_db_get_interface_info(). This function
+ * is invoked by switchlink_process_neigh_msg() for getting the intf
+ * info from the database.
+ *
+ * Since this is a dummy method, we are passing an ifindex 1 to get L3
+ * interface info and ifindex 2 to get L2 interface info from the db.
+ *
+ * The actual function can also return SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND
+ * in case it is not able to find the interface in the database.
+ * That scenario is mocked by passing an ifindex of 3.
+ */
+switchlink_db_status_t
+switchlink_db_get_interface_info(uint32_t ifindex,
+                                 switchlink_db_interface_info_t *intf_info) {
+  if (ifindex == 1) {
+    intf_info->intf_h = TEST_INTF_H;
+    intf_info->intf_type = SWITCHLINK_INTF_TYPE_L3;
+  } else if (ifindex == 2) {
+    intf_info->intf_h = TEST_INTF_H;
+    intf_info->bridge_h = TEST_BRIDGE_H;
+    intf_info->intf_type = SWITCHLINK_INTF_TYPE_L2_ACCESS;
+  } else if (ifindex == 3) {
+    intf_info = nullptr;
+    return SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND;
+  }
+  return SWITCHLINK_DB_STATUS_SUCCESS;
+}
+
+/*
+ * Test fixture.
+ */
+class SwitchlinkNeighborTest : public ::testing::Test {
+protected:
+  struct nl_msg *nlmsg_ = nullptr;
+
+  // Sets up the test fixture.
+  void SetUp() override { ResetVariables(); }
+
+  // Tears down the test fixture.
+  void TearDown() override {
+    if (nlmsg_) {
+      nlmsg_free(nlmsg_);
+      nlmsg_ = nullptr;
+    }
+  }
+
+  void ResetVariables() {
+    // result variables
+    results.clear();
+  }
+};
+
+/*
+ * Creates an IPv4 neighbor
+ *
+ * Validates switchlink_process_neigh_msg(). It parses an
+ * RTM_NEWNEIGH message, invokes switchlink_create_neigh()
+ * for creating neighbor, nexthop and route entry.
+ *
+ * In create call...
+ * We invoke switchlink_create_mac()...
+ * ...and switchlink_create_neigh()....
+ * Hence we expect 2 test_results here, and this is the
+ * reason why test_results has been taken as a vector of size 2.
+ */
+TEST_F(SwitchlinkNeighborTest, createIPv4Neighbor) {
+  struct ndmsg hdr = {
+      .ndm_family = AF_INET,
+      .ndm_ifindex = 1,
+      .ndm_state = NUD_REACHABLE,
+      .ndm_flags = 0x1,
+      .ndm_type = 1,
+  };
+
+  const uint32_t ipv4_addr = IPV4_ADDR(10, 10, 10, 1);
+  const unsigned char mac_addr[6] = {0x00, 0xdd, 0xee, 0xaa, 0xdd, 0x00};
+
+  // Arrange
+  nlmsg_ = nlmsg_alloc_size(1024);
+  ASSERT_NE(nlmsg_, nullptr);
+  nlmsg_put(nlmsg_, 0, 0, RTM_NEWNEIGH, 0, 0);
+  nlmsg_append(nlmsg_, &hdr, sizeof(hdr), NLMSG_ALIGNTO);
+  nla_put_u32(nlmsg_, NDA_DST, htonl(ipv4_addr));
+  nla_put(nlmsg_, NDA_LLADDR, sizeof(mac_addr), &mac_addr);
+
+  // Act
+  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  switchlink_process_neigh_msg(nlmsg, nlmsg->nlmsg_type);
+
+  // Assert
+  EXPECT_EQ(results.size(), 2);
+
+  // Verify test results for MAC creation
+  EXPECT_EQ(results[0].opType, CREATE_MAC);
+  EXPECT_EQ(results[0].num_handler_calls, 1);
+  EXPECT_EQ(results[0].bridge_h, 0);
+  EXPECT_EQ(results[0].intf_h, TEST_INTF_H);
+  EXPECT_EQ(memcmp(results[0].mac_addr, mac_addr, sizeof(mac_addr)), 0);
+
+  // Verify test results for NEIGHBOR creation
+  EXPECT_EQ(results[1].opType, CREATE_NEIGHBOR);
+  EXPECT_EQ(results[1].num_handler_calls, 1);
+  EXPECT_EQ(results[1].vrf_h, 0);
+  EXPECT_EQ(results[1].intf_h, TEST_INTF_H);
+  EXPECT_EQ(results[1].ipaddr.family, AF_INET);
+  EXPECT_EQ(results[1].ipaddr.ip.v4addr.s_addr, ipv4_addr);
+  EXPECT_EQ(results[1].ipaddr.prefix_len, 32);
+  EXPECT_EQ(memcmp(results[1].mac_addr, mac_addr, sizeof(mac_addr)), 0);
+}
+
+/*
+ * Verfies the behavior of switchlink_process_neigh_msg() when
+ * invalid neighbor state (NUD_INCOMPLETE) is passed in the header.
+ */
+TEST_F(SwitchlinkNeighborTest, verifyInvalidNeighborState) {
+  struct ndmsg hdr = {
+      .ndm_family = AF_INET,
+      .ndm_ifindex = 1,
+      .ndm_state = NUD_INCOMPLETE,
+      .ndm_flags = 0x1,
+      .ndm_type = 1,
+  };
+
+  const uint32_t ipv4_addr = IPV4_ADDR(10, 10, 10, 1);
+  const unsigned char mac_addr[6] = {0x00, 0xdd, 0xee, 0xaa, 0xdd, 0x00};
+
+  // Arrange
+  nlmsg_ = nlmsg_alloc_size(1024);
+  ASSERT_NE(nlmsg_, nullptr);
+  nlmsg_put(nlmsg_, 0, 0, RTM_NEWNEIGH, 0, 0);
+  nlmsg_append(nlmsg_, &hdr, sizeof(hdr), NLMSG_ALIGNTO);
+  nla_put_u32(nlmsg_, NDA_DST, htonl(ipv4_addr));
+  nla_put(nlmsg_, NDA_LLADDR, sizeof(mac_addr), &mac_addr);
+
+  // Act
+  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  switchlink_process_neigh_msg(nlmsg, nlmsg->nlmsg_type);
+
+  // Assert
+  EXPECT_EQ(results.size(), 0);
+}
+
+/*
+ * Verfies the behavior of switchlink_process_neigh_msg() when
+ * switchlink_db_get_interface_info() isn't able to fetch valid
+ * interface info from the database.
+ */
+TEST_F(SwitchlinkNeighborTest, verifyInvalidInterfaceInfo) {
+  struct ndmsg hdr = {
+      .ndm_family = AF_INET,
+      .ndm_ifindex = 3,
+      .ndm_state = NUD_INCOMPLETE,
+      .ndm_flags = 0x1,
+      .ndm_type = 1,
+  };
+
+  const uint32_t ipv4_addr = IPV4_ADDR(10, 10, 10, 1);
+  const unsigned char mac_addr[6] = {0x00, 0xdd, 0xee, 0xaa, 0xdd, 0x00};
+
+  // Arrange
+  nlmsg_ = nlmsg_alloc_size(1024);
+  ASSERT_NE(nlmsg_, nullptr);
+  nlmsg_put(nlmsg_, 0, 0, RTM_NEWNEIGH, 0, 0);
+  nlmsg_append(nlmsg_, &hdr, sizeof(hdr), NLMSG_ALIGNTO);
+  nla_put_u32(nlmsg_, NDA_DST, htonl(ipv4_addr));
+  nla_put(nlmsg_, NDA_LLADDR, sizeof(mac_addr), &mac_addr);
+
+  // Act
+  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  switchlink_process_neigh_msg(nlmsg, nlmsg->nlmsg_type);
+
+  // Assert
+  EXPECT_EQ(results.size(), 0);
+}
+
+/*
+ * Tries to create an IPv4 neighbor without any MAC address info
+ *
+ * Verifies switchlink_process_neigh_msg(). It parses an
+ * RTM_NEWNEIGH message with valid ipv4 address but an invalid/null
+ * MAC address
+ *
+ * In this case, switchlink_delete_neigh() will be invoked to
+ * remove the neighbor entry even though the message type is
+ * RTM_NEWNEIGH.
+ */
+TEST_F(SwitchlinkNeighborTest, createIPv4NeighborWithInvalidMac) {
+  struct ndmsg hdr = {
+      .ndm_family = AF_INET,
+      .ndm_ifindex = 1,
+      .ndm_state = NUD_REACHABLE,
+      .ndm_flags = 0x1,
+      .ndm_type = 1,
+  };
+
+  const uint32_t ipv4_addr = IPV4_ADDR(10, 10, 10, 1);
+
+  // Arrange
+  nlmsg_ = nlmsg_alloc_size(1024);
+  ASSERT_NE(nlmsg_, nullptr);
+  nlmsg_put(nlmsg_, 0, 0, RTM_NEWNEIGH, 0, 0);
+  nlmsg_append(nlmsg_, &hdr, sizeof(hdr), NLMSG_ALIGNTO);
+  nla_put_u32(nlmsg_, NDA_DST, htonl(ipv4_addr));
+
+  // Act
+  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  switchlink_process_neigh_msg(nlmsg, nlmsg->nlmsg_type);
+
+  // Assert
+  EXPECT_EQ(results.size(), 1);
+
+  // Verify test results for NEIGHBOR deletion
+  EXPECT_EQ(results[0].opType, DELETE_NEIGHBOR);
+  EXPECT_EQ(results[0].num_handler_calls, 1);
+  EXPECT_EQ(results[0].vrf_h, 0);
+  EXPECT_EQ(results[0].intf_h, TEST_INTF_H);
+  EXPECT_EQ(results[0].ipaddr.family, AF_INET);
+  EXPECT_EQ(results[0].ipaddr.ip.v4addr.s_addr, ipv4_addr);
+  EXPECT_EQ(results[0].ipaddr.prefix_len, 32);
+}
+
+/*
+ * Creates an IPv6 neighbor
+ *
+ * Validates switchlink_process_neigh_msg(). It parses an
+ * RTM_NEWNEIGH message, invokes switchlink_create_neigh()
+ * for creating neighbor, nexthop and route entry.
+ *
+ * In create call...
+ * We invoke switchlink_create_mac()...
+ * ...and switchlink_create_neigh()....
+ * Hence we expect 2 test_results here, and this is the
+ * reason why test_results has been taken as a vector of size 2.
+ */
+TEST_F(SwitchlinkNeighborTest, createIPv6Neighbor) {
+  struct ndmsg hdr = {
+      .ndm_family = AF_INET6,
+      .ndm_ifindex = 2,
+      .ndm_state = NUD_PERMANENT,
+      .ndm_flags = 0x1,
+      .ndm_type = 1,
+  };
+
+  const unsigned char mac_addr[6] = {0x00, 0xdd, 0xee, 0xaa, 0xdd, 0x00};
+
+  struct in6_addr addr6;
+  inet_pton(AF_INET6, "2001::1", &addr6);
+  // Word 0 of IPv6 address.
+  const uint16_t V6ADDR_0 = htons(0x2001);
+  // Word 7 of IPv6 address.
+  const uint16_t V6ADDR_7 = htons(0x0001);
+
+  // Arrange
+  nlmsg_ = nlmsg_alloc_size(1024);
+  ASSERT_NE(nlmsg_, nullptr);
+  nlmsg_put(nlmsg_, 0, 0, RTM_NEWNEIGH, 0, 0);
+  nlmsg_append(nlmsg_, &hdr, sizeof(hdr), NLMSG_ALIGNTO);
+  nla_put(nlmsg_, NDA_DST, sizeof(addr6), &addr6);
+  nla_put(nlmsg_, NDA_LLADDR, sizeof(mac_addr), &mac_addr);
+
+  // Act
+  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  switchlink_process_neigh_msg(nlmsg, nlmsg->nlmsg_type);
+
+  // Assert
+  EXPECT_EQ(results.size(), 2);
+
+  // Verify test results for MAC creation
+  EXPECT_EQ(results[0].opType, CREATE_MAC);
+  EXPECT_EQ(results[0].num_handler_calls, 1);
+  EXPECT_EQ(results[0].bridge_h, TEST_BRIDGE_H);
+  EXPECT_EQ(results[0].intf_h, TEST_INTF_H);
+  EXPECT_EQ(memcmp(results[0].mac_addr, mac_addr, sizeof(mac_addr)), 0);
+
+  // Verify test results for NEIGHBOR creation
+  EXPECT_EQ(results[1].opType, CREATE_NEIGHBOR);
+  EXPECT_EQ(results[1].num_handler_calls, 1);
+  EXPECT_EQ(results[1].vrf_h, 0);
+  EXPECT_EQ(results[1].intf_h, TEST_INTF_H);
+  EXPECT_EQ(results[1].ipaddr.family, AF_INET6);
+  EXPECT_EQ(results[1].ipaddr.ip.v6addr.__in6_u.__u6_addr16[0], V6ADDR_0);
+  EXPECT_EQ(results[1].ipaddr.ip.v6addr.__in6_u.__u6_addr16[7], V6ADDR_7);
+  EXPECT_EQ(results[1].ipaddr.prefix_len, 128);
+  EXPECT_EQ(memcmp(results[1].mac_addr, mac_addr, sizeof(mac_addr)), 0);
+}
+
+/*
+ * Deletes an IPv4 neighbor
+ *
+ * Validates switchlink_process_neigh_msg(). It parses an
+ * RTM_DELNEIGH message, invokes switchlink_delete_neigh()
+ * for deleting neighbor, nexthop and route entry.
+ *
+ * In delete call...
+ * We invoke switchlink_delete_neigh().
+ */
+TEST_F(SwitchlinkNeighborTest, deleteIPv4Neighbor) {
+  struct ndmsg hdr = {
+      .ndm_family = AF_INET,
+      .ndm_ifindex = 1,
+      .ndm_state = NUD_STALE,
+      .ndm_flags = 0x1,
+      .ndm_type = 1,
+  };
+
+  const uint32_t ipv4_addr = IPV4_ADDR(10, 10, 10, 1);
+  const unsigned char mac_addr[6] = {0x00, 0xdd, 0xee, 0xaa, 0xdd, 0x00};
+
+  // Arrange
+  nlmsg_ = nlmsg_alloc_size(1024);
+  ASSERT_NE(nlmsg_, nullptr);
+  nlmsg_put(nlmsg_, 0, 0, RTM_DELNEIGH, 0, 0);
+  nlmsg_append(nlmsg_, &hdr, sizeof(hdr), NLMSG_ALIGNTO);
+  nla_put_u32(nlmsg_, NDA_DST, htonl(ipv4_addr));
+  nla_put(nlmsg_, NDA_LLADDR, sizeof(mac_addr), &mac_addr);
+
+  // Act
+  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  switchlink_process_neigh_msg(nlmsg, nlmsg->nlmsg_type);
+
+  // Assert
+  EXPECT_EQ(results.size(), 1);
+
+  // Verify test results for NEIGHBOR deletion
+  EXPECT_EQ(results[0].opType, DELETE_NEIGHBOR);
+  EXPECT_EQ(results[0].num_handler_calls, 1);
+  EXPECT_EQ(results[0].vrf_h, 0);
+  EXPECT_EQ(results[0].intf_h, TEST_INTF_H);
+  EXPECT_EQ(results[0].ipaddr.family, AF_INET);
+  EXPECT_EQ(results[0].ipaddr.ip.v4addr.s_addr, ipv4_addr);
+  EXPECT_EQ(results[0].ipaddr.prefix_len, 32);
+}
+
+/*
+ * Deletes an IPv6 neighbor
+ *
+ * Validates switchlink_process_neigh_msg(). It parses an
+ * RTM_DELNEIGH message, invokes switchlink_delete_neigh()
+ * for creating neighbor, nexthop and route entry.
+ *
+ * In delete call...
+ * We invoke switchlink_delete_neigh().
+ */
+TEST_F(SwitchlinkNeighborTest, deleteIPv6Neighbor) {
+  struct ndmsg hdr = {
+      .ndm_family = AF_INET6,
+      .ndm_ifindex = 1,
+      .ndm_state = NUD_REACHABLE,
+      .ndm_flags = 0x1,
+      .ndm_type = 1,
+  };
+
+  const unsigned char mac_addr[6] = {0x00, 0xdd, 0xee, 0xaa, 0xdd, 0x00};
+
+  struct in6_addr addr6;
+  inet_pton(AF_INET6, "2001::1", &addr6);
+  // Word 0 of IPv6 address.
+  const uint16_t V6ADDR_0 = htons(0x2001);
+  // Word 7 of IPv6 address.
+  const uint16_t V6ADDR_7 = htons(0x0001);
+
+  // Arrange
+  nlmsg_ = nlmsg_alloc_size(1024);
+  ASSERT_NE(nlmsg_, nullptr);
+  nlmsg_put(nlmsg_, 0, 0, RTM_DELNEIGH, 0, 0);
+  nlmsg_append(nlmsg_, &hdr, sizeof(hdr), NLMSG_ALIGNTO);
+  nla_put(nlmsg_, NDA_DST, sizeof(addr6), &addr6);
+  nla_put(nlmsg_, NDA_LLADDR, sizeof(mac_addr), &mac_addr);
+
+  // Act
+  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  switchlink_process_neigh_msg(nlmsg, nlmsg->nlmsg_type);
+
+  // Assert
+  EXPECT_EQ(results.size(), 1);
+
+  // Verify test results for NEIGHBOR deletion
+  EXPECT_EQ(results[0].opType, DELETE_NEIGHBOR);
+  EXPECT_EQ(results[0].num_handler_calls, 1);
+  EXPECT_EQ(results[0].vrf_h, 0);
+  EXPECT_EQ(results[0].intf_h, TEST_INTF_H);
+  EXPECT_EQ(results[0].ipaddr.family, AF_INET6);
+  EXPECT_EQ(results[0].ipaddr.ip.v6addr.__in6_u.__u6_addr16[0], V6ADDR_0);
+  EXPECT_EQ(results[0].ipaddr.ip.v6addr.__in6_u.__u6_addr16[7], V6ADDR_7);
+  EXPECT_EQ(results[0].ipaddr.prefix_len, 128);
+}

--- a/switchlink/switchlink_neigh_test.cc
+++ b/switchlink/switchlink_neigh_test.cc
@@ -57,15 +57,9 @@ void switchlink_create_mac(switchlink_mac_addr_t mac_addr,
                            switchlink_handle_t intf_h) {
 
   struct test_results temp = {0};
-  if (mac_addr) {
-    memcpy(temp.mac_addr, mac_addr, sizeof(switchlink_mac_addr_t));
-  }
-  if (bridge_h) {
-    temp.bridge_h = bridge_h;
-  }
-  if (intf_h) {
-    temp.intf_h = intf_h;
-  }
+  memcpy(temp.mac_addr, mac_addr, sizeof(switchlink_mac_addr_t));
+  temp.bridge_h = bridge_h;
+  temp.intf_h = intf_h;
   temp.opType = CREATE_MAC;
   results.push_back(temp);
 }

--- a/switchlink/testing.cmake
+++ b/switchlink/testing.cmake
@@ -56,3 +56,17 @@ set_test_options(switchlink_address_test)
 
 add_test(NAME switchlink_address_test COMMAND switchlink_address_test)
 
+############################
+# switchlink_neighbor_test #
+############################
+
+add_executable(switchlink_neighbor_test
+    switchlink_neigh_test.cc
+    switchlink_neigh.c
+    switchlink_neigh.h
+)
+
+set_test_options(switchlink_neighbor_test)
+
+add_test(NAME switchlink_neighbor_test COMMAND switchlink_neighbor_test)
+


### PR DESCRIPTION
This PR contains UT written for switchlink_neighbor.cc belonging to krnlmon/switchlink directory.
Test Cases Added:
> createIPv4Neighbor
verifyInvalidNeighborState
verifyInvalidInterfaceInfo
createIPv4NeighborWithInvalidMac
createIPv6Neighbor
deleteIPv4Neighbor
deleteIPv6Neighbor
