### PR TITLE
Revise netlink library definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,12 @@ cmake_minimum_required(VERSION 3.15)
 
 project(krnlmon LANGUAGES C CXX)
 
+include(FindPkgConfig)
+
+# Find netlink libraries
+pkg_check_modules(nl3 REQUIRED IMPORTED_TARGET libnl-3.0)
+pkg_check_modules(nl3-route REQUIRED IMPORTED_TARGET libnl-route-3.0)
+
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 add_compile_options(-Werror)
@@ -31,7 +37,7 @@ add_library(krnlmon SHARED
     krnlmon_main.h
 )
 
-target_link_libraries(krnlmon nl-route-3 nl-3)
+target_link_libraries(krnlmon PkgConfig::nl3 PkgConfig::nl3-route)
 
 # Version number for .pc file.
 set(VERSION 1.0)

--- a/switchlink/CMakeLists.txt
+++ b/switchlink/CMakeLists.txt
@@ -4,10 +4,6 @@
 # SPDX-License-Identifier: Apache 2.0
 
 include(FindGTest)
-include(FindPkgConfig)
-
-# Find netlink libraries
-pkg_check_modules(libnl3 REQUIRED IMPORTED_TARGET libnl-3.0 libnl-route-3.0)
 
 add_subdirectory(sai)
 
@@ -39,7 +35,7 @@ if(WITH_OVSP4RT)
     target_compile_definitions(switchlink_o PRIVATE OVSP4RT_SUPPORT)
 endif()
 
-target_link_libraries(switchlink_o PkgConfig::libnl3)
+target_link_libraries(switchlink_o PkgConfig::nl3)
 
 target_include_directories(switchlink_o PRIVATE
     ${SDE_INSTALL_DIR}/include/target-utils/third-party  # judy

--- a/switchlink/testing.cmake
+++ b/switchlink/testing.cmake
@@ -13,7 +13,7 @@ function(define_switchlink_test test_name)
     target_link_libraries(${test_name} PUBLIC
         GTest::gtest
         GTest::gtest_main
-        PkgConfig::libnl3
+        PkgConfig::nl3
         target_sys
     )
 


### PR DESCRIPTION
- Import netlink libraries at the top of the krnlmon cmake tree.

- Import libnl-3.0 and libnl-route-3.0 separately, defining alias targets in the PkgConfig:: namespace.

- Replace all netlink library references with alias targets.

This fixes a problem I encountered when cross-compiling P4 Control Plane. It is also better form.