### PR TITLE
switchlink_route UT

### DIFF
--- a/switchlink/switchlink_route.c
+++ b/switchlink/switchlink_route.c
@@ -229,7 +229,6 @@ void switchlink_process_route_msg(const struct nlmsghdr *nlmsg, int msgtype) {
         iif = nla_get_u32(attr);
         break;
       default:
-        krnlmon_log_debug("route: skipping attribute type %d \n", attr_type);
         break;
     }
     attr = nla_next(attr, &attrlen);

--- a/switchlink/switchlink_route_test.cc
+++ b/switchlink/switchlink_route_test.cc
@@ -1,0 +1,738 @@
+#include <arpa/inet.h>
+#include <memory.h>
+#include <vector>
+
+#include "netlink/msg.h"
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "switchlink/switchlink_handle.h"
+#include "switchlink/switchlink_int.h"
+#include "switchlink/switchlink_route.h"
+}
+
+using namespace std;
+
+switchlink_handle_t g_default_vrf_h = 2;
+switchlink_handle_t g_cpu_rx_nhop_h = 3;
+
+#define IPV4_ADDR(a, b, c, d) (((a) << 24) | ((b) << 16) | ((c) << 8) | (d))
+
+// enum for diff operation types
+enum operation_type {
+  PROCESS_ECMP = 1,
+  CREATE_ROUTE = 2,
+  DELETE_ROUTE = 3,
+};
+
+/*
+ * Result variables.
+ */
+struct test_results {
+  // Parameter values
+  switchlink_ip_addr_t dst;
+  switchlink_ip_addr_t gateway;
+  switchlink_handle_t intf_h;
+  switchlink_handle_t ecmp_h;
+  switchlink_db_nexthop_info_t nexthop_info;
+  switchlink_db_ecmp_info_t ecmp_info;
+  // Handler tracking
+  enum operation_type opType;
+};
+
+// Value to return for the switch interface handle.
+const switchlink_handle_t TEST_INTF_H1 = 0x10001;
+const switchlink_handle_t TEST_INTF_H2 = 0x20002;
+const switchlink_handle_t TEST_ECMP_H = 0x30003;
+
+vector<test_results> results(2);
+
+/*
+ * Dummy function for switchlink_create_route(). This function is
+ * invoked by switchlink_process_route_msg() when the msgtype is
+ * RTM_NEWROUTE. The actual method creates route and adds entry
+ * to the database.
+ *
+ * Since this is a dummy method, the objective is to validate
+ * the invocation of this method with correct arguments. All the
+ * input params are stored in the test results structure and
+ * validated by the test case.
+ */
+void switchlink_create_route(switchlink_handle_t vrf_h,
+                             const switchlink_ip_addr_t *dst,
+                             const switchlink_ip_addr_t *gateway,
+                             switchlink_handle_t ecmp_h,
+                             switchlink_handle_t intf_h) {
+  struct test_results temp = {0};
+  if (dst) {
+    temp.dst = *dst;
+  }
+  if (gateway) {
+    temp.gateway = *gateway;
+  }
+  temp.intf_h = intf_h;
+  temp.ecmp_h = ecmp_h;
+  temp.opType = CREATE_ROUTE;
+  results.push_back(temp);
+}
+
+/*
+ * Dummy function for switchlink_delete_route(). This function is
+ * invoked by switchlink_process_route_msg() when the msgtype is
+ * RTM_DELROUTE. The actual method deletes route and removes
+ * entry from the database.
+ *
+ * Since this is a dummy method, the objective is to validate
+ * the invocation of this method with correct arguments. All the
+ * input params are stored in the test results structure and
+ * validated by the test case.
+ */
+void switchlink_delete_route(switchlink_handle_t vrf_h,
+                             const switchlink_ip_addr_t *dst) {
+  struct test_results temp = {0};
+  if (dst) {
+    temp.dst = *dst;
+  }
+  temp.opType = DELETE_ROUTE;
+  results.push_back(temp);
+}
+
+/*
+ * Dummy function for switchlink_db_get_interface_info(). This function
+ * is invoked by switchlink_process_route_msg() to get the intf
+ * info from the database.
+ *
+ * Since this is a dummy method, we are passing an ifindex 1 to get valid
+ * interface info.
+ *
+ * The actual function can also return SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND
+ * if it is not able to find the interface in the database.
+ * That scenario is mocked by passing an ifindex of 2.
+ */
+switchlink_db_status_t
+switchlink_db_get_interface_info(uint32_t ifindex,
+                                 switchlink_db_interface_info_t *intf_info) {
+  switch (ifindex) {
+  case 1:
+    intf_info->intf_h = TEST_INTF_H1;
+    break;
+  case 2:
+    intf_info->intf_h = TEST_INTF_H2;
+    break;
+  default:
+    return SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND;
+  }
+  return SWITCHLINK_DB_STATUS_SUCCESS;
+}
+
+/*
+ * Dummy function for switchlink_create_nexthop(). Returns 0 on success
+ * and -1 in case of error.
+ */
+
+int switchlink_create_nexthop(switchlink_db_nexthop_info_t *nexthop_info) {
+  if (nexthop_info->intf_h == TEST_INTF_H2)
+    return 0;
+  return -1;
+}
+
+/*
+ * Dummy function for switchlink_create_ecmp().
+ */
+int switchlink_create_ecmp(switchlink_db_ecmp_info_t *ecmp_info) {
+  return 0; 
+}
+
+/*
+ * Dummy function for switchlink_db_add_ecmp().
+ */
+switchlink_db_status_t
+switchlink_db_add_ecmp(switchlink_db_ecmp_info_t *ecmp_info) {
+  return SWITCHLINK_DB_STATUS_SUCCESS;
+}
+
+/*
+ * Dummy function for switchlink_db_update_nexthop_using_by().
+ */
+switchlink_db_status_t switchlink_db_update_nexthop_using_by(
+    switchlink_db_nexthop_info_t *nexthop_info) {
+  struct test_results temp = {0};
+  if (nexthop_info) {
+    temp.nexthop_info = *nexthop_info;
+  }
+  results.push_back(temp);
+  return SWITCHLINK_DB_STATUS_SUCCESS;
+}
+
+/*
+ * Dummy function for switchlink_db_add_nexthop().
+ */
+switchlink_db_status_t
+switchlink_db_add_nexthop(switchlink_db_nexthop_info_t *nexthop_info) {
+  struct test_results temp = {0};
+  if (nexthop_info) {
+    temp.nexthop_info = *nexthop_info;
+  }
+  results.push_back(temp);
+  return SWITCHLINK_DB_STATUS_SUCCESS;
+}
+
+/*
+ * Dummy function for switchlink_db_get_ecmp_info().
+ */
+switchlink_db_status_t
+switchlink_db_get_ecmp_info(switchlink_db_ecmp_info_t *ecmp_info) {
+  ecmp_info->ecmp_h = TEST_ECMP_H;
+  if (ecmp_info) {
+    results[0].ecmp_info = *ecmp_info;
+  }
+  return SWITCHLINK_DB_STATUS_SUCCESS;
+}
+
+/*
+ * Dummy function for switchlink_db_get_nexthop_info().
+ * Returns success for intf handle: TEST_INTF_H1
+ * Returns failure for intf handle: TEST_INTF_H2
+ */
+switchlink_db_status_t
+switchlink_db_get_nexthop_info(switchlink_db_nexthop_info_t *nexthop_info) {
+
+  if (nexthop_info->intf_h == TEST_INTF_H1) {
+    nexthop_info->nhop_h = 1;
+    return SWITCHLINK_DB_STATUS_SUCCESS;
+  } else if (nexthop_info->intf_h == TEST_INTF_H2) {
+    nexthop_info->nhop_h = 2;
+    return SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND;
+  }
+
+  return SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND;
+}
+
+/*
+ * Test fixture.
+ */
+class SwitchlinkRouteTest : public ::testing::Test {
+protected:
+  struct nl_msg *nlmsg_ = nullptr;
+
+  // Sets up the test fixture.
+  void SetUp() override { ResetVariables(); }
+
+  // Tears down the test fixture.
+  void TearDown() override {
+    if (nlmsg_) {
+      nlmsg_free(nlmsg_);
+      nlmsg_ = nullptr;
+    }
+  }
+
+  void ResetVariables() {
+    // result variables
+    results.clear();
+  }
+};
+
+/*
+ * Creates an IPv4 route
+ *
+ * Validates switchlink_process_route_msg(). It parses an
+ * RTM_NEWROUTE message, invokes switchlink_create_route()
+ * for creating route entry.
+ *
+ */
+TEST_F(SwitchlinkRouteTest, createIPv4Route) {
+  struct rtmsg hdr = {
+      .rtm_family = AF_INET,
+      .rtm_dst_len = 24,
+      .rtm_src_len = 24,
+      .rtm_tos = 1,
+      .rtm_table = 1,
+      .rtm_protocol = 1,
+      .rtm_scope = 1,
+      .rtm_type = 1,
+      .rtm_flags = 0x1,
+  };
+
+  const uint32_t src_addr = IPV4_ADDR(10, 10, 10, 10);
+  const uint32_t dst_addr = IPV4_ADDR(20, 20, 20, 20);
+  const uint32_t gateway_addr = IPV4_ADDR(20, 20, 20, 1);
+  const uint32_t oifindex = 1;
+  const uint32_t iifindex = 1;
+
+  // Arrange
+  nlmsg_ = nlmsg_alloc_size(1024);
+  ASSERT_NE(nlmsg_, nullptr);
+  nlmsg_put(nlmsg_, 0, 0, RTM_NEWROUTE, 0, 0);
+  nlmsg_append(nlmsg_, &hdr, sizeof(hdr), NLMSG_ALIGNTO);
+  nla_put_u32(nlmsg_, RTA_SRC, htonl(src_addr));
+  nla_put_u32(nlmsg_, RTA_DST, htonl(dst_addr));
+  nla_put_u32(nlmsg_, RTA_GATEWAY, htonl(gateway_addr));
+  nla_put_u32(nlmsg_, RTA_OIF, oifindex);
+  nla_put_u32(nlmsg_, RTA_IIF, iifindex);
+
+  // Act
+  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  switchlink_process_route_msg(nlmsg, nlmsg->nlmsg_type);
+
+  // Assert
+  ASSERT_EQ(results.size(), 1);
+
+  // Verify test results for ROUTE creation
+  EXPECT_EQ(results[0].opType, CREATE_ROUTE);
+  EXPECT_EQ(results[0].intf_h, TEST_INTF_H1);
+  EXPECT_EQ(results[0].dst.family, AF_INET);
+  EXPECT_EQ(results[0].dst.ip.v4addr.s_addr, dst_addr);
+  EXPECT_EQ(results[0].dst.prefix_len, 24);
+  EXPECT_EQ(results[0].gateway.family, AF_INET);
+  EXPECT_EQ(results[0].gateway.ip.v4addr.s_addr, gateway_addr);
+  EXPECT_EQ(results[0].gateway.prefix_len, 32);
+}
+
+/*
+ * Validates switchlink_process_route_msg() for an invalid
+ * interface. The function simply returns without invoking
+ * switchlink_route_create() method and the test results is
+ * expected to be empty.
+ */
+TEST_F(SwitchlinkRouteTest, invalidInterface) {
+  struct rtmsg hdr = {
+      .rtm_family = AF_INET,
+      .rtm_dst_len = 24,
+      .rtm_src_len = 24,
+      .rtm_tos = 1,
+      .rtm_table = 1,
+      .rtm_protocol = 1,
+      .rtm_scope = 1,
+      .rtm_type = 1,
+      .rtm_flags = 0x1,
+  };
+
+  const uint32_t src_addr = IPV4_ADDR(10, 10, 10, 10);
+  const uint32_t dst_addr = IPV4_ADDR(20, 20, 20, 20);
+  const uint32_t gateway_addr = IPV4_ADDR(20, 20, 20, 1);
+  const uint32_t oifindex = 3;
+  const uint32_t iifindex = 1;
+
+  // Arrange
+  nlmsg_ = nlmsg_alloc_size(1024);
+  ASSERT_NE(nlmsg_, nullptr);
+  nlmsg_put(nlmsg_, 0, 0, RTM_NEWROUTE, 0, 0);
+  nlmsg_append(nlmsg_, &hdr, sizeof(hdr), NLMSG_ALIGNTO);
+  nla_put_u32(nlmsg_, RTA_SRC, htonl(src_addr));
+  nla_put_u32(nlmsg_, RTA_DST, htonl(dst_addr));
+  nla_put_u32(nlmsg_, RTA_GATEWAY, htonl(gateway_addr));
+  nla_put_u32(nlmsg_, RTA_OIF, oifindex);
+  nla_put_u32(nlmsg_, RTA_IIF, iifindex);
+
+  // Act
+  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  switchlink_process_route_msg(nlmsg, nlmsg->nlmsg_type);
+
+  // Assert
+  EXPECT_EQ(results.size(), 0);
+}
+
+/*
+ * Creates an IPv4 route
+ *
+ * Validates switchlink_process_route_msg(). It parses an
+ * RTM_NEWROUTE message, invokes switchlink_create_route()
+ * for creating route entry.
+ *
+ * The destination prefix len and addr is 0.
+ */
+TEST_F(SwitchlinkRouteTest, zeroDestPrefixLen) {
+  struct rtmsg hdr = {
+      .rtm_family = AF_INET,
+      .rtm_dst_len = 0,
+      .rtm_src_len = 24,
+      .rtm_tos = 1,
+      .rtm_table = 1,
+      .rtm_protocol = 1,
+      .rtm_scope = 1,
+      .rtm_type = 1,
+      .rtm_flags = 0x1,
+  };
+
+  const uint32_t src_addr = IPV4_ADDR(10, 10, 10, 10);
+  const uint32_t dst_addr = IPV4_ADDR(20, 20, 20, 20);
+  const uint32_t gateway_addr = IPV4_ADDR(20, 20, 20, 1);
+  const uint32_t oifindex = 1;
+  const uint32_t iifindex = 1;
+
+  // Arrange
+  nlmsg_ = nlmsg_alloc_size(1024);
+  ASSERT_NE(nlmsg_, nullptr);
+  nlmsg_put(nlmsg_, 0, 0, RTM_NEWROUTE, 0, 0);
+  nlmsg_append(nlmsg_, &hdr, sizeof(hdr), NLMSG_ALIGNTO);
+  nla_put_u32(nlmsg_, RTA_SRC, htonl(src_addr));
+  nla_put_u32(nlmsg_, RTA_DST, htonl(dst_addr));
+  nla_put_u32(nlmsg_, RTA_GATEWAY, htonl(gateway_addr));
+  nla_put_u32(nlmsg_, RTA_OIF, oifindex);
+  nla_put_u32(nlmsg_, RTA_IIF, iifindex);
+
+  // Act
+  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  switchlink_process_route_msg(nlmsg, nlmsg->nlmsg_type);
+
+  // Assert
+  ASSERT_EQ(results.size(), 1);
+
+  // Verify test results for ROUTE creation
+  EXPECT_EQ(results[0].opType, CREATE_ROUTE);
+  EXPECT_EQ(results[0].intf_h, TEST_INTF_H1);
+  EXPECT_EQ(results[0].dst.family, AF_INET);
+  EXPECT_EQ(results[0].dst.ip.v4addr.s_addr, 0);
+  EXPECT_EQ(results[0].dst.prefix_len, 0);
+  EXPECT_EQ(results[0].gateway.family, AF_INET);
+  EXPECT_EQ(results[0].gateway.ip.v4addr.s_addr, gateway_addr);
+  EXPECT_EQ(results[0].gateway.prefix_len, 32);
+}
+
+/*
+ * Validates switchlink_process_route_msg() for an unspecified
+ * address family. The function simply returns without invoking
+ * switchlink_route_create() method and the test results is
+ * expected to be empty.
+ */
+TEST_F(SwitchlinkRouteTest, verifyUnspecifiedAddressFamily) {
+  struct rtmsg hdr = {
+      .rtm_family = AF_UNSPEC,
+      .rtm_dst_len = 24,
+      .rtm_src_len = 24,
+      .rtm_tos = 1,
+      .rtm_table = 1,
+      .rtm_protocol = 1,
+      .rtm_scope = 1,
+      .rtm_type = 1,
+      .rtm_flags = 0x1,
+  };
+
+  const uint32_t src_addr = IPV4_ADDR(10, 10, 10, 10);
+  const uint32_t dst_addr = IPV4_ADDR(20, 20, 20, 20);
+  const uint32_t gateway_addr = IPV4_ADDR(20, 20, 20, 1);
+  const uint32_t oifindex = 1;
+
+  // Arrange
+  nlmsg_ = nlmsg_alloc_size(1024);
+  ASSERT_NE(nlmsg_, nullptr);
+  nlmsg_put(nlmsg_, 0, 0, RTM_NEWROUTE, 0, 0);
+  nlmsg_append(nlmsg_, &hdr, sizeof(hdr), NLMSG_ALIGNTO);
+  nla_put_u32(nlmsg_, RTA_SRC, htonl(src_addr));
+  nla_put_u32(nlmsg_, RTA_DST, htonl(dst_addr));
+  nla_put_u32(nlmsg_, RTA_GATEWAY, htonl(gateway_addr));
+  nla_put_u32(nlmsg_, RTA_OIF, oifindex);
+
+  // Act
+  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  switchlink_process_route_msg(nlmsg, nlmsg->nlmsg_type);
+
+  // Assert
+  ASSERT_EQ(results.size(), 0);
+}
+
+/*
+ * Creates an IPv6 route
+ *
+ * Validates switchlink_process_route_msg(). It parses an
+ * RTM_NEWROUTE message, invokes switchlink_create_route()
+ * for creating route entry.
+ *
+ */
+TEST_F(SwitchlinkRouteTest, createIPv6Route) {
+  struct rtmsg hdr = {
+      .rtm_family = AF_INET6,
+      .rtm_dst_len = 64,
+      .rtm_src_len = 64,
+      .rtm_tos = 1,
+      .rtm_table = 1,
+      .rtm_protocol = 1,
+      .rtm_scope = 1,
+      .rtm_type = 1,
+      .rtm_flags = 0x1,
+  };
+
+  struct in6_addr gateway_addr6;
+  struct in6_addr dst_addr6;
+  struct in6_addr src_addr6;
+
+  inet_pton(AF_INET6, "1001::1", &src_addr6);
+
+  inet_pton(AF_INET6, "2001::1", &gateway_addr6);
+  // Word 0 of IPv6 address.
+  const uint16_t GATEWAY_V6ADDR_0 = htons(0x2001);
+  // Word 7 of IPv6 address.
+  const uint16_t GATEWAY_V6ADDR_7 = htons(0x0001);
+
+  inet_pton(AF_INET6, "2001::2", &dst_addr6);
+  // Word 0 of IPv6 address.
+  const uint16_t DST_V6ADDR_0 = htons(0x2001);
+  // Word 7 of IPv6 address.
+  const uint16_t DST_V6ADDR_7 = htons(0x0002);
+
+  const uint32_t oifindex = 1;
+
+  // Arrange
+  nlmsg_ = nlmsg_alloc_size(1024);
+  ASSERT_NE(nlmsg_, nullptr);
+  nlmsg_put(nlmsg_, 0, 0, RTM_NEWROUTE, 0, 0);
+  nlmsg_append(nlmsg_, &hdr, sizeof(hdr), NLMSG_ALIGNTO);
+  nla_put(nlmsg_, RTA_SRC, sizeof(src_addr6), &src_addr6);
+  nla_put(nlmsg_, RTA_DST, sizeof(dst_addr6), &dst_addr6);
+  nla_put(nlmsg_, RTA_GATEWAY, sizeof(gateway_addr6), &gateway_addr6);
+  nla_put_u32(nlmsg_, RTA_OIF, oifindex);
+
+  // Act
+  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  switchlink_process_route_msg(nlmsg, nlmsg->nlmsg_type);
+
+  // Assert
+  ASSERT_EQ(results.size(), 1);
+
+  // Verify test results for ROUTE creation
+  EXPECT_EQ(results[0].opType, CREATE_ROUTE);
+  EXPECT_EQ(results[0].intf_h, TEST_INTF_H1);
+  EXPECT_EQ(results[0].dst.family, AF_INET6);
+  EXPECT_EQ(results[0].dst.ip.v6addr.__in6_u.__u6_addr16[0], DST_V6ADDR_0);
+  EXPECT_EQ(results[0].dst.ip.v6addr.__in6_u.__u6_addr16[7], DST_V6ADDR_7);
+  EXPECT_EQ(results[0].dst.prefix_len, 64);
+  EXPECT_EQ(results[0].gateway.family, AF_INET6);
+  EXPECT_EQ(results[0].gateway.ip.v6addr.__in6_u.__u6_addr16[0],
+            GATEWAY_V6ADDR_0);
+  EXPECT_EQ(results[0].gateway.ip.v6addr.__in6_u.__u6_addr16[7],
+            GATEWAY_V6ADDR_7);
+  EXPECT_EQ(results[0].gateway.prefix_len, 128);
+}
+
+/*
+ * Deletes an IPv4 route
+ *
+ * Validates switchlink_process_route_msg(). It parses an
+ * RTM_DELROUTE message, invokes switchlink_delete_route()
+ * for deleting route entry.
+ *
+ */
+TEST_F(SwitchlinkRouteTest, deleteIPv4Route) {
+  struct rtmsg hdr = {
+      .rtm_family = AF_INET,
+      .rtm_dst_len = 24,
+      .rtm_src_len = 24,
+      .rtm_tos = 1,
+      .rtm_table = 1,
+      .rtm_protocol = 1,
+      .rtm_scope = 1,
+      .rtm_type = 1,
+      .rtm_flags = 0x1,
+  };
+
+  const uint32_t src_addr = IPV4_ADDR(10, 10, 10, 10);
+  const uint32_t dst_addr = IPV4_ADDR(20, 20, 20, 20);
+  const uint32_t gateway_addr = IPV4_ADDR(20, 20, 20, 1);
+  const uint32_t oifindex = 1;
+
+  // Arrange
+  nlmsg_ = nlmsg_alloc_size(1024);
+  ASSERT_NE(nlmsg_, nullptr);
+  nlmsg_put(nlmsg_, 0, 0, RTM_DELROUTE, 0, 0);
+  nlmsg_append(nlmsg_, &hdr, sizeof(hdr), NLMSG_ALIGNTO);
+  nla_put_u32(nlmsg_, RTA_SRC, htonl(src_addr));
+  nla_put_u32(nlmsg_, RTA_DST, htonl(dst_addr));
+  nla_put_u32(nlmsg_, RTA_GATEWAY, htonl(gateway_addr));
+  nla_put_u32(nlmsg_, RTA_OIF, oifindex);
+
+  // Act
+  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  switchlink_process_route_msg(nlmsg, nlmsg->nlmsg_type);
+
+  // Assert
+  ASSERT_EQ(results.size(), 1);
+
+  // Verify test results for ROUTE creation
+  EXPECT_EQ(results[0].opType, DELETE_ROUTE);
+  EXPECT_EQ(results[0].dst.family, AF_INET);
+  EXPECT_EQ(results[0].dst.ip.v4addr.s_addr, dst_addr);
+  EXPECT_EQ(results[0].dst.prefix_len, 24);
+}
+
+/*
+ * Deletes an IPv6 route
+ *
+ * Validates switchlink_process_route_msg(). It parses an
+ * RTM_DELROUTE message, invokes switchlink_delete_route()
+ * for deleting route entry.
+ *
+ */
+TEST_F(SwitchlinkRouteTest, deleteIPv6Route) {
+  struct rtmsg hdr = {
+      .rtm_family = AF_INET6,
+      .rtm_dst_len = 64,
+      .rtm_src_len = 64,
+      .rtm_tos = 1,
+      .rtm_table = 1,
+      .rtm_protocol = 1,
+      .rtm_scope = 1,
+      .rtm_type = 1,
+      .rtm_flags = 0x1,
+  };
+
+  struct in6_addr gateway_addr6;
+  struct in6_addr dst_addr6;
+  struct in6_addr src_addr6;
+
+  inet_pton(AF_INET6, "1001::1", &src_addr6);
+
+  inet_pton(AF_INET6, "2001::1", &gateway_addr6);
+  // Word 0 of IPv6 address.
+  const uint16_t GATEWAY_V6ADDR_0 = htons(0x2001);
+  // Word 7 of IPv6 address.
+  const uint16_t GATEWAY_V6ADDR_7 = htons(0x0001);
+
+  inet_pton(AF_INET6, "2001::2", &dst_addr6);
+  // Word 0 of IPv6 address.
+  const uint16_t DST_V6ADDR_0 = htons(0x2001);
+  // Word 7 of IPv6 address.
+  const uint16_t DST_V6ADDR_7 = htons(0x0002);
+
+  const uint32_t oifindex = 1;
+
+  // Arrange
+  nlmsg_ = nlmsg_alloc_size(1024);
+  ASSERT_NE(nlmsg_, nullptr);
+  nlmsg_put(nlmsg_, 0, 0, RTM_DELROUTE, 0, 0);
+  nlmsg_append(nlmsg_, &hdr, sizeof(hdr), NLMSG_ALIGNTO);
+  nla_put(nlmsg_, RTA_SRC, sizeof(src_addr6), &src_addr6);
+  nla_put(nlmsg_, RTA_DST, sizeof(dst_addr6), &dst_addr6);
+  nla_put(nlmsg_, RTA_GATEWAY, sizeof(gateway_addr6), &gateway_addr6);
+  nla_put_u32(nlmsg_, RTA_OIF, oifindex);
+
+  // Act
+  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  switchlink_process_route_msg(nlmsg, nlmsg->nlmsg_type);
+
+  // Assert
+  ASSERT_EQ(results.size(), 1);
+
+  // Verify test results for ROUTE creation
+  EXPECT_EQ(results[0].opType, DELETE_ROUTE);
+  EXPECT_EQ(results[0].dst.family, AF_INET6);
+  EXPECT_EQ(results[0].dst.ip.v6addr.__in6_u.__u6_addr16[0], DST_V6ADDR_0);
+  EXPECT_EQ(results[0].dst.ip.v6addr.__in6_u.__u6_addr16[7], DST_V6ADDR_7);
+  EXPECT_EQ(results[0].dst.prefix_len, 64);
+}
+
+/*
+ * Creates an IPv4 ECMP route
+ *
+ * Validates switchlink_process_route_msg(). It parses an
+ * RTM_NEWROUTE message, invokes switchlink_create_route()
+ * for creating route entry.
+ *
+ * It invokes a internal call to process_ecmp() method,
+ * where nexthop_info is updated.
+ *
+ */
+TEST_F(SwitchlinkRouteTest, processEcmpUpdatev4Nexthop) {
+  struct rtmsg hdr = {
+      .rtm_family = AF_INET,
+      .rtm_dst_len = 24,
+      .rtm_src_len = 24,
+      .rtm_tos = 1,
+      .rtm_table = 1,
+      .rtm_protocol = 1,
+      .rtm_scope = 1,
+      .rtm_type = 1,
+      .rtm_flags = 0x1,
+  };
+
+  struct rtnexthop rt_nh = {
+      .rtnh_len = 8,
+      .rtnh_flags = 0x2,
+      .rtnh_hops = 2,
+      .rtnh_ifindex = 1,
+  };
+
+  const uint32_t gateway_addr1 = IPV4_ADDR(20, 20, 20, 1);
+  const uint32_t oifindex = 1;
+
+  // Arrange
+  nlmsg_ = nlmsg_alloc_size(1024);
+  ASSERT_NE(nlmsg_, nullptr);
+  nlmsg_put(nlmsg_, 0, 0, RTM_NEWROUTE, 0, 0);
+  nlmsg_append(nlmsg_, &hdr, sizeof(hdr), NLMSG_ALIGNTO);
+
+  nla_put(nlmsg_, RTA_MULTIPATH, sizeof(rt_nh), &rt_nh);
+  nla_put_u32(nlmsg_, RTA_GATEWAY, htonl(gateway_addr1));
+
+  // Act
+  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  switchlink_process_route_msg(nlmsg, nlmsg->nlmsg_type);
+
+  // Assert
+  ASSERT_EQ(results.size(), 2);
+  EXPECT_EQ(results[0].nexthop_info.intf_h, TEST_INTF_H1);
+  EXPECT_EQ(results[0].nexthop_info.vrf_h, 2);
+  EXPECT_EQ(results[0].nexthop_info.ip_addr.family, AF_INET);
+  EXPECT_EQ(results[0].nexthop_info.ip_addr.ip.v4addr.s_addr, gateway_addr1);
+  EXPECT_EQ(results[0].nexthop_info.ip_addr.prefix_len, 32);
+  EXPECT_EQ(results[0].nexthop_info.using_by, SWITCHLINK_NHOP_FROM_ROUTE);
+  EXPECT_EQ(results[1].ecmp_h, TEST_ECMP_H);
+}
+
+/*
+ * Creates an IPv4 ECMP route
+ *
+ * Validates switchlink_process_route_msg(). It parses an
+ * RTM_NEWROUTE message, invokes switchlink_create_route()
+ * for creating route entry.
+ *
+ * It invokes a internal call to process_ecmp() method,
+ * where nexthop_info is created.
+ *
+ */
+TEST_F(SwitchlinkRouteTest, processEcmpCreatev4Nexthop) {
+  struct rtmsg hdr = {
+      .rtm_family = AF_INET,
+      .rtm_dst_len = 24,
+      .rtm_src_len = 24,
+      .rtm_tos = 1,
+      .rtm_table = 1,
+      .rtm_protocol = 1,
+      .rtm_scope = 1,
+      .rtm_type = 1,
+      .rtm_flags = 0x1,
+  };
+
+  struct rtnexthop rt_nh = {
+      .rtnh_len = 8,
+      .rtnh_flags = 0x2,
+      .rtnh_hops = 2,
+      .rtnh_ifindex = 2,
+  };
+
+  const uint32_t gateway_addr1 = IPV4_ADDR(20, 20, 20, 1);
+  const uint32_t oifindex = 1;
+
+  // Arrange
+  nlmsg_ = nlmsg_alloc_size(1024);
+  ASSERT_NE(nlmsg_, nullptr);
+  nlmsg_put(nlmsg_, 0, 0, RTM_NEWROUTE, 0, 0);
+  nlmsg_append(nlmsg_, &hdr, sizeof(hdr), NLMSG_ALIGNTO);
+
+  nla_put(nlmsg_, RTA_MULTIPATH, sizeof(rt_nh), &rt_nh);
+  nla_put_u32(nlmsg_, RTA_GATEWAY, htonl(gateway_addr1));
+
+  // Act
+  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  switchlink_process_route_msg(nlmsg, nlmsg->nlmsg_type);
+
+  // Assert
+  ASSERT_EQ(results.size(), 2);
+  EXPECT_EQ(results[0].nexthop_info.intf_h, TEST_INTF_H2);
+  EXPECT_EQ(results[0].nexthop_info.vrf_h, 2);
+  EXPECT_EQ(results[0].nexthop_info.ip_addr.family, AF_INET);
+  EXPECT_EQ(results[0].nexthop_info.ip_addr.ip.v4addr.s_addr, gateway_addr1);
+  EXPECT_EQ(results[0].nexthop_info.ip_addr.prefix_len, 32);
+  EXPECT_EQ(results[0].nexthop_info.using_by, SWITCHLINK_NHOP_FROM_ROUTE);
+  EXPECT_EQ(results[0].ecmp_info.nhops[0], 2);
+  EXPECT_EQ(results[1].ecmp_h, TEST_ECMP_H);
+}

