### PR TITLE
Move switchlink globals to a common file

### DIFF
--- a/switchlink/CMakeLists.txt
+++ b/switchlink/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(switchlink_o OBJECT
     switchlink_db.h
     switchlink_db_int.h
     switchlink.h
+    switchlink_globals.c
     switchlink_handle.h
     switchlink_int.h
     switchlink_link.c

--- a/switchlink/switchlink_address.c
+++ b/switchlink/switchlink_address.c
@@ -21,8 +21,6 @@
 #include "switchlink_int.h"
 #include "switchlink_handle.h"
 
-switchlink_handle_t g_default_vrf_h;
-
 /*
  * Routine Description:
  *    Process address netlink messages

--- a/switchlink/switchlink_globals.c
+++ b/switchlink/switchlink_globals.c
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2023 Intel Corporation.
+ * SPDX-License-Identifier: Apache 2.0
+ */
+
+#include "switchlink.h"
+
+switchlink_handle_t g_default_vrf_h = 0;
+switchlink_handle_t g_default_bridge_h = 0;
+switchlink_handle_t g_cpu_rx_nhop_h = 0;
+

--- a/switchlink/switchlink_link.c
+++ b/switchlink/switchlink_link.c
@@ -46,10 +46,6 @@ struct link_attrs {
   uint8_t ttl;
 };
 
-switchlink_handle_t g_default_vrf_h = 0;
-switchlink_handle_t g_default_bridge_h = 0;
-switchlink_handle_t g_cpu_rx_nhop_h = 0;
-
 static const switchlink_mac_addr_t null_mac = {0, 0, 0, 0, 0, 0};
 
 /*

--- a/switchlink/switchlink_neigh.c
+++ b/switchlink/switchlink_neigh.c
@@ -24,9 +24,6 @@
 #include "switchlink_neigh.h"
 #include "switchlink_handle.h"
 
-switchlink_handle_t g_default_vrf_h;
-switchlink_handle_t g_default_bridge_h;
-
 /*
  * Routine Description:
  *    Process neighbor netlink messages

--- a/switchlink/testing.cmake
+++ b/switchlink/testing.cmake
@@ -40,6 +40,7 @@ endfunction()
 
 add_executable(switchlink_link_test
     switchlink_link_test.cc
+    switchlink_globals.c
     switchlink_link.c
     switchlink_link.h
 )
@@ -53,6 +54,7 @@ define_switchlink_test(switchlink_link_test)
 add_executable(switchlink_address_test
     switchlink_address_test.cc
     switchlink_address.c
+    switchlink_globals.c
 )
 
 define_switchlink_test(switchlink_address_test)
@@ -63,6 +65,7 @@ define_switchlink_test(switchlink_address_test)
 
 add_executable(switchlink_neighbor_test
     switchlink_neigh_test.cc
+    switchlink_globals.c
     switchlink_neigh.c
     switchlink_neigh.h
 )


### PR DESCRIPTION
- Collect the defining instances of g_default_vrf_h, g_default_bridge_h, and g_cpu_rx_nhop_h in a common source file, to provide a single point of definition for use in both krnlmon and unit tests.