### PR TITLE
Standardize cmake_minimum_required() commands

### DIFF
--- a/switchapi/CMakeLists.txt
+++ b/switchapi/CMakeLists.txt
@@ -3,8 +3,6 @@
 # Copyright 2022-2023 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-cmake_minimum_required(VERSION 3.5)
-
 if(ES2K_TARGET)
   add_subdirectory(es2k)
 elseif(DPDK_TARGET)

--- a/switchapi/dpdk/CMakeLists.txt
+++ b/switchapi/dpdk/CMakeLists.txt
@@ -3,8 +3,6 @@
 # Copyright 2022-2023 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-cmake_minimum_required(VERSION 3.5)
-
 add_library(switchapi_target_o OBJECT
   switch_config.c
   switch_device.c

--- a/switchapi/es2k/CMakeLists.txt
+++ b/switchapi/es2k/CMakeLists.txt
@@ -3,8 +3,6 @@
 # Copyright 2022-2023 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-cmake_minimum_required(VERSION 3.5)
-
 add_library(switchapi_target_o OBJECT
   switch_config.c
   switch_device.c

--- a/switchlink/sai/CMakeLists.txt
+++ b/switchlink/sai/CMakeLists.txt
@@ -3,8 +3,6 @@
 # Copyright 2022-2023 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-cmake_minimum_required(VERSION 3.5)
-
 add_library(switchlink_sai_o OBJECT
    switchlink_handle_ecmp.c
    switchlink_handle_link.c

--- a/switchsai/CMakeLists.txt
+++ b/switchsai/CMakeLists.txt
@@ -3,8 +3,6 @@
 # Copyright 2022 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-cmake_minimum_required(VERSION 3.5)
-
 add_library(switchsai_o OBJECT
    sai.c
    saifdb.c

--- a/switchutils/CMakeLists.txt
+++ b/switchutils/CMakeLists.txt
@@ -3,8 +3,6 @@
 # Copyright 2022 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-cmake_minimum_required(VERSION 3.5)
-
 add_library(switchutils_o OBJECT
     switch_log.h
     switch_utils.h


### PR DESCRIPTION
- Specify `cmake_minimum_required(VERSION 3.15)` in all CMakeLists.txt files that are the root of a project.

- Remove `cmake_minimum_required()` commands from all CMakeLists.txt files that are not the root of a project.