--- a/switchlink/switchlink_route_test.cc
+++ b/switchlink/switchlink_route_test.cc
@@ -45,6 +45,22 @@ const switchlink_handle_t TEST_INTF_H1 = 0x10001;
 const switchlink_handle_t TEST_INTF_H2 = 0x20002;
 const switchlink_handle_t TEST_ECMP_H = 0x30003;
 
+const uint8_t v4_SRC_PREFIX_LEN = 24;
+const uint8_t v4_DST_PREFIX_LEN = 24;
+const uint8_t v6_SRC_PREFIX_LEN = 64;
+const uint8_t v6_DST_PREFIX_LEN = 64;
+
+const unsigned char RTM_TOS = 1;
+const unsigned char RTM_TABLE_ID = 1;
+const unsigned char RTM_PROTOCOL = 1;
+const unsigned char RTM_SCOPE = 1;
+const unsigned char RTM_TYPE = 1;
+const unsigned char RTM_FLAGS = 0x1;
+
+const unsigned short RTNH_LEN = 8;
+const unsigned char RTNH_HOPS = 2;
+const unsigned char RTNH_FLAGS = 0x2;
+
 vector<test_results> results(2);
 
 /*
@@ -129,11 +145,8 @@ switchlink_db_get_interface_info(uint32_t ifindex,
  * Dummy function for switchlink_create_nexthop(). Returns 0 on success
  * and -1 in case of error.
  */
