### PR TITLE
Add support for include-what-you-use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ cmake_minimum_required(VERSION 3.15)
 project(krnlmon LANGUAGES C CXX)
 
 include(FindPkgConfig)
+include(cmake/iwyu.cmake)
 
 # Find netlink libraries
 pkg_check_modules(nl3 REQUIRED IMPORTED_TARGET libnl-3.0)

--- a/cmake/iwyu.cmake
+++ b/cmake/iwyu.cmake
@@ -1,0 +1,15 @@
+# cmake -B build <other options> -DIWYU=ON
+# cmake --build build >& iwyu.log
+
+option(IWYU "Run include-what-you-use" OFF)
+
+if(IWYU)
+  find_program(IWYU_PATH NAMES include-what-you-use iwyu)
+  if(NOT IWYU_PATH)
+    message(FATAL_ERROR "Could not find include-what-you-use")
+  endif()
+  mark_as_advanced(IWYU_PATH)
+  set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${IWYU_PATH})
+  set(CMAKE_C_INCLUDE_WHAT_YOU_USE ${IWYU_PATH})
+  message("IWYU enabled")
+endif()


### PR DESCRIPTION
[include-what-you-use](https://include-what-you-use.org) is a utility developed at Google that analyzes C and C++ source files, looking for violations of the Include What You Use rule, and recommends fixes for them.

"The main goal of include-what-you-use is to remove superfluous #includes. It does this both by figuring out what #includes are not actually needed for this file (for both .cc and .h files), and replacing #includes with forward-declares when possible."

This CL implements a cmake option that can be used to run include-what-you-use on krnlmon. It requires standalone build support (https://github.com/ipdk-io/krnlmon/pull/56), plus a trivial change to FindDpdkDriver (https://github.com/ipdk-io/networking-recipe/pull/315) in order to analyze krnlmon for DPDK.