### PR TITLE
Modify to work with revised driver modules

### DIFF
--- a/switchapi/dpdk/CMakeLists.txt
+++ b/switchapi/dpdk/CMakeLists.txt
@@ -36,8 +36,7 @@ target_include_directories(switchapi_target_o PRIVATE
   ${SDE_INSTALL_DIR}/include/target-sys
 )
 
-find_library(TDI tdi)
-find_library(TDI_JSON_PARSER tdi_json_parser)
-
 target_link_libraries(switchapi_target_o PRIVATE
-  ${TDI} ${TDI_JSON_PARSER})
+  sde::tdi
+  sde::tdi_json_parser
+)

--- a/switchapi/es2k/CMakeLists.txt
+++ b/switchapi/es2k/CMakeLists.txt
@@ -36,8 +36,7 @@ target_include_directories(switchapi_target_o PRIVATE
   ${SDE_INSTALL_DIR}/include/target-sys
 )
 
-find_library(TDI tdi)
-find_library(TDI_JSON_PARSER tdi_json_parser)
-
 target_link_libraries(switchapi_target_o PRIVATE
-  ${TDI} ${TDI_JSON_PARSER})
+  sde::tdi
+  sde::tdi_json_parser
+)

--- a/switchlink/testing.cmake
+++ b/switchlink/testing.cmake
@@ -14,7 +14,7 @@ function(define_switchlink_test test_name)
         GTest::gtest
         GTest::gtest_main
         PkgConfig::nl3
-        target_sys
+        sde::target_sys
     )
 
     target_link_directories(${test_name} PUBLIC ${DRIVER_SDK_DIRS})


### PR DESCRIPTION
- Remove local find_library() calls.

- Use sde:: namespace when referencing SDE libraries.

This PR depends on [changes made to the P4 driver libraries in networking-recipe](https://github.com/ipdk-io/networking-recipe/pull/253).