-
 int switchlink_create_nexthop(switchlink_db_nexthop_info_t *nexthop_info) {
-  if (nexthop_info->intf_h == TEST_INTF_H2)
-    return 0;
-  return -1;
+  return (nexthop_info->intf_h == TEST_INTF_H2) ? 0 : -1;
 }
 
 /*
@@ -243,14 +256,14 @@ protected:
 TEST_F(SwitchlinkRouteTest, createIPv4Route) {
   struct rtmsg hdr = {
       .rtm_family = AF_INET,
-      .rtm_dst_len = 24,
-      .rtm_src_len = 24,
-      .rtm_tos = 1,
-      .rtm_table = 1,
-      .rtm_protocol = 1,
-      .rtm_scope = 1,
-      .rtm_type = 1,
-      .rtm_flags = 0x1,
+      .rtm_dst_len = v4_DST_PREFIX_LEN,
+      .rtm_src_len = v4_SRC_PREFIX_LEN,
+      .rtm_tos = RTM_TOS,
+      .rtm_table = RTM_TABLE_ID,
+      .rtm_protocol = RTM_PROTOCOL,
+      .rtm_scope = RTM_SCOPE,
+      .rtm_type = RTM_TYPE,
+      .rtm_flags = RTM_FLAGS,
   };
 
   const uint32_t src_addr = IPV4_ADDR(10, 10, 10, 10);
@@ -282,7 +295,7 @@ TEST_F(SwitchlinkRouteTest, createIPv4Route) {
   EXPECT_EQ(results[0].intf_h, TEST_INTF_H1);
   EXPECT_EQ(results[0].dst.family, AF_INET);
   EXPECT_EQ(results[0].dst.ip.v4addr.s_addr, dst_addr);
-  EXPECT_EQ(results[0].dst.prefix_len, 24);
+  EXPECT_EQ(results[0].dst.prefix_len, v4_DST_PREFIX_LEN);
   EXPECT_EQ(results[0].gateway.family, AF_INET);
   EXPECT_EQ(results[0].gateway.ip.v4addr.s_addr, gateway_addr);
   EXPECT_EQ(results[0].gateway.prefix_len, 32);
@@ -297,14 +310,14 @@ TEST_F(SwitchlinkRouteTest, createIPv4Route) {
 TEST_F(SwitchlinkRouteTest, invalidInterface) {
   struct rtmsg hdr = {
       .rtm_family = AF_INET,
-      .rtm_dst_len = 24,
-      .rtm_src_len = 24,
-      .rtm_tos = 1,
-      .rtm_table = 1,
-      .rtm_protocol = 1,
-      .rtm_scope = 1,
-      .rtm_type = 1,
-      .rtm_flags = 0x1,
+      .rtm_dst_len = v4_DST_PREFIX_LEN,
+      .rtm_src_len = v4_SRC_PREFIX_LEN,
+      .rtm_tos = RTM_TOS,
+      .rtm_table = RTM_TABLE_ID,
+      .rtm_protocol = RTM_PROTOCOL,
+      .rtm_scope = RTM_SCOPE,
+      .rtm_type = RTM_TYPE,
+      .rtm_flags = RTM_FLAGS,
   };
 
   const uint32_t src_addr = IPV4_ADDR(10, 10, 10, 10);
@@ -345,13 +358,13 @@ TEST_F(SwitchlinkRouteTest, zeroDestPrefixLen) {
   struct rtmsg hdr = {
       .rtm_family = AF_INET,
       .rtm_dst_len = 0,
-      .rtm_src_len = 24,
-      .rtm_tos = 1,
-      .rtm_table = 1,
-      .rtm_protocol = 1,
-      .rtm_scope = 1,
-      .rtm_type = 1,
-      .rtm_flags = 0x1,
+      .rtm_src_len = v4_SRC_PREFIX_LEN,
+      .rtm_tos = RTM_TOS,
+      .rtm_table = RTM_TABLE_ID,
+      .rtm_protocol = RTM_PROTOCOL,
+      .rtm_scope = RTM_SCOPE,
+      .rtm_type = RTM_TYPE,
+      .rtm_flags = RTM_FLAGS,
   };
 
   const uint32_t src_addr = IPV4_ADDR(10, 10, 10, 10);
@@ -398,14 +411,14 @@ TEST_F(SwitchlinkRouteTest, zeroDestPrefixLen) {
 TEST_F(SwitchlinkRouteTest, verifyUnspecifiedAddressFamily) {
   struct rtmsg hdr = {
       .rtm_family = AF_UNSPEC,
-      .rtm_dst_len = 24,
-      .rtm_src_len = 24,
-      .rtm_tos = 1,
-      .rtm_table = 1,
-      .rtm_protocol = 1,
-      .rtm_scope = 1,
-      .rtm_type = 1,
-      .rtm_flags = 0x1,
+      .rtm_dst_len = v4_DST_PREFIX_LEN,
+      .rtm_src_len = v4_SRC_PREFIX_LEN,
+      .rtm_tos = RTM_TOS,
+      .rtm_table = RTM_TABLE_ID,
+      .rtm_protocol = RTM_PROTOCOL,
+      .rtm_scope = RTM_SCOPE,
+      .rtm_type = RTM_TYPE,
+      .rtm_flags = RTM_FLAGS,
   };
 
   const uint32_t src_addr = IPV4_ADDR(10, 10, 10, 10);
@@ -442,14 +455,14 @@ TEST_F(SwitchlinkRouteTest, verifyUnspecifiedAddressFamily) {
 TEST_F(SwitchlinkRouteTest, createIPv6Route) {
   struct rtmsg hdr = {
       .rtm_family = AF_INET6,
-      .rtm_dst_len = 64,
-      .rtm_src_len = 64,
-      .rtm_tos = 1,
-      .rtm_table = 1,
-      .rtm_protocol = 1,
-      .rtm_scope = 1,
-      .rtm_type = 1,
-      .rtm_flags = 0x1,
+      .rtm_dst_len = v6_DST_PREFIX_LEN,
+      .rtm_src_len = v6_SRC_PREFIX_LEN,
+      .rtm_tos = RTM_TOS,
+      .rtm_table = RTM_TABLE_ID,
+      .rtm_protocol = RTM_PROTOCOL,
+      .rtm_scope = RTM_SCOPE,
+      .rtm_type = RTM_TYPE,
+      .rtm_flags = RTM_FLAGS,
   };
 
   struct in6_addr gateway_addr6;
@@ -495,7 +508,7 @@ TEST_F(SwitchlinkRouteTest, createIPv6Route) {
   EXPECT_EQ(results[0].dst.family, AF_INET6);
   EXPECT_EQ(results[0].dst.ip.v6addr.__in6_u.__u6_addr16[0], DST_V6ADDR_0);
   EXPECT_EQ(results[0].dst.ip.v6addr.__in6_u.__u6_addr16[7], DST_V6ADDR_7);
-  EXPECT_EQ(results[0].dst.prefix_len, 64);
+  EXPECT_EQ(results[0].dst.prefix_len, v6_DST_PREFIX_LEN);
   EXPECT_EQ(results[0].gateway.family, AF_INET6);
   EXPECT_EQ(results[0].gateway.ip.v6addr.__in6_u.__u6_addr16[0],
             GATEWAY_V6ADDR_0);
@@ -515,14 +528,14 @@ TEST_F(SwitchlinkRouteTest, createIPv6Route) {
 TEST_F(SwitchlinkRouteTest, deleteIPv4Route) {
   struct rtmsg hdr = {
       .rtm_family = AF_INET,
-      .rtm_dst_len = 24,
-      .rtm_src_len = 24,
-      .rtm_tos = 1,
-      .rtm_table = 1,
-      .rtm_protocol = 1,
-      .rtm_scope = 1,
-      .rtm_type = 1,
-      .rtm_flags = 0x1,
+      .rtm_dst_len = v4_DST_PREFIX_LEN,
+      .rtm_src_len = v4_SRC_PREFIX_LEN,
+      .rtm_tos = RTM_TOS,
+      .rtm_table = RTM_TABLE_ID,
+      .rtm_protocol = RTM_PROTOCOL,
+      .rtm_scope = RTM_SCOPE,
+      .rtm_type = RTM_TYPE,
+      .rtm_flags = RTM_FLAGS,
   };
 
   const uint32_t src_addr = IPV4_ADDR(10, 10, 10, 10);
@@ -551,7 +564,7 @@ TEST_F(SwitchlinkRouteTest, deleteIPv4Route) {
   EXPECT_EQ(results[0].opType, DELETE_ROUTE);
   EXPECT_EQ(results[0].dst.family, AF_INET);
   EXPECT_EQ(results[0].dst.ip.v4addr.s_addr, dst_addr);
-  EXPECT_EQ(results[0].dst.prefix_len, 24);
+  EXPECT_EQ(results[0].dst.prefix_len, v4_DST_PREFIX_LEN);
 }
 
 /*
@@ -565,14 +578,14 @@ TEST_F(SwitchlinkRouteTest, deleteIPv4Route) {
 TEST_F(SwitchlinkRouteTest, deleteIPv6Route) {
   struct rtmsg hdr = {
       .rtm_family = AF_INET6,
-      .rtm_dst_len = 64,
-      .rtm_src_len = 64,
-      .rtm_tos = 1,
-      .rtm_table = 1,
-      .rtm_protocol = 1,
-      .rtm_scope = 1,
-      .rtm_type = 1,
-      .rtm_flags = 0x1,
+      .rtm_dst_len = v6_DST_PREFIX_LEN,
+      .rtm_src_len = v6_SRC_PREFIX_LEN,
+      .rtm_tos = RTM_TOS,
+      .rtm_table = RTM_TABLE_ID,
+      .rtm_protocol = RTM_PROTOCOL,
+      .rtm_scope = RTM_SCOPE,
+      .rtm_type = RTM_TYPE,
+      .rtm_flags = RTM_FLAGS,
   };
 
   struct in6_addr gateway_addr6;
@@ -617,7 +630,7 @@ TEST_F(SwitchlinkRouteTest, deleteIPv6Route) {
   EXPECT_EQ(results[0].dst.family, AF_INET6);
   EXPECT_EQ(results[0].dst.ip.v6addr.__in6_u.__u6_addr16[0], DST_V6ADDR_0);
   EXPECT_EQ(results[0].dst.ip.v6addr.__in6_u.__u6_addr16[7], DST_V6ADDR_7);
-  EXPECT_EQ(results[0].dst.prefix_len, 64);
+  EXPECT_EQ(results[0].dst.prefix_len, v6_DST_PREFIX_LEN);
 }
 
 /*
@@ -634,20 +647,20 @@ TEST_F(SwitchlinkRouteTest, deleteIPv6Route) {
 TEST_F(SwitchlinkRouteTest, processEcmpUpdatev4Nexthop) {
   struct rtmsg hdr = {
       .rtm_family = AF_INET,
-      .rtm_dst_len = 24,
-      .rtm_src_len = 24,
-      .rtm_tos = 1,
-      .rtm_table = 1,
-      .rtm_protocol = 1,
-      .rtm_scope = 1,
-      .rtm_type = 1,
-      .rtm_flags = 0x1,
+      .rtm_dst_len = v4_DST_PREFIX_LEN,
+      .rtm_src_len = v4_SRC_PREFIX_LEN,
+      .rtm_tos = RTM_TOS,
+      .rtm_table = RTM_TABLE_ID,
+      .rtm_protocol = RTM_PROTOCOL,
+      .rtm_scope = RTM_SCOPE,
+      .rtm_type = RTM_TYPE,
+      .rtm_flags = RTM_FLAGS,
   };
 
   struct rtnexthop rt_nh = {
-      .rtnh_len = 8,
-      .rtnh_flags = 0x2,
-      .rtnh_hops = 2,
+      .rtnh_len = RTNH_LEN,
+      .rtnh_flags = RTNH_FLAGS,
+      .rtnh_hops = RTNH_HOPS,
       .rtnh_ifindex = 1,
   };
 
@@ -670,7 +683,7 @@ TEST_F(SwitchlinkRouteTest, processEcmpUpdatev4Nexthop) {
   // Assert
   ASSERT_EQ(results.size(), 2);
   EXPECT_EQ(results[0].nexthop_info.intf_h, TEST_INTF_H1);
-  EXPECT_EQ(results[0].nexthop_info.vrf_h, 2);
+  EXPECT_EQ(results[0].nexthop_info.vrf_h, g_default_vrf_h);
   EXPECT_EQ(results[0].nexthop_info.ip_addr.family, AF_INET);
   EXPECT_EQ(results[0].nexthop_info.ip_addr.ip.v4addr.s_addr, gateway_addr1);
   EXPECT_EQ(results[0].nexthop_info.ip_addr.prefix_len, 32);
@@ -692,20 +705,20 @@ TEST_F(SwitchlinkRouteTest, processEcmpUpdatev4Nexthop) {
 TEST_F(SwitchlinkRouteTest, processEcmpCreatev4Nexthop) {
   struct rtmsg hdr = {
       .rtm_family = AF_INET,
-      .rtm_dst_len = 24,
-      .rtm_src_len = 24,
-      .rtm_tos = 1,
-      .rtm_table = 1,
-      .rtm_protocol = 1,
-      .rtm_scope = 1,
-      .rtm_type = 1,
-      .rtm_flags = 0x1,
+      .rtm_dst_len = v4_DST_PREFIX_LEN,
+      .rtm_src_len = v4_SRC_PREFIX_LEN,
+      .rtm_tos = RTM_TOS,
+      .rtm_table = RTM_TABLE_ID,
+      .rtm_protocol = RTM_PROTOCOL,
+      .rtm_scope = RTM_SCOPE,
+      .rtm_type = RTM_TYPE,
+      .rtm_flags = RTM_FLAGS,
   };
 
   struct rtnexthop rt_nh = {
-      .rtnh_len = 8,
-      .rtnh_flags = 0x2,
-      .rtnh_hops = 2,
+      .rtnh_len = RTNH_LEN,
+      .rtnh_flags = RTNH_FLAGS,
+      .rtnh_hops = RTNH_HOPS,
       .rtnh_ifindex = 2,
   };
 
@@ -728,7 +741,7 @@ TEST_F(SwitchlinkRouteTest, processEcmpCreatev4Nexthop) {
   // Assert
   ASSERT_EQ(results.size(), 2);
   EXPECT_EQ(results[0].nexthop_info.intf_h, TEST_INTF_H2);
-  EXPECT_EQ(results[0].nexthop_info.vrf_h, 2);
+  EXPECT_EQ(results[0].nexthop_info.vrf_h, g_default_vrf_h);
   EXPECT_EQ(results[0].nexthop_info.ip_addr.family, AF_INET);
   EXPECT_EQ(results[0].nexthop_info.ip_addr.ip.v4addr.s_addr, gateway_addr1);
   EXPECT_EQ(results[0].nexthop_info.ip_addr.prefix_len, 32);

--- a/switchlink/testing.cmake
+++ b/switchlink/testing.cmake
@@ -69,6 +69,18 @@ add_executable(switchlink_neighbor_test
 
 define_switchlink_test(switchlink_neighbor_test)
 
+#########################
+# switchlink_route_test #
+#########################
+
+add_executable(switchlink_route_test
+    switchlink_route_test.cc
+    switchlink_route.c
+    switchlink_route.h
+)
+
+define_switchlink_test(switchlink_route_test)
+
 ################
 # krnlmon-test #
 ################
@@ -86,6 +98,7 @@ add_custom_target(krnlmon-test
     switchlink_link_test
     switchlink_address_test
     switchlink_neighbor_test
+    switchlink_route_test
   WORKING_DIRECTORY
     ${CMAKE_BINARY_DIR}
 )


### PR DESCRIPTION
This PR contains krnlmon UT written for switchlink_route.c file.
Test Cases added:
1. createIPv4Route()
2. invalidInterface()
3. zeroDestPrefixLen()
4. verifyUnspecifiedAddressFamily()
5. createIPv6Route()
6. deleteIPv4Route()
7. deleteIPv6Route()
8. processEcmpUpdatev4Nexthop()
9. processEcmpCreatev4Nexthop()