### PR TITLE
Standalone krnlmon build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,15 +7,27 @@
 # Version 3.15 is the baseline for P4 Control Plane.
 cmake_minimum_required(VERSION 3.15)
 
-project(krnlmon LANGUAGES C CXX)
+project(krnlmon VERSION 2.0 LANGUAGES C CXX)
 
 include(FindPkgConfig)
+
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  include(cmake/standalone.cmake)
+endif()
+
+if(SAI_SOURCE_DIR STREQUAL "")
+  message(FATAL_ERROR "SAI_SOURCE_DIR not defined!")
+endif()
+
+find_path(SAI_INCLUDE_DIR NAMES "sai.h" PATHS ${SAI_SOURCE_DIR}/inc)
+if(NOT SAI_INCLUDE_DIR)
+  message(FATAL_ERROR "sai.h not found")
+endif()
+mark_as_advanced(SAI_INCLUDE_DIR)
 
 # Find netlink libraries
 pkg_check_modules(nl3 REQUIRED IMPORTED_TARGET libnl-3.0)
 pkg_check_modules(nl3-route REQUIRED IMPORTED_TARGET libnl-route-3.0)
-
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 add_compile_options(-Werror)
 
@@ -27,23 +39,21 @@ add_subdirectory(switchsai)
 add_subdirectory(switchutils)
 
 add_library(krnlmon SHARED
-    $<TARGET_OBJECTS:switchapi_o>
-    $<TARGET_OBJECTS:switchapi_target_o>
-    $<TARGET_OBJECTS:switchlink_o>
-    $<TARGET_OBJECTS:switchlink_sai_o>
-    $<TARGET_OBJECTS:switchsai_o>
-    $<TARGET_OBJECTS:switchutils_o>
-    krnlmon_main.cc
-    krnlmon_main.h
+  $<TARGET_OBJECTS:switchapi_o>
+  $<TARGET_OBJECTS:switchapi_target_o>
+  $<TARGET_OBJECTS:switchlink_o>
+  $<TARGET_OBJECTS:switchlink_sai_o>
+  $<TARGET_OBJECTS:switchsai_o>
+  $<TARGET_OBJECTS:switchutils_o>
+  krnlmon_main.cc
+  krnlmon_main.h
 )
 
 # Required for Ninja.
 set_target_properties(switchutils_o PROPERTIES LINKER_LANGUAGE "C")
 
 target_link_libraries(krnlmon PkgConfig::nl3 PkgConfig::nl3-route)
