### PR TITLE
Revise switchlink_link_test

### DIFF
--- a/switchlink/switchlink_link_test.cc
+++ b/switchlink/switchlink_link_test.cc
@@ -46,7 +46,6 @@ enum handler_type {
   DELETE_INTERFACE = 2,           // switchlink_delete_interface
   CREATE_TUNNEL_INTERFACE = 3,    // switchlink_create_tunnel_interface
   DELETE_TUNNEL_INTERFACE = 4,    // switchlink_delete_tunnel_interface
-  CREATE_VRF = 5,                 // switchlink_create_vrf
 };
 
 /**
@@ -107,11 +106,10 @@ void switchlink_delete_tunnel_interface(uint32_t ifindex) {
   results.push_back(temp);
 }
 
-// fulfills an external reference
+// This function is not called by the UUT, but it is referenced by a
+// function in the same source file. We provide a definition to avoid
+// a link error.
 int switchlink_create_vrf(switchlink_handle_t* vrf_h) {
-  struct test_results temp = {0};
-  temp.handler = CREATE_VRF;
-  results.push_back(temp);
   return 0;
 }
 
@@ -125,7 +123,7 @@ class SwitchlinkTest : public ::testing::Test {
   struct nl_msg* nlmsg_ = nullptr;
 
   // Sets up the test fixture.
-  void SetUp() override { ResetVariables(); }
+  void SetUp() override { InitializeGlobalState(); }
 
   // Tears down the test fixture.
   void TearDown() override {
@@ -135,9 +133,8 @@ class SwitchlinkTest : public ::testing::Test {
     }
   }
 
-  // Resets static state between test cases.
-  void ResetVariables() {
-    // global variables
+  void InitializeGlobalState() {
+    // switchlink variables
     g_default_vrf_h = 0;
     g_default_bridge_h = 0;
     g_cpu_rx_nhop_h = 0;

--- a/switchlink/switchlink_link_test.cc
+++ b/switchlink/switchlink_link_test.cc
@@ -26,9 +26,9 @@ extern "C" {
     to test the unit in isolation.
 
     Each dummy function stores the parameter with which it was called
-    in the results structure (below), sets results.handler to an enum
-    indicating which function was called, and increments
-    results.num_handler_calls so we know if more than one call was made.
+    in a results structure (below), sets the handler type to an enum
+    indicating which function was called, and appends the structure to
+    the list of results.
 
     The SetUp method in the Test Fixture resets the result variables
     at the beginning of each test case, and the test case inspects the
@@ -38,6 +38,9 @@ extern "C" {
     sequentially, not in parallel, or (2) each test case is run in a
     separate process. If that's not the case, we will need to come up
     with a more creative solution (such as thread-specific storage).
+
+    TODO: Look into using CMock instead of the clumsy methodology used
+    in this test.
 ******************************************************************************/
 
 enum handler_type {
@@ -231,8 +234,8 @@ class SwitchlinkTest : public ::testing::Test {
  * with (kind = None) and calls switchlink_create_interface() with the correct
  * attributes.
  *
- * A generic link is one that does not specify an IFLA_INFO_KIND. It is used
- * for vanilla ethernet interfaces.
+ * A generic link is one that does not specify an IFLA_INFO_KIND attribute.
+ * It is used for vanilla ethernet interfaces.
  *
  * When INFO_KIND is omitted, switchlink_process_link_msg() sets the
  * link_type to SWITCHLINK_LINK_TYPE_NONE.


### PR DESCRIPTION
- Update switchlink_link_test to use std::vector<test_result> to capture test results in dummy functions.

- Use clang-format to canonicalize source file.

- Make Arrange / Act / Assert section breaks in each test case more prominent, to try to make the logic easier to follow.

- Remove debug code.