### PR TITLE
Exclude external files from coverage report

### DIFF
--- a/switchlink/testing.cmake
+++ b/switchlink/testing.cmake
@@ -117,6 +117,9 @@ set_target_properties(krnlmon-test PROPERTIES EXCLUDE_FROM_ALL TRUE)
 add_custom_target(krnlmon-coverage
     lcov --capture --directory ${CMAKE_BINARY_DIR}
     --output-file krnlmon.info
+    --exclude '/opt/deps/*'
+    --exclude '/usr/include/*'
+    --exclude '9/**'
   COMMAND
     genhtml krnlmon.info --output-directory coverage
   WORKING_DIRECTORY


### PR DESCRIPTION
- Improve accuracy of coverage report by excluding external header files.