### PR TITLE
Switchlink unit test maintenance

### DIFF
--- a/switchlink/switchlink_address_test.cc
+++ b/switchlink/switchlink_address_test.cc
@@ -2,9 +2,9 @@
 #include <linux/if_arp.h>
 #include <memory.h>
 #include <netlink/msg.h>
+
 #include <vector>
 
-#include "netlink/msg.h"
 #include "gtest/gtest.h"
 
 extern "C" {
@@ -51,8 +51,8 @@ vector<test_results> results(2);
  * in the test results structure and validated against each test case.
  */
 void switchlink_create_route(switchlink_handle_t vrf_h,
-                             const switchlink_ip_addr_t *addr,
-                             const switchlink_ip_addr_t *gateway,
+                             const switchlink_ip_addr_t* addr,
+                             const switchlink_ip_addr_t* gateway,
                              switchlink_handle_t ecmp_h,
                              switchlink_handle_t intf_h) {
   struct test_results temp = {};
@@ -80,7 +80,7 @@ void switchlink_create_route(switchlink_handle_t vrf_h,
  * in the test results structure and validated against each test case.
  */
 void switchlink_delete_route(switchlink_handle_t vrf_h,
-                             const switchlink_ip_addr_t *addr) {
+                             const switchlink_ip_addr_t* addr) {
   struct test_results temp = {};
   if (addr) {
     temp.addr = *addr;
@@ -100,9 +100,8 @@ void switchlink_delete_route(switchlink_handle_t vrf_h,
  * find the interface in the database. That scenario is mocked by passing
  * an ifindex of 2.
  */
-switchlink_db_status_t
-switchlink_db_get_interface_info(uint32_t ifindex,
-                                 switchlink_db_interface_info_t *intf_info) {
+switchlink_db_status_t switchlink_db_get_interface_info(
+    uint32_t ifindex, switchlink_db_interface_info_t* intf_info) {
   if (ifindex == 1) {
     intf_info->intf_h = TEST_INTF_H;
   } else if (ifindex == 2) {
@@ -116,8 +115,8 @@ switchlink_db_get_interface_info(uint32_t ifindex,
  * Test fixture.
  */
 class SwitchlinkAddressTest : public ::testing::Test {
-protected:
-  struct nl_msg *nlmsg_ = nullptr;
+ protected:
+  struct nl_msg* nlmsg_ = nullptr;
 
   // Sets up the test fixture.
   void SetUp() override { ResetVariables(); }
@@ -166,7 +165,7 @@ TEST_F(SwitchlinkAddressTest, addIpv4Address) {
   nla_put_u32(nlmsg_, IFA_ADDRESS, htonl(ipv4_addr));
 
   // Act
-  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  const struct nlmsghdr* nlmsg = nlmsg_hdr(nlmsg_);
   switchlink_process_address_msg(nlmsg, nlmsg->nlmsg_type);
 
   // Assert
@@ -213,7 +212,7 @@ TEST_F(SwitchlinkAddressTest, deleteIpv4Address) {
   nla_put_u32(nlmsg_, IFA_ADDRESS, htonl(ipv4_addr));
 
   // Act
-  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  const struct nlmsghdr* nlmsg = nlmsg_hdr(nlmsg_);
   switchlink_process_address_msg(nlmsg, nlmsg->nlmsg_type);
 
   // Assert
@@ -263,7 +262,7 @@ TEST_F(SwitchlinkAddressTest, addIpv6Address) {
   nla_put(nlmsg_, IFA_ADDRESS, sizeof(addr6), &addr6);
 
   // Act
-  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  const struct nlmsghdr* nlmsg = nlmsg_hdr(nlmsg_);
   switchlink_process_address_msg(nlmsg, nlmsg->nlmsg_type);
 
   // Assert
@@ -316,7 +315,7 @@ TEST_F(SwitchlinkAddressTest, deleteIpv6Address) {
   nla_put(nlmsg_, IFA_ADDRESS, sizeof(addr6), &addr6);
 
   // Act
-  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  const struct nlmsghdr* nlmsg = nlmsg_hdr(nlmsg_);
   switchlink_process_address_msg(nlmsg, nlmsg->nlmsg_type);
 
   // Assert
@@ -356,7 +355,7 @@ TEST_F(SwitchlinkAddressTest, wrongAddressFamilyTest) {
   nla_put_u32(nlmsg_, IFA_ADDRESS, htonl(ipv4_addr));
 
   // Act
-  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  const struct nlmsghdr* nlmsg = nlmsg_hdr(nlmsg_);
   switchlink_process_address_msg(nlmsg, nlmsg->nlmsg_type);
 
   // Assert
@@ -387,7 +386,7 @@ TEST_F(SwitchlinkAddressTest, interfaceNotFoundTest) {
   nla_put_u32(nlmsg_, IFA_ADDRESS, htonl(ipv4_addr));
 
   // Act
-  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  const struct nlmsghdr* nlmsg = nlmsg_hdr(nlmsg_);
   switchlink_process_address_msg(nlmsg, nlmsg->nlmsg_type);
 
   // Assert

--- a/switchlink/switchlink_link_test.cc
+++ b/switchlink/switchlink_link_test.cc
@@ -8,7 +8,6 @@
 #include <vector>
 
 #include "gtest/gtest.h"
-#include "netlink/msg.h"
 
 extern "C" {
 #include "switchlink/switchlink_handle.h"
@@ -42,10 +41,10 @@ extern "C" {
 ******************************************************************************/
 
 enum handler_type {
-  CREATE_INTERFACE = 1,           // switchlink_create_interface
-  DELETE_INTERFACE = 2,           // switchlink_delete_interface
-  CREATE_TUNNEL_INTERFACE = 3,    // switchlink_create_tunnel_interface
-  DELETE_TUNNEL_INTERFACE = 4,    // switchlink_delete_tunnel_interface
+  CREATE_INTERFACE = 1,         // switchlink_create_interface
+  DELETE_INTERFACE = 2,         // switchlink_delete_interface
+  CREATE_TUNNEL_INTERFACE = 3,  // switchlink_create_tunnel_interface
+  DELETE_TUNNEL_INTERFACE = 4,  // switchlink_delete_tunnel_interface
 };
 
 /**
@@ -109,9 +108,7 @@ void switchlink_delete_tunnel_interface(uint32_t ifindex) {
 // This function is not called by the UUT, but it is referenced by a
 // function in the same source file. We provide a definition to avoid
 // a link error.
-int switchlink_create_vrf(switchlink_handle_t* vrf_h) {
-  return 0;
-}
+int switchlink_create_vrf(switchlink_handle_t* vrf_h) { return 0; }
 
 //----------------------------------------------------------------------
 // Test fixture

--- a/switchlink/switchlink_neigh_test.cc
+++ b/switchlink/switchlink_neigh_test.cc
@@ -1,8 +1,9 @@
 #include <arpa/inet.h>
 #include <memory.h>
+#include <netlink/msg.h>
+
 #include <vector>
 
-#include "netlink/msg.h"
 #include "gtest/gtest.h"
 
 extern "C" {
@@ -55,7 +56,6 @@ vector<test_results> results(2);
 void switchlink_create_mac(switchlink_mac_addr_t mac_addr,
                            switchlink_handle_t bridge_h,
                            switchlink_handle_t intf_h) {
-
   struct test_results temp = {0};
   memcpy(temp.mac_addr, mac_addr, sizeof(switchlink_mac_addr_t));
   temp.bridge_h = bridge_h;
@@ -76,7 +76,7 @@ void switchlink_create_mac(switchlink_mac_addr_t mac_addr,
  * validated by the test case.
  */
 void switchlink_create_neigh(switchlink_handle_t vrf_h,
-                             const switchlink_ip_addr_t *ipaddr,
+                             const switchlink_ip_addr_t* ipaddr,
                              switchlink_mac_addr_t mac_addr,
                              switchlink_handle_t intf_h) {
   struct test_results temp = {0};
@@ -101,7 +101,7 @@ void switchlink_create_neigh(switchlink_handle_t vrf_h,
  * validated by the test case.
  */
 void switchlink_delete_neigh(switchlink_handle_t vrf_h,
-                             const switchlink_ip_addr_t *addr,
+                             const switchlink_ip_addr_t* addr,
                              switchlink_handle_t intf_h) {
   struct test_results temp = {0};
   if (addr) {
@@ -124,9 +124,8 @@ void switchlink_delete_neigh(switchlink_handle_t vrf_h,
  * if it is not able to find the interface in the database.
  * That scenario is handled as the default case.
  */
-switchlink_db_status_t
-switchlink_db_get_interface_info(uint32_t ifindex,
-                                 switchlink_db_interface_info_t *intf_info) {
+switchlink_db_status_t switchlink_db_get_interface_info(
+    uint32_t ifindex, switchlink_db_interface_info_t* intf_info) {
   switch (ifindex) {
     case 1:
       intf_info->intf_h = TEST_INTF_H;
@@ -147,8 +146,8 @@ switchlink_db_get_interface_info(uint32_t ifindex,
  * Test fixture.
  */
 class SwitchlinkNeighborTest : public ::testing::Test {
-protected:
-  struct nl_msg *nlmsg_ = nullptr;
+ protected:
+  struct nl_msg* nlmsg_ = nullptr;
 
   // Sets up the test fixture.
   void SetUp() override { ResetVariables(); }
@@ -201,7 +200,7 @@ TEST_F(SwitchlinkNeighborTest, createIPv4Neighbor) {
   nla_put(nlmsg_, NDA_LLADDR, sizeof(mac_addr), &mac_addr);
 
   // Act
-  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  const struct nlmsghdr* nlmsg = nlmsg_hdr(nlmsg_);
   switchlink_process_neigh_msg(nlmsg, nlmsg->nlmsg_type);
 
   // Assert
@@ -248,7 +247,7 @@ TEST_F(SwitchlinkNeighborTest, verifyInvalidNeighborState) {
   nla_put(nlmsg_, NDA_LLADDR, sizeof(mac_addr), &mac_addr);
 
   // Act
-  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  const struct nlmsghdr* nlmsg = nlmsg_hdr(nlmsg_);
   switchlink_process_neigh_msg(nlmsg, nlmsg->nlmsg_type);
 
   // Assert
@@ -281,7 +280,7 @@ TEST_F(SwitchlinkNeighborTest, verifyInvalidInterfaceInfo) {
   nla_put(nlmsg_, NDA_LLADDR, sizeof(mac_addr), &mac_addr);
 
   // Act
-  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  const struct nlmsghdr* nlmsg = nlmsg_hdr(nlmsg_);
   switchlink_process_neigh_msg(nlmsg, nlmsg->nlmsg_type);
 
   // Assert
@@ -318,7 +317,7 @@ TEST_F(SwitchlinkNeighborTest, createIPv4NeighborWithInvalidMac) {
   nla_put_u32(nlmsg_, NDA_DST, htonl(ipv4_addr));
 
   // Act
-  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  const struct nlmsghdr* nlmsg = nlmsg_hdr(nlmsg_);
   switchlink_process_neigh_msg(nlmsg, nlmsg->nlmsg_type);
 
   // Assert
@@ -373,7 +372,7 @@ TEST_F(SwitchlinkNeighborTest, createIPv6Neighbor) {
   nla_put(nlmsg_, NDA_LLADDR, sizeof(mac_addr), &mac_addr);
 
   // Act
-  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  const struct nlmsghdr* nlmsg = nlmsg_hdr(nlmsg_);
   switchlink_process_neigh_msg(nlmsg, nlmsg->nlmsg_type);
 
   // Assert
@@ -427,7 +426,7 @@ TEST_F(SwitchlinkNeighborTest, deleteIPv4Neighbor) {
   nla_put(nlmsg_, NDA_LLADDR, sizeof(mac_addr), &mac_addr);
 
   // Act
-  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  const struct nlmsghdr* nlmsg = nlmsg_hdr(nlmsg_);
   switchlink_process_neigh_msg(nlmsg, nlmsg->nlmsg_type);
 
   // Assert
@@ -479,7 +478,7 @@ TEST_F(SwitchlinkNeighborTest, deleteIPv6Neighbor) {
   nla_put(nlmsg_, NDA_LLADDR, sizeof(mac_addr), &mac_addr);
 
   // Act
-  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  const struct nlmsghdr* nlmsg = nlmsg_hdr(nlmsg_);
   switchlink_process_neigh_msg(nlmsg, nlmsg->nlmsg_type);
 
   // Assert

--- a/switchlink/switchlink_route_test.cc
+++ b/switchlink/switchlink_route_test.cc
@@ -1,8 +1,9 @@
 #include <arpa/inet.h>
 #include <memory.h>
+#include <netlink/msg.h>
+
 #include <vector>
 
-#include "netlink/msg.h"
 #include "gtest/gtest.h"
 
 extern "C" {
@@ -75,8 +76,8 @@ vector<test_results> results(2);
  * validated by the test case.
  */
 void switchlink_create_route(switchlink_handle_t vrf_h,
-                             const switchlink_ip_addr_t *dst,
-                             const switchlink_ip_addr_t *gateway,
+                             const switchlink_ip_addr_t* dst,
+                             const switchlink_ip_addr_t* gateway,
                              switchlink_handle_t ecmp_h,
                              switchlink_handle_t intf_h) {
   struct test_results temp = {0};
@@ -104,7 +105,7 @@ void switchlink_create_route(switchlink_handle_t vrf_h,
  * validated by the test case.
  */
 void switchlink_delete_route(switchlink_handle_t vrf_h,
-                             const switchlink_ip_addr_t *dst) {
+                             const switchlink_ip_addr_t* dst) {
   struct test_results temp = {0};
   if (dst) {
     temp.dst = *dst;
@@ -125,18 +126,17 @@ void switchlink_delete_route(switchlink_handle_t vrf_h,
  * if it is not able to find the interface in the database.
  * That scenario is mocked by passing an ifindex of 2.
  */
-switchlink_db_status_t
-switchlink_db_get_interface_info(uint32_t ifindex,
-                                 switchlink_db_interface_info_t *intf_info) {
+switchlink_db_status_t switchlink_db_get_interface_info(
+    uint32_t ifindex, switchlink_db_interface_info_t* intf_info) {
   switch (ifindex) {
-  case 1:
-    intf_info->intf_h = TEST_INTF_H1;
-    break;
-  case 2:
-    intf_info->intf_h = TEST_INTF_H2;
-    break;
-  default:
-    return SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND;
+    case 1:
+      intf_info->intf_h = TEST_INTF_H1;
+      break;
+    case 2:
+      intf_info->intf_h = TEST_INTF_H2;
+      break;
+    default:
+      return SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND;
   }
   return SWITCHLINK_DB_STATUS_SUCCESS;
 }
@@ -145,22 +145,20 @@ switchlink_db_get_interface_info(uint32_t ifindex,
  * Dummy function for switchlink_create_nexthop(). Returns 0 on success
  * and -1 in case of error.
  */
-int switchlink_create_nexthop(switchlink_db_nexthop_info_t *nexthop_info) {
+int switchlink_create_nexthop(switchlink_db_nexthop_info_t* nexthop_info) {
   return (nexthop_info->intf_h == TEST_INTF_H2) ? 0 : -1;
 }
 
 /*
  * Dummy function for switchlink_create_ecmp().
  */
-int switchlink_create_ecmp(switchlink_db_ecmp_info_t *ecmp_info) {
-  return 0; 
-}
+int switchlink_create_ecmp(switchlink_db_ecmp_info_t* ecmp_info) { return 0; }
 
 /*
  * Dummy function for switchlink_db_add_ecmp().
  */
-switchlink_db_status_t
-switchlink_db_add_ecmp(switchlink_db_ecmp_info_t *ecmp_info) {
+switchlink_db_status_t switchlink_db_add_ecmp(
+    switchlink_db_ecmp_info_t* ecmp_info) {
   return SWITCHLINK_DB_STATUS_SUCCESS;
 }
 
@@ -168,7 +166,7 @@ switchlink_db_add_ecmp(switchlink_db_ecmp_info_t *ecmp_info) {
  * Dummy function for switchlink_db_update_nexthop_using_by().
  */
 switchlink_db_status_t switchlink_db_update_nexthop_using_by(
-    switchlink_db_nexthop_info_t *nexthop_info) {
+    switchlink_db_nexthop_info_t* nexthop_info) {
   struct test_results temp = {0};
   if (nexthop_info) {
     temp.nexthop_info = *nexthop_info;
@@ -180,8 +178,8 @@ switchlink_db_status_t switchlink_db_update_nexthop_using_by(
 /*
  * Dummy function for switchlink_db_add_nexthop().
  */
-switchlink_db_status_t
-switchlink_db_add_nexthop(switchlink_db_nexthop_info_t *nexthop_info) {
+switchlink_db_status_t switchlink_db_add_nexthop(
+    switchlink_db_nexthop_info_t* nexthop_info) {
   struct test_results temp = {0};
   if (nexthop_info) {
     temp.nexthop_info = *nexthop_info;
@@ -193,8 +191,8 @@ switchlink_db_add_nexthop(switchlink_db_nexthop_info_t *nexthop_info) {
 /*
  * Dummy function for switchlink_db_get_ecmp_info().
  */
-switchlink_db_status_t
-switchlink_db_get_ecmp_info(switchlink_db_ecmp_info_t *ecmp_info) {
+switchlink_db_status_t switchlink_db_get_ecmp_info(
+    switchlink_db_ecmp_info_t* ecmp_info) {
   ecmp_info->ecmp_h = TEST_ECMP_H;
   if (ecmp_info) {
     results[0].ecmp_info = *ecmp_info;
@@ -207,9 +205,8 @@ switchlink_db_get_ecmp_info(switchlink_db_ecmp_info_t *ecmp_info) {
  * Returns success for intf handle: TEST_INTF_H1
  * Returns failure for intf handle: TEST_INTF_H2
  */
-switchlink_db_status_t
-switchlink_db_get_nexthop_info(switchlink_db_nexthop_info_t *nexthop_info) {
-
+switchlink_db_status_t switchlink_db_get_nexthop_info(
+    switchlink_db_nexthop_info_t* nexthop_info) {
   if (nexthop_info->intf_h == TEST_INTF_H1) {
     nexthop_info->nhop_h = 1;
     return SWITCHLINK_DB_STATUS_SUCCESS;
@@ -225,8 +222,8 @@ switchlink_db_get_nexthop_info(switchlink_db_nexthop_info_t *nexthop_info) {
  * Test fixture.
  */
 class SwitchlinkRouteTest : public ::testing::Test {
-protected:
-  struct nl_msg *nlmsg_ = nullptr;
+ protected:
+  struct nl_msg* nlmsg_ = nullptr;
 
   // Sets up the test fixture.
   void SetUp() override { ResetVariables(); }
@@ -284,7 +281,7 @@ TEST_F(SwitchlinkRouteTest, createIPv4Route) {
   nla_put_u32(nlmsg_, RTA_IIF, iifindex);
 
   // Act
-  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  const struct nlmsghdr* nlmsg = nlmsg_hdr(nlmsg_);
   switchlink_process_route_msg(nlmsg, nlmsg->nlmsg_type);
 
   // Assert
@@ -338,7 +335,7 @@ TEST_F(SwitchlinkRouteTest, invalidInterface) {
   nla_put_u32(nlmsg_, RTA_IIF, iifindex);
 
   // Act
-  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  const struct nlmsghdr* nlmsg = nlmsg_hdr(nlmsg_);
   switchlink_process_route_msg(nlmsg, nlmsg->nlmsg_type);
 
   // Assert
@@ -385,7 +382,7 @@ TEST_F(SwitchlinkRouteTest, zeroDestPrefixLen) {
   nla_put_u32(nlmsg_, RTA_IIF, iifindex);
 
   // Act
-  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  const struct nlmsghdr* nlmsg = nlmsg_hdr(nlmsg_);
   switchlink_process_route_msg(nlmsg, nlmsg->nlmsg_type);
 
   // Assert
@@ -437,7 +434,7 @@ TEST_F(SwitchlinkRouteTest, verifyUnspecifiedAddressFamily) {
   nla_put_u32(nlmsg_, RTA_OIF, oifindex);
 
   // Act
-  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  const struct nlmsghdr* nlmsg = nlmsg_hdr(nlmsg_);
   switchlink_process_route_msg(nlmsg, nlmsg->nlmsg_type);
 
   // Assert
@@ -496,7 +493,7 @@ TEST_F(SwitchlinkRouteTest, createIPv6Route) {
   nla_put_u32(nlmsg_, RTA_OIF, oifindex);
 
   // Act
-  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  const struct nlmsghdr* nlmsg = nlmsg_hdr(nlmsg_);
   switchlink_process_route_msg(nlmsg, nlmsg->nlmsg_type);
 
   // Assert
@@ -554,7 +551,7 @@ TEST_F(SwitchlinkRouteTest, deleteIPv4Route) {
   nla_put_u32(nlmsg_, RTA_OIF, oifindex);
 
   // Act
-  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  const struct nlmsghdr* nlmsg = nlmsg_hdr(nlmsg_);
   switchlink_process_route_msg(nlmsg, nlmsg->nlmsg_type);
 
   // Assert
@@ -619,7 +616,7 @@ TEST_F(SwitchlinkRouteTest, deleteIPv6Route) {
   nla_put_u32(nlmsg_, RTA_OIF, oifindex);
 
   // Act
-  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  const struct nlmsghdr* nlmsg = nlmsg_hdr(nlmsg_);
   switchlink_process_route_msg(nlmsg, nlmsg->nlmsg_type);
 
   // Assert
@@ -677,7 +674,7 @@ TEST_F(SwitchlinkRouteTest, processEcmpUpdatev4Nexthop) {
   nla_put_u32(nlmsg_, RTA_GATEWAY, htonl(gateway_addr1));
 
   // Act
-  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  const struct nlmsghdr* nlmsg = nlmsg_hdr(nlmsg_);
   switchlink_process_route_msg(nlmsg, nlmsg->nlmsg_type);
 
   // Assert
@@ -735,7 +732,7 @@ TEST_F(SwitchlinkRouteTest, processEcmpCreatev4Nexthop) {
   nla_put_u32(nlmsg_, RTA_GATEWAY, htonl(gateway_addr1));
 
   // Act
-  const struct nlmsghdr *nlmsg = nlmsg_hdr(nlmsg_);
+  const struct nlmsghdr* nlmsg = nlmsg_hdr(nlmsg_);
   switchlink_process_route_msg(nlmsg, nlmsg->nlmsg_type);
 
   // Assert


### PR DESCRIPTION
- Normalize #includes for <netlink/msg.h>.
- Normalize files with clang-format.