### PR TITLE
Refine switchlink unit test definitions

### DIFF
--- a/switchlink/testing.cmake
+++ b/switchlink/testing.cmake
@@ -5,28 +5,33 @@
 
 option(TEST_COVERAGE OFF "Measure unit test code coverage")
 
-####################
-# set_test_options #
-####################
+##########################
+# define_switchlink_test #
+##########################
 
-function(set_test_options _TGT)
-    target_link_libraries(${_TGT} PUBLIC
+function(define_switchlink_test test_name)
+    target_link_libraries(${test_name} PUBLIC
         GTest::gtest
         GTest::gtest_main
         PkgConfig::libnl3
         target_sys
     )
 
-    target_link_directories(${_TGT} PUBLIC ${DRIVER_SDK_DIRS})
+    target_link_directories(${test_name} PUBLIC ${DRIVER_SDK_DIRS})
 
-    target_include_directories(${_TGT} PRIVATE
+    target_include_directories(${test_name} PRIVATE
         ${SDE_INSTALL_DIR}/include/target-sys
     )
 
     if(TEST_COVERAGE)
-        target_compile_options(${_TGT} PRIVATE -fprofile-arcs -ftest-coverage)
-        target_link_libraries(${_TGT} PUBLIC gcov)
+        target_compile_options(${test_name} PRIVATE
+            -fprofile-arcs
+            -ftest-coverage
+        )
+        target_link_libraries(${test_name} PUBLIC gcov)
     endif()
+
+    add_test(NAME ${test_name} COMMAND ${test_name})
 endfunction()
 
 ########################
@@ -39,9 +44,7 @@ add_executable(switchlink_link_test
     switchlink_link.h
 )
 
-set_test_options(switchlink_link_test)
-
-add_test(NAME switchlink_link_test COMMAND switchlink_link_test)
+define_switchlink_test(switchlink_link_test)
 
 ###########################
 # switchlink_address_test #
@@ -52,9 +55,7 @@ add_executable(switchlink_address_test
     switchlink_address.c
 )
 
-set_test_options(switchlink_address_test)
-
-add_test(NAME switchlink_address_test COMMAND switchlink_address_test)
+define_switchlink_test(switchlink_address_test)
 
 ############################
 # switchlink_neighbor_test #
@@ -66,7 +67,44 @@ add_executable(switchlink_neighbor_test
     switchlink_neigh.h
 )
 
-set_test_options(switchlink_neighbor_test)
+define_switchlink_test(switchlink_neighbor_test)
 
-add_test(NAME switchlink_neighbor_test COMMAND switchlink_neighbor_test)
+################
+# krnlmon-test #
+################
 
+if(TEST_COVERAGE)
+    set(test_options -T test -T coverage)
+endif()
+
+# On-demand target to build and run the krnlmon tests with a
+# minimum of configuration.
+add_custom_target(krnlmon-test
+  COMMAND
+    ctest ${test_options}
+  DEPENDS
+    switchlink_link_test
+    switchlink_address_test
+    switchlink_neighbor_test
+  WORKING_DIRECTORY
+    ${CMAKE_BINARY_DIR}
+)
+
+unset(test_options)
+
+set_target_properties(krnlmon-test PROPERTIES EXCLUDE_FROM_ALL TRUE)
+
+####################
+# krnlmon-coverage #
+####################
+
+add_custom_target(krnlmon-coverage
+    lcov --capture --directory ${CMAKE_BINARY_DIR}
+    --output-file krnlmon.info
+  COMMAND
+    genhtml krnlmon.info --output-directory coverage
+  WORKING_DIRECTORY
+    ${CMAKE_BINARY_DIR}/Testing
+)
+
+set_target_properties(krnlmon-coverage PROPERTIES EXCLUDE_FROM_ALL TRUE)


### PR DESCRIPTION
- Change `set_test_options()` function to `define_switchlink_test()`, which sets the options and then does an `add_test()`.

- Implement `krnlmon-test` target to build and run krnlmon unit tests with a minimum of configuration.
```
      cmake -B build -DES2K_TARGET=ON -DWITH_OVSP4RT=OFF
      cmake --build build --target krnlmon-test
```
- Implement `krnlmon-coverage` target to generate a unit test coverage report.
```
      cmake -B build -DES2K_TARGET=on -DWITH_OVSP4RT=off \
            -DTEST_COVERAGE=on
      cmake --build build --target krnlmon-test
      cmake --build build --target krnlmon-coverage
```
  The last two commands may be combined:
```
      cmake --build build --target krnlmon-test \
            --target krnlmon-coverage
```