### PR TITLE
Fix compiler error in set_table_name()

### DIFF
--- a/switchapi/dpdk/switch_table.c
+++ b/switchapi/dpdk/switch_table.c
@@ -279,12 +279,12 @@ static const char *switch_table_id_to_string(switch_table_id_t table_id) {
   }
 }
 
-static void set_table_name(char *dest, size_t destsize, const char *src) {
-  size_t nchars = strnlen(src, destsize);
-  if (nchars >= destsize)
-    nchars = destsize - 1;
-  strncpy(dest, src, nchars);
-  dest[nchars] = 0;
+// Ensures that dest is null-terminated if len(src) >= destsize.
+static void set_table_name(char* dest, size_t destsize, const char* src) {
+  if (destsize) {
+    strncpy(dest, src, destsize);
+    dest[destsize - 1] = 0;
+  }
 }
 
 switch_status_t switch_table_init(switch_device_t device,

--- a/switchapi/switch_table.h
+++ b/switchapi/switch_table.h
@@ -1,6 +1,8 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache 2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +24,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif /* __cplusplus */
+#endif
 
 #define SWITCH_TABLE_ID_VALID(_table_id) \
         _table_id > SWITCH_TABLE_NONE &&_table_id < SWITCH_TABLE_MAX
@@ -187,7 +189,7 @@ typedef struct switch_table_s {
   switch_size_t table_size;
   switch_size_t num_entries;
   switch_direction_t direction;
-  switch_uint8_t table_name[SWITCH_MAX_STRING_SIZE];
+  char table_name[SWITCH_MAX_STRING_SIZE];
 } switch_table_t;
 
 switch_status_t switch_api_table_size_get(switch_device_t device,


### PR DESCRIPTION
- Rewrite set_table_name(). GCC 12 raises a stringop-overread error on it. This is, to the best of our knowledge, a false positive, but we must needs propitiate the compiler.

- Change the type of the table_name member from uint8_t to char. It's a string, not a byte array, and one of our builds flagged this as a signed/unsigned mismatch.