-
-# Version number for .pc file.
-set(VERSION 1.0)
+target_link_libraries(krnlmon absl::synchronization)
 
 # TODO: Look into using configure_package_config_file()
 configure_file(libkrnlmon.pc.in
@@ -52,8 +62,8 @@ configure_file(libkrnlmon.pc.in
 install(TARGETS krnlmon LIBRARY)
 
 install(
-    FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/libkrnlmon.pc
-    DESTINATION
-        ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+  FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/libkrnlmon.pc
+  DESTINATION
+    ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )

--- a/cmake/standalone.cmake
+++ b/cmake/standalone.cmake
@@ -1,0 +1,78 @@
+# standalone.cmake
+#
+# Copyright 2022-2023 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+#
+# Initialization for standalone krnlmon build.
+#
+
+include(CTest)
+include(GNUInstallDirs)
+
+message(STATUS "Standalone krnlmon build")
+
+#-----------------------------------------------------------------------
+# Build type
+#-----------------------------------------------------------------------
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
+      "Choose the build type" FORCE)
+
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug;MinSizeRel;Release;RelWithDebInfo")
+endif()
+
+#-----------------------------------------------------------------------
+# Path definitions
+#-----------------------------------------------------------------------
+set(DEPEND_INSTALL_DIR "$ENV{DEPEND_INSTALL}" CACHE PATH
+    "Dependencies install directory")
+
+set(SDE_INSTALL_DIR "$ENV{SDE_INSTALL}" CACHE PATH
+    "SDE install directory")
+
+if(SDE_INSTALL_DIR STREQUAL "")
+  message(FATAL_ERROR "SDE_INSTALL_DIR (SDE_INSTALL) not defined!")
+elseif(DEPEND_INSTALL_DIR STREQUAL "")
+  message(FATAL_ERROR "DEPEND_INSTALL_DIR (DEPEND_INSTALL) not defined!")
+endif()
+
+#-----------------------------------------------------------------------
+# Target selection
+#-----------------------------------------------------------------------
+include(SelectTdiTarget)
+add_compile_options(-D${TARGETFLAG})
+
+#-----------------------------------------------------------------------
+# P4 Driver
+#-----------------------------------------------------------------------
+if(DPDK_TARGET)
+  find_package(DpdkDriver)
+elseif(ES2K_TARGET)
+  find_package(Es2kDriver)
+elseif(TOFINO_TARGET)
+  message(FATAL_ERROR "Tofino target not supported")
+endif()
+
+#-----------------------------------------------------------------------
+# Search paths
+#-----------------------------------------------------------------------
+if(CMAKE_CROSSCOMPILING)
+  list(APPEND CMAKE_FIND_ROOT_PATH ${DEPEND_INSTALL_DIR})
+else()
+  list(APPEND CMAKE_PREFIX_PATH ${DEPEND_INSTALL_DIR})
+endif()
+
+#-----------------------------------------------------------------------
+# Abseil
+#-----------------------------------------------------------------------
+find_package(absl CONFIG REQUIRED PATHS)
+mark_as_advanced(absl_DIR)
+
+message(STATUS "Found Abseil version ${absl_VERSION}")
+
+if(absl_VERSION VERSION_GREATER_EQUAL "20230125")
+  add_compile_definitions(ABSL_LEGACY_THREAD_ANNOTATIONS)
+endif()
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/cmake/standalone.cmake
+++ b/cmake/standalone.cmake
@@ -3,8 +3,14 @@
 # Copyright 2022-2023 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
-# Initialization for standalone krnlmon build.
+# Initializes for a standalone krnlmon build.
 #
+# Ensures that CMAKE_BUILD_TYPE, DEPEND_INSTALL_DIR, SDE_INSTALL_DIR,
+# and the TDI target variables are defined.
+#
+# Imports the P4 SDE and Abseil libraries.
+#
+# Sets recommended compiler options.
 
 include(CTest)
 include(GNUInstallDirs)
@@ -55,7 +61,7 @@ elseif(TOFINO_TARGET)
 endif()
 
 #-----------------------------------------------------------------------
-# Search paths
+# Stratum dependencies (Abseil)
 #-----------------------------------------------------------------------
 if(CMAKE_CROSSCOMPILING)
   list(APPEND CMAKE_FIND_ROOT_PATH ${DEPEND_INSTALL_DIR})
@@ -75,4 +81,10 @@ if(absl_VERSION VERSION_GREATER_EQUAL "20230125")
   add_compile_definitions(ABSL_LEGACY_THREAD_ANNOTATIONS)
 endif()
 
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+#-----------------------------------------------------------------------
+# Compiler settings
+#-----------------------------------------------------------------------
+include(CompilerSettings)
+set_basic_compiler_options()
+set_legacy_security_options()
+#set_extended_security_options()

--- a/libkrnlmon.pc.in
+++ b/libkrnlmon.pc.in
@@ -5,5 +5,5 @@ includedir=${prefix}/include
 
 Name: libkrnlmon
 Description: RFC 3594 kernel monitor
-Version: @VERSION@
+Version: @PROJECT_VERSION@
 Libs: -L${libdir} -lkrnlmon

--- a/switchapi/CMakeLists.txt
+++ b/switchapi/CMakeLists.txt
@@ -7,6 +7,8 @@ if(ES2K_TARGET)
   add_subdirectory(es2k)
 elseif(DPDK_TARGET)
   add_subdirectory(dpdk)
+else()
+  message(FATAL_ERROR "TDI target not defined!")
 endif()
 
 add_library(switchapi_o OBJECT

--- a/switchlink/CMakeLists.txt
+++ b/switchlink/CMakeLists.txt
@@ -43,7 +43,7 @@ target_include_directories(switchlink_o PRIVATE
     ${SDE_INSTALL_DIR}/include/target-utils/third-party/tommyds
     ${SDE_INSTALL_DIR}/include/target-utils/third-party/xxHash
     ${SDE_INSTALL_DIR}/include/target-sys
-    ${SAI_SOURCE_DIR}/inc
+    ${SAI_INCLUDE_DIR}
 )
 
 if(BUILD_TESTING)

--- a/switchlink/sai/CMakeLists.txt
+++ b/switchlink/sai/CMakeLists.txt
@@ -19,7 +19,7 @@ target_include_directories(switchlink_sai_o PRIVATE
     ${SDE_INSTALL_DIR}/include/target-utils/third-party/tommyds
     ${SDE_INSTALL_DIR}/include/target-utils/third-party/xxHash
     ${SDE_INSTALL_DIR}/include/target-sys
-    ${SAI_SOURCE_DIR}/inc
+    ${SAI_INCLUDE_DIR}
 )
 
 

--- a/switchsai/CMakeLists.txt
+++ b/switchsai/CMakeLists.txt
@@ -18,7 +18,7 @@ add_library(switchsai_o OBJECT
 )
 
 target_include_directories(switchsai_o PRIVATE
-    ${SAI_SOURCE_DIR}/inc
+    ${SAI_INCLUDE_DIR}
     ${SDE_INSTALL_DIR}/include
     ${SDE_INSTALL_DIR}/include/bf_types
     ${SDE_INSTALL_DIR}/include/target-utils # id


### PR DESCRIPTION
This CL makes it possible to build the Kernel Monitor from its own cmake listfile, independently (more or less) of P4 Control Plane.

For example:

```bash
export SDE_INSTALL=<es2k-sde-dir>
cd krnlmon/krnlmon

cmake -B build \
    -DSAI_SOURCE_DIR=../SAI \
    -DCMAKE_MODULE_PATH=../../cmake \
    -DCMAKE_INSTALL_PREFIX=install \
    -DTDI_TARGET=es2k

cmake --build build -j4
```

The chief awkwardness is making the `SelectTdiTarget`, `FindDpdkDriver`, and `FindTofinoDriver` modules available to the standalone build. The long-term solution is probably to create a separate repository that contains the common modules and reference it through a cmake variable in any project that requires them.

Reasons for supporting standalone build:
- Makes the Kernel Monitor a component in its own right, and hence easier to reuse the code in other projects.
- Allows us to do test builds and run unit tests on the component itself (e.g., when a PR is created to update krnlmon).
- Improves our ability to do incremental builds of larger systems (something we very much want to do for MEV).
- Allows us to run analyzers such as include-what-you-use on Kernel Monitor (https://github.com/ipdk-io/krnlmon/pull/61).

The effort has led to additional error checks and some improvements in the krnlmon build.