### PR TITLE
Program nexthop table as a ternary match.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,6 @@ The Kernel Monitor receives RFC 3549 messages from the Linux Kernel over a Netli
 
 ## Breaking changes
 
-Since there is a change in p4 program, where nexthop table has been moved to
-WCM block from SEM block (exact match). TDI provides seperate API's for each
-block. Since Ternary/WCM needs a MASK to be populated we need to use a newer
-API which can take mask as a parameter. Changes with a MACRO has been
-introduced in `switchapi/es2k/switch_pd_routing.c`, which defines ternary match
-MACRO enablement. If user wants to pick older p4 program, then user need to
-modify this MACRO value to 0 and re-build infrap4d to be compatible with
-older Exact match type for nexthop table.
+### 11 Oct 2023
 
-PR: https://github.com/ipdk-io/krnlmon/pull/59 introduces this breakage changes.
+- https://github.com/ipdk-io/krnlmon/pull/59: The NextHop table in the P4 program has been moved from the SEM block (exact match) to the WCM block (ternary block). The Kernel Monitor must use a different API to write the entry to the WCM block. krnlmon is no longer compatible with older versions of the P4 program.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # ipdk-io/krnlmon
 The Kernel Monitor receives RFC 3549 messages from the Linux Kernel over a Netlink socket when changes are made to the kernel networking data structures.
+
+## Breaking changes
+
+Since there is a change in p4 program, where nexthop table has been moved to
+WCM block from SEM block (exact match). TDI provides seperate API's for each
+block. Since Ternary/WCM needs a MASK to be populated we need to use a newer
+API which can take mask as a parameter. Changes with a MACRO has been
+introduced in `switchapi/es2k/switch_pd_routing.c`, which defines ternary match
+MACRO enablement. If user wants to pick older p4 program, then user need to
+modify this MACRO value to 0 and re-build infrap4d to be compatible with
+older Exact match type for nexthop table.
+
+PR: https://github.com/ipdk-io/krnlmon/pull/59 introduces this breakage changes.

--- a/switchapi/es2k/switch_pd_routing.c
+++ b/switchapi/es2k/switch_pd_routing.c
@@ -25,6 +25,9 @@
 
 #include "port_mgr/dpdk/bf_dpdk_port_if.h"
 
+// Table match type definitions.
+#define NEXTHOP_TABLE_TERNARY_MATCH 1
+
 switch_status_t switch_routing_table_entry (
         switch_device_t device,
         const switch_pd_routing_info_t *api_routing_info,
@@ -180,10 +183,20 @@ switch_status_t switch_pd_nexthop_table_entry(
         goto dealloc_resources;
     }
 
+#if NEXTHOP_TABLE_TERNARY_MATCH
+    // When Nexthop table is of type ternary Match
     status = tdi_key_field_set_value_and_mask(key_hdl, field_id,
                                      (api_nexthop_pd_info->nexthop_handle &
                                      ~(SWITCH_HANDLE_TYPE_NHOP <<
                                      SWITCH_HANDLE_TYPE_SHIFT)), 0xFFFF);
+#else
+    // When Nexthop table is of type exact Match
+    status = tdi_key_field_set_value(key_hdl, field_id,
+                                     (api_nexthop_pd_info->nexthop_handle &
+                                     ~(SWITCH_HANDLE_TYPE_NHOP <<
+                                     SWITCH_HANDLE_TYPE_SHIFT)));
+#endif
+
     if (status != TDI_SUCCESS) {
         krnlmon_log_error("Unable to set value for key ID: %d for nexthop_table,"
                           " error: %d", field_id, status);

--- a/switchapi/es2k/switch_pd_routing.c
+++ b/switchapi/es2k/switch_pd_routing.c
@@ -180,10 +180,10 @@ switch_status_t switch_pd_nexthop_table_entry(
         goto dealloc_resources;
     }
 
-    status = tdi_key_field_set_value(key_hdl, field_id,
+    status = tdi_key_field_set_value_and_mask(key_hdl, field_id,
                                      (api_nexthop_pd_info->nexthop_handle &
                                      ~(SWITCH_HANDLE_TYPE_NHOP <<
-                                     SWITCH_HANDLE_TYPE_SHIFT)));
+                                     SWITCH_HANDLE_TYPE_SHIFT)), 0xFFFF);
     if (status != TDI_SUCCESS) {
         krnlmon_log_error("Unable to set value for key ID: %d for nexthop_table,"
                           " error: %d", field_id, status);


### PR DESCRIPTION
Earlier, nexthop table was exact match, due to LAG addition, nexthop table is moved to WCM block, ternary match. Changes in krnlmon is made to program nexthop table as ternary match