### PR TITLE
multiple Defs bug fix

### DIFF
--- a/switchlink/switchlink_address.c
+++ b/switchlink/switchlink_address.c
@@ -21,8 +21,6 @@
 #include "switchlink_int.h"
 #include "switchlink_handle.h"
 
-switchlink_handle_t g_default_vrf_h;
-
 /*
  * Routine Description:
  *    Process address netlink messages

--- a/switchlink/switchlink_address_test.cc
+++ b/switchlink/switchlink_address_test.cc
@@ -15,6 +15,8 @@ extern "C" {
 
 using namespace std;
 
+switchlink_handle_t g_default_vrf_h = 0;
+
 #define IPV4_ADDR(a, b, c, d) (((a) << 24) | ((b) << 16) | ((c) << 8) | (d))
 
 // enum for diff operation types

--- a/switchlink/switchlink_neigh.c
+++ b/switchlink/switchlink_neigh.c
@@ -24,9 +24,6 @@
 #include "switchlink_neigh.h"
 #include "switchlink_handle.h"
 
-switchlink_handle_t g_default_vrf_h;
-switchlink_handle_t g_default_bridge_h;
-
 /*
  * Routine Description:
  *    Process neighbor netlink messages

--- a/switchlink/switchlink_neigh_test.cc
+++ b/switchlink/switchlink_neigh_test.cc
@@ -13,6 +13,9 @@ extern "C" {
 
 using namespace std;
 
+switchlink_handle_t g_default_vrf_h = 0;
+switchlink_handle_t g_default_bridge_h = 0;
+
 #define IPV4_ADDR(a, b, c, d) (((a) << 24) | ((b) << 16) | ((c) << 8) | (d))
 
 // enum for diff operation types


### PR DESCRIPTION
Problem Statement:
krnlmon code isn't compiling on Fedora 33, works on ubuntu 20.04.
[ 42%] Building CXX object stratum/proto/gnmi/CMakeFiles/gnmi_proto.dir/__/__/__/pb.out/gnmi/gnmi.grpc.pb.cc.o
/usr/bin/ld: switchlink/CMakeFiles/switchlink_o.dir/switchlink_link.c.o:/root/snagapat/mvlut/trial/networking-recipe/krnlmon/krnlmon/switchlink/switchlink_link.c:49: **multiple definition of** `g_default_vrf_h'; switchlink/CMakeFiles/switchlink_o.dir/switchlink_address.c.o:/root/snagapat/mvlut/trial/networking-recipe/krnlmon/krnlmon/switchlink/switchlink_address.c:24: first defined here
[ 43%] Building CXX object stratum/proto/gnmi/CMakeFiles/gnmi_proto.dir/__/__/__/pb.out/gnmi/gnmi_ext.pb.cc.o
/usr/bin/ld: switchlink/CMakeFiles/switchlink_o.dir/switchlink_neigh.c.o:/root/snagapat/mvlut/trial/networking-recipe/krnlmon/krnlmon/switchlink/switchlink_neigh.c:28: **multiple definition of** `g_default_bridge_h'; switchlink/CMakeFiles/switchlink_o.dir/switchlink_link.c.o:/root/snagapat/mvlut/trial/networking-recipe/krnlmon/krnlmon/switchlink/switchlink_link.c:50: first defined here
/usr/bin/ld: switchlink/CMakeFiles/switchlink_o.dir/switchlink_neigh.c.o:/root/snagapat/mvlut/trial/networking-recipe/krnlmon/krnlmon/switchlink/switchlink_neigh.c:27: **multiple definition of** `g_default_vrf_h'; switchlink/CMakeFiles/switchlink_o.dir/switchlink_address.c.o:/root/snagapat/mvlut/trial/networking-recipe/krnlmon/krnlmon/switchlink/switchlink_address.c:24: first defined here

Analysis:
Gcc version on fedora 33 is higher than 10, and the default behavior of gcc has changed with respect to tentative definitions.

Fix:
Adding the global variables required for the test execution, in the test file of that particular file instead of the source code file.
