### PR TITLE
Overhaul formatting of krnlmon source files

### DIFF
--- a/krnlmon_main.cc
+++ b/krnlmon_main.cc
@@ -20,11 +20,11 @@ static pthread_t stop_tid;
 
 extern "C" {
 // Ensure that the functions passed to pthread_create() have C interfaces.
-static void *krnlmon_main_wrapper(void *arg);
-static void *krnlmon_stop_wrapper(void *arg);
+static void* krnlmon_main_wrapper(void* arg);
+static void* krnlmon_stop_wrapper(void* arg);
 }
 
-static void *krnlmon_main_wrapper(void *arg) {
+static void* krnlmon_main_wrapper(void* arg) {
   // Wait for stratum server to signal that it is ready.
   auto ready_sync = static_cast<absl::Notification*>(arg);
   ready_sync->WaitForNotification();
@@ -35,7 +35,7 @@ static void *krnlmon_main_wrapper(void *arg) {
   return nullptr;
 }
 
-static void *krnlmon_stop_wrapper(void *arg) {
+static void* krnlmon_stop_wrapper(void* arg) {
   // Wait for stratum server to signal that it is done.
   auto done_sync = static_cast<absl::Notification*>(arg);
   done_sync->WaitForNotification();
@@ -46,7 +46,7 @@ static void *krnlmon_stop_wrapper(void *arg) {
   return nullptr;
 }
 
-static void print_strerror(const char *msg, int err) {
+static void print_strerror(const char* msg, int err) {
   char errbuf[64];
   printf("%s: %s\n", msg, strerror_r(err, errbuf, sizeof(errbuf)));
 }
@@ -54,8 +54,8 @@ static void print_strerror(const char *msg, int err) {
 int krnlmon_create_main_thread(absl::Notification* ready_sync) {
   int rc = pthread_create(&main_tid, NULL, &krnlmon_main_wrapper, ready_sync);
   if (rc) {
-     print_strerror("Error creating switchlink_main thread", rc);
-     return -1;
+    print_strerror("Error creating switchlink_main thread", rc);
+    return -1;
   }
 
   rc = pthread_setname_np(main_tid, "switchlink_main");
@@ -69,8 +69,8 @@ int krnlmon_create_main_thread(absl::Notification* ready_sync) {
 int krnlmon_create_shutdown_thread(absl::Notification* done_sync) {
   int rc = pthread_create(&stop_tid, NULL, &krnlmon_stop_wrapper, done_sync);
   if (rc) {
-     print_strerror("Error creating switchlink_stop thread", rc);
-     return -1;
+    print_strerror("Error creating switchlink_stop thread", rc);
+    return -1;
   }
 
   rc = pthread_setname_np(stop_tid, "switchlink_stop");

--- a/switchapi/dpdk/switch_config.c
+++ b/switchapi/dpdk/switch_config.c
@@ -25,12 +25,13 @@ extern "C" {
 #define __FILE_ID__ SWITCH_CONFIG
 switch_config_info_t config_info;
 
-switch_status_t switch_config_init(switch_config_t *switch_config) {
+switch_status_t switch_config_init(switch_config_t* switch_config) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (config_info.config_inited) {
     status = SWITCH_STATUS_ITEM_ALREADY_EXISTS;
-    krnlmon_log_error("config init failed, error: %s", switch_error_to_string(status));
+    krnlmon_log_error("config init failed, error: %s",
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -68,14 +69,13 @@ switch_status_t switch_config_free(void) {
 }
 
 switch_status_t switch_config_device_context_set(
-    switch_device_t device, switch_device_context_t *device_ctx) {
+    switch_device_t device, switch_device_context_t* device_ctx) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (device_ctx && config_info.device_inited[device]) {
     status = SWITCH_STATUS_ITEM_ALREADY_EXISTS;
-    krnlmon_log_error("config free failed for device %d, error: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("config free failed for device %d, error: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -91,14 +91,13 @@ switch_status_t switch_config_device_context_set(
 }
 
 switch_status_t switch_config_device_context_get(
-    switch_device_t device, switch_device_context_t **device_ctx) {
+    switch_device_t device, switch_device_context_t** device_ctx) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!config_info.device_inited[device]) {
     status = SWITCH_STATUS_UNINITIALIZED;
     krnlmon_log_error("Failed to get device context for device %d, error: %s\n",
-              device,
-              switch_error_to_string(status));
+                      device, switch_error_to_string(status));
     return status;
   }
 
@@ -108,14 +107,14 @@ switch_status_t switch_config_device_context_get(
 }
 
 switch_status_t switch_config_table_sizes_get(switch_device_t device,
-                                              switch_size_t *table_sizes) {
+                                              switch_size_t* table_sizes) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   status = switch_table_default_sizes_get(table_sizes);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("Failed to get config table sizes for device %d, error: %s\n",
-              device,
-              switch_error_to_string(status));
+    krnlmon_log_error(
+        "Failed to get config table sizes for device %d, error: %s\n", device,
+        switch_error_to_string(status));
     return status;
   }
 

--- a/switchapi/dpdk/switch_config.c
+++ b/switchapi/dpdk/switch_config.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/dpdk/switch_device.c
+++ b/switchapi/dpdk/switch_device.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/dpdk/switch_device.c
+++ b/switchapi/dpdk/switch_device.c
@@ -50,25 +50,22 @@ switch_status_t switch_api_init(switch_device_t device) {
 
   status = switch_config_init(&api_config);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("switch api init failed on device %d: %s\n",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("switch api init failed on device %d: %s\n", device,
+                      switch_error_to_string(status));
   }
 
   status = switch_api_device_add(device);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("switch api init failed on device %d: %s\n",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("switch api init failed on device %d: %s\n", device,
+                      switch_error_to_string(status));
     return status;
   }
 
 #ifdef THRIFT_ENABLED
   status = start_switch_api_rpc_server();
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("start_switch_api_rpc_server on device %d",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("start_switch_api_rpc_server on device %d", device,
+                      switch_error_to_string(status));
     return status;
   }
 #endif  // THRIFT_ENABLED
@@ -77,7 +74,7 @@ switch_status_t switch_api_init(switch_device_t device) {
 }
 
 switch_status_t switch_device_context_get(
-    switch_device_t device, switch_device_context_t **device_ctx) {
+    switch_device_t device, switch_device_context_t** device_ctx) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   status = switch_config_device_context_get(device, device_ctx);
@@ -85,8 +82,7 @@ switch_status_t switch_device_context_get(
     krnlmon_log_error(
         "device context get failed on device %d: "
         "device config context get failed(%s)",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -94,7 +90,7 @@ switch_status_t switch_device_context_get(
 }
 
 switch_status_t switch_device_api_init(switch_device_t device) {
-  switch_device_context_t *device_ctx = NULL;
+  switch_device_context_t* device_ctx = NULL;
   switch_api_type_t api_type = 0;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   switch_status_t tmp_status = SWITCH_STATUS_SUCCESS;
@@ -104,8 +100,7 @@ switch_status_t switch_device_api_init(switch_device_t device) {
     krnlmon_log_error(
         "device api init failed on device %d: "
         "device context get failed(%s)",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -186,9 +181,7 @@ switch_status_t switch_device_api_init(switch_device_t device) {
       krnlmon_log_error(
           "device init failed on device %d "
           "for api type %d %s: (%s)",
-          device,
-          api_type,
-          switch_api_type_to_string(api_type),
+          device, api_type, switch_api_type_to_string(api_type),
           switch_error_to_string(status));
       goto cleanup;
     }
@@ -207,15 +200,14 @@ cleanup:
 }
 
 switch_status_t switch_device_api_free(switch_device_t device) {
-  switch_device_context_t *device_ctx = NULL;
+  switch_device_context_t* device_ctx = NULL;
   switch_api_type_t api_type = 0;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("device init failed on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device init failed on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -299,8 +291,7 @@ switch_status_t switch_device_api_free(switch_device_t device) {
       krnlmon_log_error(
           "device free failed on device %d "
           "for api type %s: (%s)",
-          device,
-          switch_api_type_to_string(api_type),
+          device, switch_api_type_to_string(api_type),
           switch_error_to_string(status));
       continue;
     }
@@ -312,8 +303,8 @@ switch_status_t switch_device_api_free(switch_device_t device) {
 }
 
 switch_status_t switch_device_init(switch_device_t device,
-                                   switch_size_t *table_sizes) {
-  switch_device_context_t *device_ctx = NULL;
+                                   switch_size_t* table_sizes) {
+  switch_device_context_t* device_ctx = NULL;
   switch_api_type_t api_type = 0;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
@@ -322,8 +313,7 @@ switch_status_t switch_device_init(switch_device_t device,
     krnlmon_log_error(
         "device init failed on device %d: "
         "device context get failed(%s)",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -332,8 +322,7 @@ switch_status_t switch_device_init(switch_device_t device,
     krnlmon_log_error(
         "device init failed on device %d: "
         "table init failed(%s)",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -341,14 +330,13 @@ switch_status_t switch_device_init(switch_device_t device,
     device_ctx->api_inited[api_type] = false;
   }
 
-  status = switch_api_id_allocator_new(
-      device, SWITCH_IFINDEX_SIZE, FALSE, &device_ctx->ifindex_allocator);
+  status = switch_api_id_allocator_new(device, SWITCH_IFINDEX_SIZE, FALSE,
+                                       &device_ctx->ifindex_allocator);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "device init failed on device %d: "
         "ifindex allocator init failed(%s)",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -357,8 +345,7 @@ switch_status_t switch_device_init(switch_device_t device,
     krnlmon_log_error(
         "device init failed on device %d: "
         "device api init failed(%s)",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -368,19 +355,17 @@ switch_status_t switch_device_init(switch_device_t device,
     krnlmon_log_error(
         "device init failed on device %d: "
         "rmac group create failed(%s)",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
-  status = switch_api_create_nhop_group(
-      device, &device_ctx->device_info.group_handle);
+  status = switch_api_create_nhop_group(device,
+                                        &device_ctx->device_info.group_handle);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "device init failed on device %d: "
         "nhop group create failed(%s)",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -390,7 +375,7 @@ switch_status_t switch_device_init(switch_device_t device,
 }
 
 switch_status_t switch_device_free(switch_device_t device) {
-  switch_device_context_t *device_ctx = NULL;
+  switch_device_context_t* device_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   status = switch_device_context_get(device, &device_ctx);
@@ -398,8 +383,7 @@ switch_status_t switch_device_free(switch_device_t device) {
     krnlmon_log_error(
         "device free failed on device %d: "
         "device context get failed(%s)",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -408,8 +392,7 @@ switch_status_t switch_device_free(switch_device_t device) {
     krnlmon_log_error(
         "device free failed on device %d: "
         "table free failed(%s)",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -418,8 +401,7 @@ switch_status_t switch_device_free(switch_device_t device) {
     krnlmon_log_error(
         "device free failed on device %d: "
         "device api free failed(%s)",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -429,8 +411,7 @@ switch_status_t switch_device_free(switch_device_t device) {
     krnlmon_log_error(
         "device free failed on device %d: "
         "ifindex allocator free failed(%s)",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
   }
 
   krnlmon_log_debug("device free done on device %d", device);
@@ -439,17 +420,16 @@ switch_status_t switch_device_free(switch_device_t device) {
 }
 
 switch_status_t switch_device_table_get(switch_device_t device,
-                                        switch_table_t **table_info) {
-  switch_device_context_t *device_ctx = NULL;
+                                        switch_table_t** table_info) {
+  switch_device_context_t* device_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(table_info != NULL);
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("device context get failed on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device context get failed on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -459,15 +439,14 @@ switch_status_t switch_device_table_get(switch_device_t device,
 
 switch_status_t switch_device_api_context_set(switch_device_t device,
                                               switch_api_type_t api_type,
-                                              void *context) {
-  switch_device_context_t *device_ctx = NULL;
+                                              void* context) {
+  switch_device_context_t* device_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("device context get failed on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device context get failed on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -478,17 +457,16 @@ switch_status_t switch_device_api_context_set(switch_device_t device,
 
 switch_status_t switch_device_api_context_get(switch_device_t device,
                                               switch_api_type_t api_type,
-                                              void **context) {
-  switch_device_context_t *device_ctx = NULL;
+                                              void** context) {
+  switch_device_context_t* device_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(context != NULL);
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("device context get failed on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device context get failed on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -497,7 +475,7 @@ switch_status_t switch_device_api_context_get(switch_device_t device,
 }
 
 switch_status_t switch_api_device_add(switch_device_t device) {
-  switch_device_context_t *device_ctx = NULL;
+  switch_device_context_t* device_ctx = NULL;
   switch_size_t table_sizes[SWITCH_TABLE_MAX];
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   char cpuif_netdev_name[IFNAMSIZ] = "";
@@ -506,18 +484,16 @@ switch_status_t switch_api_device_add(switch_device_t device) {
 
   if (SWITCH_CONFIG_DEVICE_INITED(device)) {
     status = SWITCH_STATUS_ITEM_ALREADY_EXISTS;
-    krnlmon_log_error("device add failed for device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device add failed for device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
   device_ctx = SWITCH_MALLOC(device, sizeof(switch_device_context_t), 0x1);
   if (!device_ctx) {
     status = SWITCH_STATUS_NO_MEMORY;
-    krnlmon_log_error("device add failed on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device add failed on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -530,17 +506,15 @@ switch_status_t switch_api_device_add(switch_device_t device) {
 
   status = switch_config_table_sizes_get(device, table_sizes);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("device add failed for device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device add failed for device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("device add failed on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device add failed on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -550,40 +524,37 @@ switch_status_t switch_api_device_add(switch_device_t device) {
 
   status = switch_device_init(device, table_sizes);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("device add failed for device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device add failed for device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
   return status;
 }
 
-static switch_status_t switch_api_device_remove_internal(switch_device_t device) {
-  switch_device_context_t *device_ctx = NULL;
+static switch_status_t switch_api_device_remove_internal(
+    switch_device_t device) {
+  switch_device_context_t* device_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!SWITCH_CONFIG_DEVICE_INITED(device)) {
     status = SWITCH_STATUS_ITEM_ALREADY_EXISTS;
-    krnlmon_log_error("device add failed for device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device add failed for device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("device context get failed on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device context get failed on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
   status = switch_device_free(device);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("device context get failed on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device context get failed on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -596,15 +567,14 @@ static switch_status_t switch_api_device_remove_internal(switch_device_t device)
 }
 
 switch_status_t switch_api_device_default_rmac_handle_get(
-    switch_device_t device, switch_handle_t *rmac_handle) {
-  switch_device_context_t *device_ctx = NULL;
+    switch_device_t device, switch_handle_t* rmac_handle) {
+  switch_device_context_t* device_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("device context get failed on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device context get failed on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -614,15 +584,14 @@ switch_status_t switch_api_device_default_rmac_handle_get(
 }
 
 switch_status_t switch_api_get_default_nhop_group(
-    switch_device_t device, switch_handle_t *nhop_group_handle) {
-  switch_device_context_t *device_ctx = NULL;
+    switch_device_t device, switch_handle_t* nhop_group_handle) {
+  switch_device_context_t* device_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("device context get failed on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device context get failed on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -631,23 +600,21 @@ switch_status_t switch_api_get_default_nhop_group(
   return status;
 }
 
-switch_status_t switch_api_device_tunnel_dmac_get(
-    switch_device_t device, switch_mac_addr_t *mac_addr) {
+switch_status_t switch_api_device_tunnel_dmac_get(switch_device_t device,
+                                                  switch_mac_addr_t* mac_addr) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
-  switch_device_context_t *device_ctx = NULL;
+  switch_device_context_t* device_ctx = NULL;
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "device tunnel dmac get failed: "
         "device context get failed on device %d: %s",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
-  SWITCH_MEMCPY(mac_addr,
-                &device_ctx->device_info.tunnel_dmac,
+  SWITCH_MEMCPY(mac_addr, &device_ctx->device_info.tunnel_dmac,
                 sizeof(switch_mac_addr_t));
 
   return status;
@@ -655,7 +622,6 @@ switch_status_t switch_api_device_tunnel_dmac_get(
 #ifdef __cplusplus
 }
 #endif
-
 
 switch_status_t switch_api_device_remove(switch_device_t device) {
   return switch_api_device_remove_internal(device);

--- a/switchapi/dpdk/switch_fdb.c
+++ b/switchapi/dpdk/switch_fdb.c
@@ -15,20 +15,18 @@
  * limitations under the License.
  */
 
-#include "switch_pd_fdb.h"
-
-#include "switch_pd_utils.h"
-
-#include "switchapi/switch_base_types.h"
 #include "switchapi/switch_fdb.h"
+
+#include "switch_pd_fdb.h"
+#include "switch_pd_utils.h"
+#include "switchapi/switch_base_types.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_rif_int.h"
 #include "switchapi/switch_status.h"
 
-switch_status_t switch_l2_hash_key_init(void *args,
-                                          switch_uint8_t *key,
-                                          switch_uint32_t *len) {
-  switch_mac_addr_t *l2_key = NULL;
+switch_status_t switch_l2_hash_key_init(void* args, switch_uint8_t* key,
+                                        switch_uint32_t* len) {
+  switch_mac_addr_t* l2_key = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!args || !key || !len) {
@@ -36,7 +34,7 @@ switch_status_t switch_l2_hash_key_init(void *args,
     return status;
   }
 
-  l2_key = (switch_mac_addr_t *)args;
+  l2_key = (switch_mac_addr_t*)args;
   *len = 0;
 
   SWITCH_MEMCPY((key + *len), l2_key, sizeof(switch_mac_addr_t));
@@ -47,49 +45,44 @@ switch_status_t switch_l2_hash_key_init(void *args,
   return status;
 }
 
-switch_int32_t switch_l2_hash_compare(const void *key1, const void *key2) {
-
-
-  switch_l2_info_t *l2_info = (switch_l2_info_t *) key2;
+switch_int32_t switch_l2_hash_compare(const void* key1, const void* key2) {
+  switch_l2_info_t* l2_info = (switch_l2_info_t*)key2;
   switch_mac_addr_t l2_mac;
 
   SWITCH_MEMSET(&l2_mac, 0x0, sizeof(switch_mac_addr_t));
 
   if (l2_info) {
-      SWITCH_MEMCPY(&l2_mac, &l2_info->api_l2_info.dst_mac,
-                    sizeof(switch_mac_addr_t));
+    SWITCH_MEMCPY(&l2_mac, &l2_info->api_l2_info.dst_mac,
+                  sizeof(switch_mac_addr_t));
   }
   return SWITCH_MEMCMP(key1, &l2_mac, SWITCH_L2_HASH_KEY_SIZE);
 }
 
-switch_status_t switch_l2_init(switch_device_t device)
-{
-  switch_l2_context_t *l2_ctx = NULL;
+switch_status_t switch_l2_init(switch_device_t device) {
+  switch_l2_context_t* l2_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   switch_status_t tmp_status = SWITCH_STATUS_SUCCESS;
 
   l2_ctx = SWITCH_MALLOC(device, sizeof(switch_l2_context_t), 0x1);
   if (!l2_ctx) {
-      status = SWITCH_STATUS_NO_MEMORY;
-      krnlmon_log_error(
+    status = SWITCH_STATUS_NO_MEMORY;
+    krnlmon_log_error(
         "switch_l2_init: Failed to allocate memory for l2 context on "
         "device: %d, error: %s\n",
-        device,
-        switch_error_to_string(status));
-      return status;
+        device, switch_error_to_string(status));
+    return status;
   }
-   
+
   SWITCH_MEMSET(l2_ctx, 0x0, sizeof(switch_l2_context_t));
 
-  status = switch_device_api_context_set(
-      device, SWITCH_API_TYPE_L2, (void *)l2_ctx);
+  status =
+      switch_device_api_context_set(device, SWITCH_API_TYPE_L2, (void*)l2_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-      krnlmon_log_error(
+    krnlmon_log_error(
         "switch_l2_init: Failed to set device api context on device %d:"
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
-      return status;
+        device, switch_error_to_string(status));
+    return status;
   }
 
   l2_ctx->l2_hashtable.size = L2_FWD_RX_TABLE_SIZE;
@@ -99,65 +92,61 @@ switch_status_t switch_l2_init(switch_device_t device)
 
   status = SWITCH_HASHTABLE_INIT(&l2_ctx->l2_hashtable);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("switch_l2_init: Failed to initialize hashtable for device %d\n",
-                     device);
+    krnlmon_log_error(
+        "switch_l2_init: Failed to initialize hashtable for device %d\n",
+        device);
     return status;
   }
 
-  status = switch_handle_type_init(
-    device, SWITCH_HANDLE_TYPE_L2_FWD_RX, L2_FWD_RX_TABLE_SIZE);
+  status = switch_handle_type_init(device, SWITCH_HANDLE_TYPE_L2_FWD_RX,
+                                   L2_FWD_RX_TABLE_SIZE);
   if (status != SWITCH_STATUS_SUCCESS) {
-      krnlmon_log_error(
+    krnlmon_log_error(
         "switch_l2_init: Failed to initialize switch handle "
         "for type SWITCH_HANDLE_TYPE_L2_FWD_RX"
         "on device %d:, error: %s\n",
-        device,
-        switch_error_to_string(status));
-      goto cleanup;
+        device, switch_error_to_string(status));
+    goto cleanup;
   }
 
-  status = switch_handle_type_init(
-      device, SWITCH_HANDLE_TYPE_L2_FWD_TX, L2_FWD_TX_TABLE_SIZE);
+  status = switch_handle_type_init(device, SWITCH_HANDLE_TYPE_L2_FWD_TX,
+                                   L2_FWD_TX_TABLE_SIZE);
   if (status != SWITCH_STATUS_SUCCESS) {
-      krnlmon_log_error(
+    krnlmon_log_error(
         "switch_l2_init: Failed to initialize switch handle "
         "for type SWITCH_HANDLE_TYPE_L2_FWD_TX"
         "on device %d:, error: %s\n",
-        device,
-        switch_error_to_string(status));
-      goto cleanup;
+        device, switch_error_to_string(status));
+    goto cleanup;
   }
 
-  return status;   
+  return status;
 
 cleanup:
   tmp_status = switch_l2_free(device);
   SWITCH_ASSERT(tmp_status == SWITCH_STATUS_SUCCESS);
   return status;
- 
 }
 
-switch_status_t switch_l2_free(switch_device_t device)
-{
-  switch_l2_context_t *l2_ctx = NULL;
+switch_status_t switch_l2_free(switch_device_t device) {
+  switch_l2_context_t* l2_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_L2, (void **)&l2_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_L2,
+                                         (void**)&l2_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "switch_l2_free: Failed to get device api context on device %d: "
         "error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
-  
+
   status = SWITCH_HASHTABLE_DONE(&l2_ctx->l2_hashtable);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("switch_l2_free: SWITCH_HASHTABLE_DONE failed for device %d: %s\n",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error(
+        "switch_l2_free: SWITCH_HASHTABLE_DONE failed for device %d: %s\n",
+        device, switch_error_to_string(status));
   }
 
   status = switch_handle_type_free(device, SWITCH_HANDLE_TYPE_L2_FWD_TX);
@@ -166,8 +155,7 @@ switch_status_t switch_l2_free(switch_device_t device)
         "switch_l2_free: Failed to free handle type "
         "SWITCH_HANDLE_TYPE_L2_FWD_TX on device %d: "
         "error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
   }
 
   status = switch_handle_type_free(device, SWITCH_HANDLE_TYPE_L2_FWD_RX);
@@ -176,8 +164,7 @@ switch_status_t switch_l2_free(switch_device_t device)
         "switch_l2_free: Failed to free handle type "
         "SWITCH_HANDLE_TYPE_L2_FWD_RX on device %d: "
         "error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
   }
 
   SWITCH_FREE(device, l2_ctx);
@@ -187,33 +174,34 @@ switch_status_t switch_l2_free(switch_device_t device)
   return status;
 }
 
-switch_status_t switch_api_l2_handle_get(
-    const switch_device_t device,
-    const switch_mac_addr_t *l2_key,
-    switch_handle_t *l2_handle) {
-  switch_l2_context_t *l2_ctx = NULL;
-  switch_l2_info_t *l2_info = NULL;
+switch_status_t switch_api_l2_handle_get(const switch_device_t device,
+                                         const switch_mac_addr_t* l2_key,
+                                         switch_handle_t* l2_handle) {
+  switch_l2_context_t* l2_ctx = NULL;
+  switch_l2_info_t* l2_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!l2_key || !l2_handle) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
-    krnlmon_log_error("Failed to find l2 handle due to invalid parameters \n"
-             "error: %s\n",
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "Failed to find l2 handle due to invalid parameters \n"
+        "error: %s\n",
+        switch_error_to_string(status));
     return status;
   }
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_L2, (void **)&l2_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_L2,
+                                         (void**)&l2_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("switch_api_l2_handle_get: Failed to get device api context \n"
-             "error: %s\n",
-              switch_error_to_string(status));
+    krnlmon_log_error(
+        "switch_api_l2_handle_get: Failed to get device api context \n"
+        "error: %s\n",
+        switch_error_to_string(status));
     return status;
   }
 
-  status = SWITCH_HASHTABLE_SEARCH(
-      &l2_ctx->l2_hashtable, (void *)l2_key, (void **)&l2_info);
+  status = SWITCH_HASHTABLE_SEARCH(&l2_ctx->l2_hashtable, (void*)l2_key,
+                                   (void**)&l2_info);
   if (status == SWITCH_STATUS_SUCCESS) {
     *l2_handle = l2_info->api_l2_info.l2_handle;
   }
@@ -221,24 +209,23 @@ switch_status_t switch_api_l2_handle_get(
   return status;
 }
 
-switch_status_t switch_api_l2_forward_create(
-    const switch_device_t device,
-    switch_api_l2_info_t *api_l2_info,
-    switch_handle_t *l2_handle)
-{
+switch_status_t switch_api_l2_forward_create(const switch_device_t device,
+                                             switch_api_l2_info_t* api_l2_info,
+                                             switch_handle_t* l2_handle) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
   switch_handle_t tnl_handle = SWITCH_API_INVALID_HANDLE;
-  switch_l2_info_t *l2_info = NULL;
-  switch_l2_context_t *l2_ctx = NULL;
+  switch_l2_info_t* l2_info = NULL;
+  switch_l2_context_t* l2_ctx = NULL;
   switch_mac_addr_t l2_mac;
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_L2, (void **)&l2_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_L2,
+                                         (void**)&l2_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("switch_api_l2_forward_create: Failed to find the device api "
-             "context, error: %s \n",
-              switch_error_to_string(status));
+    krnlmon_log_error(
+        "switch_api_l2_forward_create: Failed to find the device api "
+        "context, error: %s \n",
+        switch_error_to_string(status));
     return status;
   }
 
@@ -250,8 +237,7 @@ switch_status_t switch_api_l2_forward_create(
     krnlmon_log_error(
         "switch_api_l2_forward_create: Failed to get api l2 handle on "
         "device %d: ,error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -259,115 +245,106 @@ switch_status_t switch_api_l2_forward_create(
     krnlmon_log_info(
         "switch_api_l2_forward_create: FDB handle 0x%lx on device %d "
         "already exists\n",
-        handle,
-        device);
+        handle, device);
     *l2_handle = handle;
     return status;
   }
 
-  if(api_l2_info->type == SWITCH_L2_FWD_TX) {
-
+  if (api_l2_info->type == SWITCH_L2_FWD_TX) {
     handle = switch_l2_tx_handle_create(device);
     if (handle == SWITCH_API_INVALID_HANDLE) {
-        status = SWITCH_STATUS_NO_MEMORY;
-        krnlmon_log_error("switch_api_l2_forward_create: Failed to create l2 tx "
-                 "handle on device %d: ,error: %s\n",
-                 device, switch_error_to_string(status));
-        return status;
+      status = SWITCH_STATUS_NO_MEMORY;
+      krnlmon_log_error(
+          "switch_api_l2_forward_create: Failed to create l2 tx "
+          "handle on device %d: ,error: %s\n",
+          device, switch_error_to_string(status));
+      return status;
     }
 
     status = switch_l2_tx_get(device, handle, &l2_info);
     if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error(
-            "switch_api_l2_forward_create: Failed to get l2 tx info for "
-            "handle 0x%lx on device %d: ,error: %s\n",
-            handle,
-            device,
-            switch_error_to_string(status));
-        return status;
+      krnlmon_log_error(
+          "switch_api_l2_forward_create: Failed to get l2 tx info for "
+          "handle 0x%lx on device %d: ,error: %s\n",
+          handle, device, switch_error_to_string(status));
+      return status;
     }
 
-    switch_api_tunnel_info_t *api_tunnel_info = NULL;
+    switch_api_tunnel_info_t* api_tunnel_info = NULL;
 
     // When the learn is from TUNNEL port we have corresponding RIF handle
     if (api_l2_info->learn_from == SWITCH_L2_FWD_LEARN_TUNNEL_INTERFACE) {
-        switch_tunnel_info_t *tunnel_info = NULL;
-        tnl_handle = api_l2_info->rif_handle;
-        status = switch_tunnel_get(device, tnl_handle, &tunnel_info);
-        CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
+      switch_tunnel_info_t* tunnel_info = NULL;
+      tnl_handle = api_l2_info->rif_handle;
+      status = switch_tunnel_get(device, tnl_handle, &tunnel_info);
+      CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
 
-        api_tunnel_info = &tunnel_info->api_tunnel_info;
+      api_tunnel_info = &tunnel_info->api_tunnel_info;
     }
 
     if (api_l2_info->learn_from == SWITCH_L2_FWD_LEARN_PHYSICAL_INTERFACE) {
-        switch_rif_info_t *rif_info = NULL;
+      switch_rif_info_t* rif_info = NULL;
 
-        status = switch_rif_get(device, api_l2_info->rif_handle, &rif_info);
-        CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
-        if (rif_info->api_rif_info.phy_port_id == -1) {
-            switch_pd_to_get_port_id(&(rif_info->api_rif_info));
-        }
+      status = switch_rif_get(device, api_l2_info->rif_handle, &rif_info);
+      CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
+      if (rif_info->api_rif_info.phy_port_id == -1) {
+        switch_pd_to_get_port_id(&(rif_info->api_rif_info));
+      }
 
-        api_l2_info->port_id = rif_info->api_rif_info.phy_port_id;
+      api_l2_info->port_id = rif_info->api_rif_info.phy_port_id;
     }
 
     status = switch_pd_l2_tx_forward_table_entry(device, api_l2_info,
-                                                  api_tunnel_info,  true);
+                                                 api_tunnel_info, true);
     if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error(
-            "switch_api_l2_forward_create: Failed to create platform dependent"
-            " l2 tx forward table entry on device %d: ,error :(%s)\n",
-            device,
-            switch_error_to_string(status));
-        return status;
+      krnlmon_log_error(
+          "switch_api_l2_forward_create: Failed to create platform dependent"
+          " l2 tx forward table entry on device %d: ,error :(%s)\n",
+          device, switch_error_to_string(status));
+      return status;
     }
 
     // These FDB entries are learnt from OVS, and same FDB entry rule
     // should be programmed for 2_fwd_rx_with_tunnel_table too.
     if (api_l2_info->learn_from == SWITCH_L2_FWD_LEARN_VLAN_INTERFACE) {
-      status = switch_pd_l2_rx_forward_with_tunnel_table_entry(device,
-                                                               api_l2_info,
-                                                               true);
+      status = switch_pd_l2_rx_forward_with_tunnel_table_entry(
+          device, api_l2_info, true);
       if (status != SWITCH_STATUS_SUCCESS) {
-          krnlmon_log_error(
-              "switch_api_l2_forward_create: Failed to create platform "
-              "dependent l2 rx forward tunnel table entry on device %d: "
-              ",error :%s\n",
-              device,
-              switch_error_to_string(status));
-          return status;
+        krnlmon_log_error(
+            "switch_api_l2_forward_create: Failed to create platform "
+            "dependent l2 rx forward tunnel table entry on device %d: "
+            ",error :%s\n",
+            device, switch_error_to_string(status));
+        return status;
       }
     }
-  } else if(api_l2_info->type == SWITCH_L2_FWD_RX) {
-
+  } else if (api_l2_info->type == SWITCH_L2_FWD_RX) {
     handle = switch_l2_rx_handle_create(device);
     if (handle == SWITCH_API_INVALID_HANDLE) {
-        status = SWITCH_STATUS_NO_MEMORY;
-        krnlmon_log_error("switch_api_l2_forward_create: Failed to create l2 rx "
-                 "handle on device %d: ,error: %s\n",
-                 device, switch_error_to_string(status));
-        return status;
+      status = SWITCH_STATUS_NO_MEMORY;
+      krnlmon_log_error(
+          "switch_api_l2_forward_create: Failed to create l2 rx "
+          "handle on device %d: ,error: %s\n",
+          device, switch_error_to_string(status));
+      return status;
     }
 
     status = switch_l2_rx_get(device, handle, &l2_info);
     if (status != SWITCH_STATUS_SUCCESS) {
-         krnlmon_log_error(
-            "switch_api_l2_forward_create: Failed to get l2 rx info "
-            "for handle 0x%lx on device %d: "
-            ",error: %s\n",
-            handle,
-            device,
-            switch_error_to_string(status));
-        return status;
+      krnlmon_log_error(
+          "switch_api_l2_forward_create: Failed to get l2 rx info "
+          "for handle 0x%lx on device %d: "
+          ",error: %s\n",
+          handle, device, switch_error_to_string(status));
+      return status;
     }
 
     status = switch_pd_l2_rx_forward_table_entry(device, api_l2_info, true);
     if (status != SWITCH_STATUS_SUCCESS) {
       krnlmon_log_error(
-              "switch_api_l2_forward_create: Failed to create platform "
-              "dependent l2 rx forward table entry on device %d: ,error: %s\n",
-              device,
-              switch_error_to_string(status));
+          "switch_api_l2_forward_create: Failed to create platform "
+          "dependent l2 rx forward table entry on device %d: ,error: %s\n",
+          device, switch_error_to_string(status));
       return status;
     }
   } else {
@@ -376,36 +353,33 @@ switch_status_t switch_api_l2_forward_create(
   }
 
   api_l2_info->l2_handle = handle;
-  SWITCH_MEMCPY(&l2_info->api_l2_info,
-              api_l2_info,
-              sizeof(switch_api_l2_info_t));
+  SWITCH_MEMCPY(&l2_info->api_l2_info, api_l2_info,
+                sizeof(switch_api_l2_info_t));
 
-  status = SWITCH_HASHTABLE_INSERT(&l2_ctx->l2_hashtable,
-                                   &(l2_info->node),
-                                   (void *)&l2_mac,
-                                   (void *)l2_info);
+  status = SWITCH_HASHTABLE_INSERT(&l2_ctx->l2_hashtable, &(l2_info->node),
+                                   (void*)&l2_mac, (void*)l2_info);
   SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
 
   *l2_handle = handle;
 
-  return SWITCH_STATUS_SUCCESS; 
+  return SWITCH_STATUS_SUCCESS;
 }
 
-switch_status_t switch_api_l2_forward_delete (
-    const switch_device_t device,
-    const switch_api_l2_info_t *api_l2_info) {
+switch_status_t switch_api_l2_forward_delete(
+    const switch_device_t device, const switch_api_l2_info_t* api_l2_info) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   switch_handle_t l2_handle;
-  switch_l2_context_t *l2_ctx = NULL;
+  switch_l2_context_t* l2_ctx = NULL;
   switch_mac_addr_t l2_mac;
-  switch_l2_info_t *l2_info = NULL;
+  switch_l2_info_t* l2_info = NULL;
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_L2, (void **)&l2_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_L2,
+                                         (void**)&l2_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("switch_api_l2_forward_delete: Failed to get device api "
-             "context, error: %s \n",
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "switch_api_l2_forward_delete: Failed to get device api "
+        "context, error: %s \n",
+        switch_error_to_string(status));
     return status;
   }
 
@@ -415,66 +389,58 @@ switch_status_t switch_api_l2_forward_delete (
     krnlmon_log_error(
         "switch_api_l2_forward_delete: Failed to get api l2 "
         "handle on device: %d, error:%s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
-  status = SWITCH_HASHTABLE_DELETE(&l2_ctx->l2_hashtable, (void *)(&l2_mac),
-                                   (void **)&l2_info);
+  status = SWITCH_HASHTABLE_DELETE(&l2_ctx->l2_hashtable, (void*)(&l2_mac),
+                                   (void**)&l2_info);
   SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
 
-  if(api_l2_info->type == SWITCH_L2_FWD_TX)
-  {
-    status = switch_pd_l2_tx_forward_table_entry (device, api_l2_info, NULL,
-                                                  false);
+  if (api_l2_info->type == SWITCH_L2_FWD_TX) {
+    status =
+        switch_pd_l2_tx_forward_table_entry(device, api_l2_info, NULL, false);
     if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error(
-              "switch_api_l2_forward_delete: Failed to delete platform "
-              "dependent l2 tx forward table entry on device %d: ,error :%s\n",
-              device,
-              switch_error_to_string(status));
-        return status;
+      krnlmon_log_error(
+          "switch_api_l2_forward_delete: Failed to delete platform "
+          "dependent l2 tx forward table entry on device %d: ,error :%s\n",
+          device, switch_error_to_string(status));
+      return status;
     }
 
     /* These FDB entries are learnt from OVS, and same FDB entry rule
      * should be deleted from 2_fwd_rx_with_tunnel_table too.
      */
     if (l2_info->api_l2_info.learn_from == SWITCH_L2_FWD_LEARN_VLAN_INTERFACE) {
-      status = switch_pd_l2_rx_forward_with_tunnel_table_entry(device,
-                                                               api_l2_info,
-                                                               false);
+      status = switch_pd_l2_rx_forward_with_tunnel_table_entry(
+          device, api_l2_info, false);
       if (status != SWITCH_STATUS_SUCCESS) {
-          krnlmon_log_error(
-              "switch_api_l2_forward_delete: Failed to delete platform "
-              "dependent l2 rx forward "
-              "tunnel table entry on device %d: ,error :%s\n",
-              device,
-              switch_error_to_string(status));
-          return status;
+        krnlmon_log_error(
+            "switch_api_l2_forward_delete: Failed to delete platform "
+            "dependent l2 rx forward "
+            "tunnel table entry on device %d: ,error :%s\n",
+            device, switch_error_to_string(status));
+        return status;
       }
     }
 
     status = switch_l2_tx_handle_delete(device, l2_handle, 1);
     SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
-  }
-  else if(api_l2_info->type == SWITCH_L2_FWD_RX)
-  {
-    status = switch_pd_l2_rx_forward_table_entry (device, api_l2_info, false);
+  } else if (api_l2_info->type == SWITCH_L2_FWD_RX) {
+    status = switch_pd_l2_rx_forward_table_entry(device, api_l2_info, false);
     if (status != SWITCH_STATUS_SUCCESS) {
       krnlmon_log_error(
-              "switch_api_l2_forward_delete: Failed to delete platform "
-              "dependent l2 rx forward table entry on device %d: ,error :%s\n",
-              device,
-              switch_error_to_string(status));
+          "switch_api_l2_forward_delete: Failed to delete platform "
+          "dependent l2 rx forward table entry on device %d: ,error :%s\n",
+          device, switch_error_to_string(status));
       return status;
     }
 
     status = switch_l2_rx_handle_delete(device, l2_handle, 1);
     SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
   } else {
-      krnlmon_log_error("Invalid L2 FWD type");
-      return SWITCH_STATUS_NOT_SUPPORTED;
+    krnlmon_log_error("Invalid L2 FWD type");
+    return SWITCH_STATUS_NOT_SUPPORTED;
   }
 
   return status;

--- a/switchapi/dpdk/switch_fdb.c
+++ b/switchapi/dpdk/switch_fdb.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/dpdk/switch_handle.c
+++ b/switchapi/dpdk/switch_handle.c
@@ -46,39 +46,42 @@ switch_status_t switch_handle_type_allocator_init(switch_device_t device,
                                                   switch_uint32_t num_handles,
                                                   bool grow_on_demand,
                                                   bool zero_based) {
-  switch_device_context_t *device_ctx = NULL;
-  switch_handle_info_t *handle_info = NULL;
-  switch_id_allocator_t *allocator = NULL;
+  switch_device_context_t* device_ctx = NULL;
+  switch_handle_info_t* handle_info = NULL;
+  switch_id_allocator_t* allocator = NULL;
   switch_size_t size = 0;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (device > SWITCH_MAX_DEVICE) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("handle allocator init failed, error: %s\n",
-                     switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle allocator init: Failed to get device context, error: %s\n",
-                     switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle allocator init: Failed to get device context, error: %s\n",
+        switch_error_to_string(status));
     return status;
   }
 
   if (type >= SWITCH_HANDLE_TYPE_MAX) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
-    krnlmon_log_error("handle allocator init failedto get device context, error: %s\n",
-                     switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle allocator init failedto get device context, error: %s\n",
+        switch_error_to_string(status));
     return status;
   }
 
   handle_info = SWITCH_MALLOC(device, sizeof(switch_handle_info_t), 1);
   if (!handle_info) {
     status = SWITCH_STATUS_NO_MEMORY;
-    krnlmon_log_error("handle allocator init: Failed to allocate memory for "
-             "handle %s, error: %s\n", switch_handle_type_to_string(type),
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle allocator init: Failed to allocate memory for "
+        "handle %s, error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     return status;
   }
 
@@ -89,9 +92,10 @@ switch_status_t switch_handle_type_allocator_init(switch_device_t device,
   if (status != SWITCH_STATUS_SUCCESS) {
     SWITCH_FREE(device, handle_info);
     status = SWITCH_STATUS_FAILURE;
-    krnlmon_log_error("handle allocator init: Faile to allocate new api id "
-             "for handle %s, error: %s\n", switch_handle_type_to_string(type),
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle allocator init: Faile to allocate new api id "
+        "for handle %s, error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     return status;
   }
 
@@ -104,13 +108,13 @@ switch_status_t switch_handle_type_allocator_init(switch_device_t device,
   handle_info->zero_based = zero_based;
   handle_info->new_allocator = bf_id_allocator_new(size, zero_based);
 
-  status = SWITCH_ARRAY_INSERT(
-      &device_ctx->handle_info_array, type, (void *)handle_info);
+  status = SWITCH_ARRAY_INSERT(&device_ctx->handle_info_array, type,
+                               (void*)handle_info);
 
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle allocator init: Failed to insert handle %s, error: %s\n",
-                     switch_handle_type_to_string(type),
-                     switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle allocator init: Failed to insert handle %s, error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     switch_api_id_allocator_destroy(device, handle_info->allocator);
     bf_id_allocator_destroy(handle_info->new_allocator);
     SWITCH_FREE(device, handle_info);
@@ -122,38 +126,39 @@ switch_status_t switch_handle_type_allocator_init(switch_device_t device,
 
 switch_status_t switch_handle_type_free(switch_device_t device,
                                         switch_handle_type_t type) {
-  switch_device_context_t *device_ctx = NULL;
-  switch_handle_info_t *handle_info = NULL;
+  switch_device_context_t* device_ctx = NULL;
+  switch_handle_info_t* handle_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (device > SWITCH_MAX_DEVICE) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("handle free failed: %s\n",
-                     switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle free failed: Failed to get device context, error: %s\n",
-                     switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle free failed: Failed to get device context, error: %s\n",
+        switch_error_to_string(status));
     return status;
   }
 
   if (type >= SWITCH_HANDLE_TYPE_MAX) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("handle free failed, error: %s\n",
-                     switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
-  status = SWITCH_ARRAY_GET(
-      &device_ctx->handle_info_array, type, (void *)&handle_info);
+  status = SWITCH_ARRAY_GET(&device_ctx->handle_info_array, type,
+                            (void*)&handle_info);
 
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error("handle %s free failed: %s\n",
-                     switch_handle_type_to_string(type),
-                     switch_error_to_string(status));
+                      switch_handle_type_to_string(type),
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -161,9 +166,10 @@ switch_status_t switch_handle_type_free(switch_device_t device,
   bf_id_allocator_destroy(handle_info->new_allocator);
   status = SWITCH_ARRAY_DELETE(&device_ctx->handle_info_array, type);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle free: Failed to destroy allocator for "
-             "handle %s, error: %s\n", switch_handle_type_to_string(type),
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle free: Failed to destroy allocator for "
+        "handle %s, error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     return status;
   }
   SWITCH_FREE(device, handle_info);
@@ -171,10 +177,10 @@ switch_status_t switch_handle_type_free(switch_device_t device,
 }
 
 static switch_handle_t __switch_handle_create(switch_device_t device,
-                                       switch_handle_type_t type,
-                                       unsigned int count) {
-  switch_device_context_t *device_ctx = NULL;
-  switch_handle_info_t *handle_info = NULL;
+                                              switch_handle_type_t type,
+                                              unsigned int count) {
+  switch_device_context_t* device_ctx = NULL;
+  switch_handle_info_t* handle_info = NULL;
   switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
   switch_uint32_t id = 0;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
@@ -182,31 +188,32 @@ static switch_handle_t __switch_handle_create(switch_device_t device,
   if (device > SWITCH_MAX_DEVICE) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("handle_create failed, error: %s\n",
-                     switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle_create: Failed to get device context, error: %s\n",
-                     switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle_create: Failed to get device context, error: %s\n",
+        switch_error_to_string(status));
     return status;
   }
 
   if (type >= SWITCH_HANDLE_TYPE_MAX) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("handle_create failed, error: %s\n",
-                     switch_error_to_string(status));
+                      switch_error_to_string(status));
     return SWITCH_API_INVALID_HANDLE;
   }
 
-  status = SWITCH_ARRAY_GET(
-      &device_ctx->handle_info_array, type, (void **)&handle_info);
+  status = SWITCH_ARRAY_GET(&device_ctx->handle_info_array, type,
+                            (void**)&handle_info);
 
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error("handle_create: Failed to get handle %s, error: %s\n",
-                     switch_handle_type_to_string(type),
-                     switch_error_to_string(status));
+                      switch_handle_type_to_string(type),
+                      switch_error_to_string(status));
     return SWITCH_API_INVALID_HANDLE;
   }
 
@@ -219,10 +226,10 @@ static switch_handle_t __switch_handle_create(switch_device_t device,
       status = switch_api_id_allocator_allocate_contiguous(
           device, handle_info->allocator, count, &id);
     if (status != SWITCH_STATUS_SUCCESS) {
-      krnlmon_log_error("handle_create: Failed to allocate contiguous allocator"
-               " for handle %s, error: %s\n",
-               switch_handle_type_to_string(type),
-               switch_error_to_string(status));
+      krnlmon_log_error(
+          "handle_create: Failed to allocate contiguous allocator"
+          " for handle %s, error: %s\n",
+          switch_handle_type_to_string(type), switch_error_to_string(status));
       return SWITCH_API_INVALID_HANDLE;
     }
     handle_info->num_in_use++;
@@ -233,10 +240,10 @@ static switch_handle_t __switch_handle_create(switch_device_t device,
 }
 
 static switch_status_t _switch_handle_delete_contiguous(switch_device_t device,
-                                                 switch_handle_t handle,
-                                                 uint32_t count) {
-  switch_device_context_t *device_ctx = NULL;
-  switch_handle_info_t *handle_info = NULL;
+                                                        switch_handle_t handle,
+                                                        uint32_t count) {
+  switch_device_context_t* device_ctx = NULL;
+  switch_handle_info_t* handle_info = NULL;
   switch_uint32_t id = 0;
   switch_handle_type_t type = SWITCH_HANDLE_TYPE_NONE;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
@@ -244,25 +251,28 @@ static switch_status_t _switch_handle_delete_contiguous(switch_device_t device,
   if (device > SWITCH_MAX_DEVICE) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("handle delete contiguous failed, error: %s\n",
-                     switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle delete contiguous: Failed to get device "
-             "context, error: %s\n", switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle delete contiguous: Failed to get device "
+        "context, error: %s\n",
+        switch_error_to_string(status));
     return status;
   }
 
   type = switch_handle_type_get(handle);
-  status = SWITCH_ARRAY_GET(
-      &device_ctx->handle_info_array, type, (void *)&handle_info);
+  status = SWITCH_ARRAY_GET(&device_ctx->handle_info_array, type,
+                            (void*)&handle_info);
 
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle delete contiguous: Failed to get handle info for type %s, "
-             "error: %s\n", switch_handle_type_to_string(type),
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle delete contiguous: Failed to get handle info for type %s, "
+        "error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     return status;
   }
 
@@ -274,25 +284,26 @@ static switch_status_t _switch_handle_delete_contiguous(switch_device_t device,
 }
 
 static switch_status_t _switch_handle_delete(switch_device_t device,
-                                      switch_handle_t handle) {
+                                             switch_handle_t handle) {
   return _switch_handle_delete_contiguous(device, handle, 1);
 }
 
 static switch_handle_t _switch_handle_create(switch_device_t device,
-                                      switch_handle_type_t type,
-                                      switch_uint32_t size,
-                                      unsigned int count) {
-  switch_device_context_t *device_ctx = NULL;
-  void *i_info = NULL;
-  void *handle_array = NULL;
+                                             switch_handle_type_t type,
+                                             switch_uint32_t size,
+                                             unsigned int count) {
+  switch_device_context_t* device_ctx = NULL;
+  void* i_info = NULL;
+  void* handle_array = NULL;
   switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle create: Failed to get device context for type %s, "
-             "error: %s\n", switch_handle_type_to_string(type),
-              switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle create: Failed to get device context for type %s, "
+        "error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     return SWITCH_API_INVALID_HANDLE;
   }
 
@@ -302,29 +313,30 @@ static switch_handle_t _switch_handle_create(switch_device_t device,
   if (handle == SWITCH_API_INVALID_HANDLE) {
     status = SWITCH_STATUS_FAILURE;
     krnlmon_log_error("handle create: Invalid handle for type %s, error: %s\n",
-              switch_handle_type_to_string(type),
-              switch_error_to_string(status));
+                      switch_handle_type_to_string(type),
+                      switch_error_to_string(status));
     return SWITCH_API_INVALID_HANDLE;
   }
 
   i_info = SWITCH_MALLOC(device, size, 1);
   if (!i_info) {
     status = SWITCH_STATUS_NO_MEMORY;
-    krnlmon_log_error("handle create: Failed to allocate memory for type %s, "
-             "error: %s\n", switch_handle_type_to_string(type),
-              switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle create: Failed to allocate memory for type %s, "
+        "error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     _switch_handle_delete(device, handle);
     return SWITCH_API_INVALID_HANDLE;
   }
 
   SWITCH_MEMSET(i_info, 0, size);
 
-  status = SWITCH_ARRAY_INSERT(handle_array, handle, (void *)i_info);
+  status = SWITCH_ARRAY_INSERT(handle_array, handle, (void*)i_info);
 
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle create: Failed to insert handle for type %s, error: %s\n",
-              switch_handle_type_to_string(type),
-              switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle create: Failed to insert handle for type %s, error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     SWITCH_FREE(device, i_info);
     _switch_handle_delete(device, handle);
     return SWITCH_API_INVALID_HANDLE;
@@ -347,32 +359,31 @@ switch_handle_t switch_handle_create_contiguous(switch_device_t device,
 
 switch_status_t switch_handle_get(switch_device_t device,
                                   switch_handle_type_t type,
-                                  switch_handle_t handle,
-                                  void **i_info) {
-  switch_device_context_t *device_ctx = NULL;
-  void *handle_array = NULL;
+                                  switch_handle_t handle, void** i_info) {
+  switch_device_context_t* device_ctx = NULL;
+  void* handle_array = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!SWITCH_HANDLE_VALID(handle, type)) {
-    krnlmon_log_error("handle get failed due to invalid handle %lx\n",
-              handle);
+    krnlmon_log_error("handle get failed due to invalid handle %lx\n", handle);
     return SWITCH_STATUS_INVALID_HANDLE;
   }
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle get: Failed to get device context for handle "
-             "type %s, error: %s\n", switch_handle_type_to_string(type),
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle get: Failed to get device context for handle "
+        "type %s, error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     return status;
   }
   handle_array = &device_ctx->handle_array[type];
 
-  status = SWITCH_ARRAY_GET(handle_array, handle, (void **)i_info);
+  status = SWITCH_ARRAY_GET(handle_array, handle, (void**)i_info);
 
   type = switch_handle_type_get(handle);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error("handle get: failed to get handle type, error: %s\n",
-              switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
   return SWITCH_STATUS_SUCCESS;
@@ -382,43 +393,46 @@ switch_status_t switch_handle_delete_contiguous(switch_device_t device,
                                                 switch_handle_type_t type,
                                                 switch_handle_t handle,
                                                 uint32_t count) {
-  switch_device_context_t *device_ctx = NULL;
-  void *i_info = NULL;
-  void *handle_array = NULL;
+  switch_device_context_t* device_ctx = NULL;
+  void* i_info = NULL;
+  void* handle_array = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle delete contiguous failed for type %s, error: %s\n",
-              switch_handle_type_to_string(type),
-              switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle delete contiguous failed for type %s, error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     return status;
   }
   handle_array = &device_ctx->handle_array[type];
 
-  status = SWITCH_ARRAY_GET(handle_array, handle, (void **)&i_info);
+  status = SWITCH_ARRAY_GET(handle_array, handle, (void**)&i_info);
 
   type = switch_handle_type_get(handle);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle delete contiguous: failed to get handle "
-             "type %s, error: %s\n", switch_handle_type_to_string(type),
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle delete contiguous: failed to get handle "
+        "type %s, error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     return status;
   }
 
   status = SWITCH_ARRAY_DELETE(handle_array, handle);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle delete contiguous: failed to delete array "
-             "for handle %s, error: %s\n", switch_handle_type_to_string(type),
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle delete contiguous: failed to delete array "
+        "for handle %s, error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     return status;
   }
 
   status = _switch_handle_delete_contiguous(device, handle, count);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle delete contiguous: failed to delete "
-             "handle %s, error: %s\n", switch_handle_type_to_string(type),
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle delete contiguous: failed to delete "
+        "handle %s, error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     return status;
   }
   SWITCH_FREE(device, i_info);
@@ -433,9 +447,9 @@ switch_status_t switch_handle_delete(switch_device_t device,
 
 switch_status_t switch_api_handle_count_get(switch_device_t device,
                                             switch_handle_type_t type,
-                                            switch_size_t *num_entries) {
-  switch_device_context_t *device_ctx = NULL;
-  switch_handle_info_t *handle_info = NULL;
+                                            switch_size_t* num_entries) {
+  switch_device_context_t* device_ctx = NULL;
+  switch_handle_info_t* handle_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(type < SWITCH_HANDLE_TYPE_MAX);
@@ -445,16 +459,17 @@ switch_status_t switch_api_handle_count_get(switch_device_t device,
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error("handle count get failed, error: %s\n",
-              switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
-  status = SWITCH_ARRAY_GET(
-      &device_ctx->handle_info_array, type, (void *)&handle_info);
+  status = SWITCH_ARRAY_GET(&device_ctx->handle_info_array, type,
+                            (void*)&handle_info);
 
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle count get: Failed to get handle info, error: %s\n",
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle count get: Failed to get handle info, error: %s\n",
+        switch_error_to_string(status));
     return status;
   }
 

--- a/switchapi/dpdk/switch_handle.c
+++ b/switchapi/dpdk/switch_handle.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/dpdk/switch_id.c
+++ b/switchapi/dpdk/switch_id.c
@@ -26,17 +26,17 @@ extern "C" {
 #define __FILE_ID__ SWITCH_ID
 
 static switch_status_t switch_api_id_allocator_new_internal(
-    switch_device_t device,
-    switch_uint32_t initial_size,
-    bool zero_based,
-    switch_id_allocator_t **allocator) {
+    switch_device_t device, switch_uint32_t initial_size, bool zero_based,
+    switch_id_allocator_t** allocator) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   *allocator = SWITCH_MALLOC(device, sizeof(switch_id_allocator_t), 1);
   if (*allocator == NULL) {
     status = SWITCH_STATUS_NO_MEMORY;
-    krnlmon_log_error("id alloc: Failed to allocate memory for switch_id_allocator_t, "
-             "error: %s\n", switch_error_to_string(status));
+    krnlmon_log_error(
+        "id alloc: Failed to allocate memory for switch_id_allocator_t, "
+        "error: %s\n",
+        switch_error_to_string(status));
     return status;
   }
 
@@ -45,8 +45,10 @@ static switch_status_t switch_api_id_allocator_new_internal(
   if ((*allocator)->data == NULL) {
     status = SWITCH_STATUS_NO_MEMORY;
     SWITCH_FREE(device, *allocator);
-    krnlmon_log_error("id alloc: Failed to allocate memory for allocator data, "
-             "error: %s\n", switch_error_to_string(status));
+    krnlmon_log_error(
+        "id alloc: Failed to allocate memory for allocator data, "
+        "error: %s\n",
+        switch_error_to_string(status));
     return status;
   }
 
@@ -57,12 +59,13 @@ static switch_status_t switch_api_id_allocator_new_internal(
 }
 
 static switch_status_t switch_api_id_allocator_destroy_internal(
-    switch_device_t device, switch_id_allocator_t *allocator) {
+    switch_device_t device, switch_id_allocator_t* allocator) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!allocator) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
-    krnlmon_log_error("id destroy failed, error: %s", switch_error_to_string(status));
+    krnlmon_log_error("id destroy failed, error: %s",
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -89,10 +92,8 @@ static inline switch_int32_t switch_api_id_fit_width(switch_uint32_t val,
 }
 
 static switch_status_t switch_api_id_allocator_allocate_contiguous_internal(
-    switch_device_t device,
-    switch_id_allocator_t *allocator,
-    switch_uint8_t count,
-    switch_uint32_t *id) {
+    switch_device_t device, switch_id_allocator_t* allocator,
+    switch_uint8_t count, switch_uint32_t* id) {
   switch_uint32_t n_words = 0;
   switch_uint32_t i = 0;
   switch_int32_t pos = -1;
@@ -101,7 +102,7 @@ static switch_status_t switch_api_id_allocator_allocate_contiguous_internal(
   if (!allocator) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("id alloc contiguous failed, error: %s",
-             switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -118,11 +119,11 @@ static switch_status_t switch_api_id_allocator_allocate_contiguous_internal(
   }
 
   n_words = allocator->n_words;
-  allocator->data = SWITCH_REALLOC(
-      device, allocator->data, n_words * 2 * sizeof(switch_uint32_t));
+  allocator->data = SWITCH_REALLOC(device, allocator->data,
+                                   n_words * 2 * sizeof(switch_uint32_t));
 
-  SWITCH_MEMSET(
-      &allocator->data[n_words], 0, n_words * sizeof(switch_uint32_t));
+  SWITCH_MEMSET(&allocator->data[n_words], 0,
+                n_words * sizeof(switch_uint32_t));
   allocator->n_words = n_words * 2;
   allocator->data[n_words] |= (0xFFFFFFFF << (32 - count)) & 0xFFFFFFFF;
   *id = 32 * n_words + (allocator->zero_based ? 0 : 1);
@@ -130,13 +131,13 @@ static switch_status_t switch_api_id_allocator_allocate_contiguous_internal(
 }
 
 static switch_status_t switch_api_id_allocator_allocate_internal(
-    switch_device_t device, switch_id_allocator_t *allocator, switch_id_t *id) {
+    switch_device_t device, switch_id_allocator_t* allocator, switch_id_t* id) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!allocator) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("id alloc internal failed, error: %s",
-             switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -144,12 +145,13 @@ static switch_status_t switch_api_id_allocator_allocate_internal(
 }
 
 static switch_status_t switch_api_id_allocator_release_internal(
-    switch_device_t device, switch_id_allocator_t *allocator, switch_id_t id) {
+    switch_device_t device, switch_id_allocator_t* allocator, switch_id_t id) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!allocator) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
-    krnlmon_log_error("id release failed, error: %s", switch_error_to_string(status));
+    krnlmon_log_error("id release failed, error: %s",
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -161,33 +163,31 @@ static switch_status_t switch_api_id_allocator_release_internal(
 }
 
 switch_status_t switch_api_id_allocator_destroy(
-    switch_device_t device, switch_id_allocator_t *allocator) {
+    switch_device_t device, switch_id_allocator_t* allocator) {
   return switch_api_id_allocator_destroy_internal(device, allocator);
 }
 
 switch_status_t switch_api_id_allocator_new(switch_device_t device,
                                             switch_uint32_t initial_size,
                                             bool zero_based,
-                                            switch_id_allocator_t **allocator) {
+                                            switch_id_allocator_t** allocator) {
   return switch_api_id_allocator_new_internal(device, initial_size, zero_based,
-                                       allocator);
+                                              allocator);
 }
 
 switch_status_t switch_api_id_allocator_allocate(
-    switch_device_t device, switch_id_allocator_t *allocator, switch_id_t *id) {
-    return switch_api_id_allocator_allocate_internal(device, allocator, id);
+    switch_device_t device, switch_id_allocator_t* allocator, switch_id_t* id) {
+  return switch_api_id_allocator_allocate_internal(device, allocator, id);
 }
 
 switch_status_t switch_api_id_allocator_release(
-    switch_device_t device, switch_id_allocator_t *allocator, switch_id_t id) {
-    return switch_api_id_allocator_release_internal(device, allocator, id);
+    switch_device_t device, switch_id_allocator_t* allocator, switch_id_t id) {
+  return switch_api_id_allocator_release_internal(device, allocator, id);
 }
 
 switch_status_t switch_api_id_allocator_allocate_contiguous(
-    switch_device_t device,
-    switch_id_allocator_t *allocator,
-    switch_uint8_t count,
-    switch_id_t *id) {
+    switch_device_t device, switch_id_allocator_t* allocator,
+    switch_uint8_t count, switch_id_t* id) {
   return switch_api_id_allocator_allocate_contiguous_internal(device, allocator,
-                                                       count, id);
+                                                              count, id);
 }

--- a/switchapi/dpdk/switch_id.c
+++ b/switchapi/dpdk/switch_id.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/dpdk/switch_l3.c
+++ b/switchapi/dpdk/switch_l3.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/dpdk/switch_l3.c
+++ b/switchapi/dpdk/switch_l3.c
@@ -15,16 +15,17 @@
  * limitations under the License.
  */
 
+#include "switchapi/switch_l3.h"
+
 #include "switch_pd_routing.h"
 #include "switchapi/switch_device.h"
 #include "switchapi/switch_internal.h"
-#include "switchapi/switch_l3.h"
 #include "switchapi/switch_nhop_int.h"
 
-switch_status_t switch_route_table_entry_key_init(void *args,
-                                                  switch_uint8_t *key,
-                                                  switch_uint32_t *len) {
-  switch_route_entry_t *route_entry = NULL;
+switch_status_t switch_route_table_entry_key_init(void* args,
+                                                  switch_uint8_t* key,
+                                                  switch_uint32_t* len) {
+  switch_route_entry_t* route_entry = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!args || !key || !len) {
@@ -33,7 +34,7 @@ switch_status_t switch_route_table_entry_key_init(void *args,
   }
 
   *len = 0;
-  route_entry = (switch_route_entry_t *)args;
+  route_entry = (switch_route_entry_t*)args;
 
   SWITCH_MEMCPY(key, &route_entry->vrf_handle, sizeof(switch_handle_t));
   *len += sizeof(switch_handle_t);
@@ -49,13 +50,13 @@ switch_status_t switch_route_table_entry_key_init(void *args,
   return status;
 }
 
-switch_int32_t switch_route_entry_hash_compare(const void *key1,
-                                               const void *key2) {
+switch_int32_t switch_route_entry_hash_compare(const void* key1,
+                                               const void* key2) {
   return SWITCH_MEMCMP(key1, key2, SWITCH_ROUTE_HASH_KEY_SIZE);
 }
 
 switch_status_t switch_l3_init(switch_device_t device) {
-  switch_l3_context_t *l3_ctx = NULL;
+  switch_l3_context_t* l3_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   l3_ctx = SWITCH_MALLOC(device, sizeof(switch_l3_context_t), 0x1);
@@ -64,62 +65,57 @@ switch_status_t switch_l3_init(switch_device_t device) {
     krnlmon_log_error(
         "l3 init: Failed to allocate memory for switch_l3_context_t "
         "on device %d ,error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
   status =
-      switch_device_api_context_set(device, SWITCH_API_TYPE_L3, (void *)l3_ctx);
+      switch_device_api_context_set(device, SWITCH_API_TYPE_L3, (void*)l3_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "l3 init: Failed to set device context device %d "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
   }
-  
+
   l3_ctx->route_hashtable.size = IPV4_TABLE_SIZE;
   l3_ctx->route_hashtable.compare_func = switch_route_entry_hash_compare;
   l3_ctx->route_hashtable.key_func = switch_route_table_entry_key_init;
   l3_ctx->route_hashtable.hash_seed = SWITCH_ROUTE_HASH_SEED;
-  
+
   status = SWITCH_HASHTABLE_INIT(&l3_ctx->route_hashtable);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "l3 init: Failed to init hashtable on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
-  status = switch_handle_type_init(
-      device, SWITCH_HANDLE_TYPE_ROUTE, IPV4_TABLE_SIZE);
+  status = switch_handle_type_init(device, SWITCH_HANDLE_TYPE_ROUTE,
+                                   IPV4_TABLE_SIZE);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "l3 init: Failed to init SWITCH_HANDLE_TYPE_ROUTE on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
   return status;
-} 
+}
 
 switch_status_t switch_l3_free(switch_device_t device) {
-  switch_l3_context_t *l3_ctx = NULL;
+  switch_l3_context_t* l3_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_L3, (void **)&l3_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_L3,
+                                         (void**)&l3_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "l3 free: Failed to get device context on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
   }
 
   status = SWITCH_HASHTABLE_DONE(&l3_ctx->route_hashtable);
@@ -127,8 +123,7 @@ switch_status_t switch_l3_free(switch_device_t device) {
     krnlmon_log_error(
         "l3 free: SWITCH_HASHTABLE_DONE failed on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
   }
 
   status = switch_handle_type_free(device, SWITCH_HANDLE_TYPE_ROUTE);
@@ -136,8 +131,7 @@ switch_status_t switch_l3_free(switch_device_t device) {
     krnlmon_log_error(
         "l3 free: Failed to free SWITCH_HANDLE_TYPE_ROUTE on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
   }
 
   SWITCH_FREE(device, l3_ctx);
@@ -148,11 +142,10 @@ switch_status_t switch_l3_free(switch_device_t device) {
 }
 
 switch_status_t switch_route_table_hash_lookup(
-    switch_device_t device,
-    switch_route_entry_t *route_entry,
-    switch_handle_t *route_handle) {
-  switch_l3_context_t *l3_ctx = NULL;
-  switch_route_info_t *route_info = NULL;
+    switch_device_t device, switch_route_entry_t* route_entry,
+    switch_handle_t* route_handle) {
+  switch_l3_context_t* l3_ctx = NULL;
+  switch_route_info_t* route_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!route_entry) {
@@ -160,24 +153,22 @@ switch_status_t switch_route_table_hash_lookup(
     krnlmon_log_error(
         "route table lookup failed on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_L3, (void **)&l3_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_L3,
+                                         (void**)&l3_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "route table lookup: Failed to get device context on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
-  status = SWITCH_HASHTABLE_SEARCH(
-      &l3_ctx->route_hashtable, (void *)route_entry, (void **)&route_info);
+  status = SWITCH_HASHTABLE_SEARCH(&l3_ctx->route_hashtable, (void*)route_entry,
+                                   (void**)&route_info);
   if (status == SWITCH_STATUS_SUCCESS) {
     *route_handle = route_info->api_route_info.route_handle;
   }
@@ -187,9 +178,9 @@ switch_status_t switch_route_table_hash_lookup(
 
 switch_status_t switch_route_hashtable_insert(switch_device_t device,
                                               switch_handle_t route_handle) {
-  switch_l3_context_t *l3_ctx = NULL;
-  switch_route_info_t *route_info = NULL;
-  switch_route_entry_t *route_entry = NULL;
+  switch_l3_context_t* l3_ctx = NULL;
+  switch_route_info_t* route_info = NULL;
+  switch_route_entry_t* route_entry = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!SWITCH_ROUTE_HANDLE(route_handle)) {
@@ -197,9 +188,7 @@ switch_status_t switch_route_hashtable_insert(switch_device_t device,
     krnlmon_log_error(
         "route hashtable insert failed on device %d "
         ",route handle 0x%lx, error: %s\n",
-        device,
-        route_handle,
-        switch_error_to_string(status));
+        device, route_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -208,37 +197,30 @@ switch_status_t switch_route_hashtable_insert(switch_device_t device,
     krnlmon_log_error(
         "route hashtable insert: Failed to get route info on device %d "
         ",route handle 0x%lx, error: %s\n",
-        device,
-        route_handle,
-        switch_error_to_string(status));
+        device, route_handle, switch_error_to_string(status));
     return status;
   }
 
   route_entry = &route_info->route_entry;
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_L3, (void **)&l3_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_L3,
+                                         (void**)&l3_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "route hashtable insert failed on device %d "
         "route handle 0x%lx: l3 context get failed(%s)\n",
-        device,
-        route_handle,
-        switch_error_to_string(status));
+        device, route_handle, switch_error_to_string(status));
     return status;
   }
 
-  status = SWITCH_HASHTABLE_INSERT(&l3_ctx->route_hashtable,
-                                   &((route_info)->node),
-                                   (void *)route_entry,
-                                   (void *)(route_info));
+  status =
+      SWITCH_HASHTABLE_INSERT(&l3_ctx->route_hashtable, &((route_info)->node),
+                              (void*)route_entry, (void*)(route_info));
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "route hashtable insert failed on device %d "
         "route handle 0x%lx: hashtable insert failed(%s)\n",
-        device,
-        route_handle,
-        switch_error_to_string(status));
+        device, route_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -247,9 +229,9 @@ switch_status_t switch_route_hashtable_insert(switch_device_t device,
 
 switch_status_t switch_route_hashtable_remove(switch_device_t device,
                                               switch_handle_t route_handle) {
-  switch_l3_context_t *l3_ctx = NULL;
-  switch_route_info_t *route_info = NULL;
-  switch_route_entry_t *route_entry = NULL;
+  switch_l3_context_t* l3_ctx = NULL;
+  switch_route_info_t* route_info = NULL;
+  switch_route_entry_t* route_entry = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!SWITCH_ROUTE_HANDLE(route_handle)) {
@@ -257,9 +239,7 @@ switch_status_t switch_route_hashtable_remove(switch_device_t device,
     krnlmon_log_error(
         "route hashtable delete failed on device %d "
         "route handle 0x%lx: route handle invalid(%s)\n",
-        device,
-        route_handle,
-        switch_error_to_string(status));
+        device, route_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -268,35 +248,29 @@ switch_status_t switch_route_hashtable_remove(switch_device_t device,
     krnlmon_log_error(
         "route hashtable delete failed on device %d "
         "route handle 0x%lx: route get failed(%s)\n",
-        device,
-        route_handle,
-        switch_error_to_string(status));
+        device, route_handle, switch_error_to_string(status));
     return status;
   }
 
   route_entry = &route_info->route_entry;
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_L3, (void **)&l3_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_L3,
+                                         (void**)&l3_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "route hashtable delete failed on device %d "
         "route handle 0x%lx: l3 context get failed(%s)\n",
-        device,
-        route_handle,
-        switch_error_to_string(status));
+        device, route_handle, switch_error_to_string(status));
     return status;
   }
 
-  status = SWITCH_HASHTABLE_DELETE(
-      &l3_ctx->route_hashtable, (void *)route_entry, (void **)&route_info);
+  status = SWITCH_HASHTABLE_DELETE(&l3_ctx->route_hashtable, (void*)route_entry,
+                                   (void**)&route_info);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "route hashtable delete failed on device %d "
         "route handle 0x%lx: l3 hashtable delete failed(%s)\n",
-        device,
-        route_handle,
-        switch_error_to_string(status));
+        device, route_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -304,29 +278,27 @@ switch_status_t switch_route_hashtable_remove(switch_device_t device,
 }
 
 switch_status_t switch_api_l3_route_add(
-    switch_device_t device, switch_api_route_entry_t *api_route_entry) 
-{
+    switch_device_t device, switch_api_route_entry_t* api_route_entry) {
   switch_handle_t nhop_group_handle = SWITCH_API_INVALID_HANDLE;
   switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
-  switch_route_info_t *route_info = NULL;
-  switch_nhop_group_info_t *nhop_group_info = NULL;
+  switch_route_info_t* route_info = NULL;
+  switch_nhop_group_info_t* nhop_group_info = NULL;
   switch_route_entry_t route_entry;
   switch_handle_t route_handle = SWITCH_API_INVALID_HANDLE;
   switch_handle_t vrf_handle = SWITCH_API_INVALID_HANDLE;
   switch_handle_t nhop_default_group_handle = SWITCH_API_INVALID_HANDLE;
-  switch_nhop_member_t *nhop_member = NULL;
+  switch_nhop_member_t* nhop_member = NULL;
 
   if (!api_route_entry) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error(
         "l3 route table add failed on device %d "
         "parameters invalid(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
-  
+
   vrf_handle = api_route_entry->vrf_handle;
   if (!SWITCH_VRF_HANDLE(vrf_handle)) {
     status = SWITCH_STATUS_INVALID_HANDLE;
@@ -334,9 +306,7 @@ switch_status_t switch_api_l3_route_add(
         "l3 route table add failed on device %d "
         "vrf handle 0x%lx "
         "vrf handle invalid(%s)\n",
-        device,
-        vrf_handle,
-        switch_error_to_string(status));
+        device, vrf_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -352,9 +322,7 @@ switch_status_t switch_api_l3_route_add(
         "l3 route table add failed on device %d "
         "vrf handle 0x%lx "
         "route table lookup failed(%s)\n",
-        device,
-        vrf_handle,
-        switch_error_to_string(status));
+        device, vrf_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -363,8 +331,7 @@ switch_status_t switch_api_l3_route_add(
     krnlmon_log_error(
         "l3 route table add failed on device %d "
         "route handle create failed(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -373,59 +340,61 @@ switch_status_t switch_api_l3_route_add(
     krnlmon_log_error(
         "l3 route table add failed on device %d "
         "route get failed(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
   if (switch_handle_type_get(api_route_entry->nhop_handle) ==
-                       SWITCH_HANDLE_TYPE_NHOP) {
-    status = switch_api_get_default_nhop_group(device,
-                                               &nhop_default_group_handle);
+      SWITCH_HANDLE_TYPE_NHOP) {
+    status =
+        switch_api_get_default_nhop_group(device, &nhop_default_group_handle);
     if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error("Unable to get default NHOP group "
-                    ":%s \n", switch_error_to_string(status));
-        return status;
+      krnlmon_log_error(
+          "Unable to get default NHOP group "
+          ":%s \n",
+          switch_error_to_string(status));
+      return status;
     }
 
-    status = switch_nhop_member_get_from_nhop(
-                                        device,
-                                        nhop_default_group_handle,
-                                        api_route_entry->nhop_handle,
-                                        &nhop_member);
+    status = switch_nhop_member_get_from_nhop(device, nhop_default_group_handle,
+                                              api_route_entry->nhop_handle,
+                                              &nhop_member);
     if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error("Unable to get nhop member handle for nhop 0x%lx"
-                    ": %s \n", api_route_entry->nhop_handle,
-                    switch_error_to_string(status));
-        return status;
+      krnlmon_log_error(
+          "Unable to get nhop member handle for nhop 0x%lx"
+          ": %s \n",
+          api_route_entry->nhop_handle, switch_error_to_string(status));
+      return status;
     }
     api_route_entry->nhop_member_handle = nhop_member->member_handle;
     status = switch_pd_ipv4_table_entry(device, api_route_entry, true,
                                         SWITCH_ACTION_NHOP);
     if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error("ipv4 table update failed for NHOP action "
-                 ":%s \n", switch_error_to_string(status));
-        return status;
+      krnlmon_log_error(
+          "ipv4 table update failed for NHOP action "
+          ":%s \n",
+          switch_error_to_string(status));
+      return status;
     }
   } else if (switch_handle_type_get(api_route_entry->nhop_handle) ==
-                                   SWITCH_HANDLE_TYPE_NHOP_GROUP) {
+             SWITCH_HANDLE_TYPE_NHOP_GROUP) {
     status = switch_pd_ipv4_table_entry(device, api_route_entry, true,
                                         SWITCH_ACTION_NHOP_GROUP);
-    if(status != SWITCH_STATUS_SUCCESS) {
-      krnlmon_log_error("ipv4 table update failed for ECMP action"
-                ": %s\n", switch_error_to_string(status));
+    if (status != SWITCH_STATUS_SUCCESS) {
+      krnlmon_log_error(
+          "ipv4 table update failed for ECMP action"
+          ": %s\n",
+          switch_error_to_string(status));
       return status;
     }
   }
 
   api_route_entry->route_handle = handle;
-  SWITCH_MEMCPY(&route_info->api_route_info,
-                api_route_entry,
+  SWITCH_MEMCPY(&route_info->api_route_info, api_route_entry,
                 sizeof(switch_api_route_entry_t));
   route_info->route_entry.vrf_handle = vrf_handle;
   route_info->nhop_handle = api_route_entry->nhop_handle;
-  SWITCH_MEMCPY(&route_info->route_entry.ip,
-                &api_route_entry->ip_address,
+  SWITCH_MEMCPY(&route_info->route_entry.ip, &api_route_entry->ip_address,
                 sizeof(switch_ip_addr_t));
 
   status = switch_route_hashtable_insert(device, handle);
@@ -434,21 +403,18 @@ switch_status_t switch_api_l3_route_add(
         "l3 route table add failed on device %d "
         "vrf handle 0x%lx "
         "route table insert failed(%s)\n",
-        device,
-        vrf_handle,
-        switch_error_to_string(status));
+        device, vrf_handle, switch_error_to_string(status));
     return status;
   }
 
   return status;
 }
 
-switch_status_t switch_api_l3_delete_route(switch_device_t device,
-    switch_api_route_entry_t *api_route_entry) {
-
+switch_status_t switch_api_l3_delete_route(
+    switch_device_t device, switch_api_route_entry_t* api_route_entry) {
   switch_route_entry_t route_entry;
-  switch_nhop_group_info_t *nhop_group_info = NULL;
-  switch_route_info_t *route_info = NULL;
+  switch_nhop_group_info_t* nhop_group_info = NULL;
+  switch_route_info_t* route_info = NULL;
   switch_api_route_entry_t api_route_info;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   switch_handle_t nhop_group_handle = SWITCH_API_INVALID_HANDLE;
@@ -459,8 +425,7 @@ switch_status_t switch_api_l3_delete_route(switch_device_t device,
     krnlmon_log_error(
         "l3 route table delete failed on device %d "
         "parameters invalid(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -474,8 +439,7 @@ switch_status_t switch_api_l3_delete_route(switch_device_t device,
     krnlmon_log_error(
         "l3 route table delete failed on device %d "
         "route entry hash find failed(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -484,34 +448,34 @@ switch_status_t switch_api_l3_delete_route(switch_device_t device,
     krnlmon_log_error(
         "l3 route table delete failed on device %d "
         "route get failed(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
   api_route_info = route_info->api_route_info;
   if (route_info->nhop_handle) {
     if (switch_handle_type_get(api_route_info.nhop_handle) ==
-                               SWITCH_HANDLE_TYPE_NHOP_GROUP) {
+        SWITCH_HANDLE_TYPE_NHOP_GROUP) {
       nhop_group_handle = api_route_info.nhop_handle;
-      status = switch_nhop_get_group(device, nhop_group_handle, &nhop_group_info);
+      status =
+          switch_nhop_get_group(device, nhop_group_handle, &nhop_group_info);
       if (status != SWITCH_STATUS_SUCCESS) {
         krnlmon_log_error(
             "nhop_group info get failed on device %d nhop_group handle 0x%lx: "
             "nhop_group get Failed:(%s)\n",
-            device,
-            nhop_group_handle,
-            switch_error_to_string(status));
+            device, nhop_group_handle, switch_error_to_string(status));
         return status;
       }
     }
 
-    status = switch_pd_ipv4_table_entry(device, &api_route_info,
-                                        false, SWITCH_ACTION_NONE);
+    status = switch_pd_ipv4_table_entry(device, &api_route_info, false,
+                                        SWITCH_ACTION_NONE);
     SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
-    if(status != SWITCH_STATUS_SUCCESS)
-      krnlmon_log_error("ipv4 table delete failed, error"
-                ": %s\n", switch_error_to_string(status));
+    if (status != SWITCH_STATUS_SUCCESS)
+      krnlmon_log_error(
+          "ipv4 table delete failed, error"
+          ": %s\n",
+          switch_error_to_string(status));
   }
 
   status = switch_route_hashtable_remove(device, route_handle);
@@ -519,8 +483,7 @@ switch_status_t switch_api_l3_delete_route(switch_device_t device,
     krnlmon_log_error(
         "l3 route table delete failed on device %d "
         "route table delete failed(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 

--- a/switchapi/dpdk/switch_neighbor.c
+++ b/switchapi/dpdk/switch_neighbor.c
@@ -16,47 +16,43 @@
  */
 
 #include "switchapi/switch_neighbor.h"
-#include "switchapi/switch_neighbor_int.h"
 
+#include "switch_pd_fdb.h"
+#include "switch_pd_utils.h"
 #include "switchapi/switch_fdb.h"
 #include "switchapi/switch_internal.h"
+#include "switchapi/switch_neighbor_int.h"
 #include "switchapi/switch_nhop.h"
 #include "switchapi/switch_nhop_int.h"
 #include "switchapi/switch_rif_int.h"
 #include "switchapi/switch_rmac_int.h"
 
-#include "switch_pd_utils.h"
-#include "switch_pd_fdb.h"
-
 switch_status_t switch_neighbor_init(switch_device_t device) {
-  switch_neighbor_context_t *neighbor_ctx = NULL;
+  switch_neighbor_context_t* neighbor_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   neighbor_ctx = SWITCH_MALLOC(device, sizeof(switch_neighbor_context_t), 0x1);
   if (!neighbor_ctx) {
     status = SWITCH_STATUS_NO_MEMORY;
-    krnlmon_log_error("neighbor init failed for device %d: %s\n",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("neighbor init failed for device %d: %s\n", device,
+                      switch_error_to_string(status));
     return status;
   }
 
-  status = switch_device_api_context_set(
-      device, SWITCH_API_TYPE_NEIGHBOR, (void *)neighbor_ctx);
+  status = switch_device_api_context_set(device, SWITCH_API_TYPE_NEIGHBOR,
+                                         (void*)neighbor_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("neighbor init failed for device %d: %s\n",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("neighbor init failed for device %d: %s\n", device,
+                      switch_error_to_string(status));
     return status;
   }
 
-  status = switch_handle_type_init(
-      device, SWITCH_HANDLE_TYPE_NEIGHBOR, NEIGHBOR_MOD_TABLE_SIZE);
+  status = switch_handle_type_init(device, SWITCH_HANDLE_TYPE_NEIGHBOR,
+                                   NEIGHBOR_MOD_TABLE_SIZE);
 
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("neighbor init failed for device %d: %s\n",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("neighbor init failed for device %d: %s\n", device,
+                      switch_error_to_string(status));
     goto cleanup;
   }
 
@@ -69,25 +65,23 @@ cleanup:
 }
 
 switch_status_t switch_neighbor_free(switch_device_t device) {
-  switch_neighbor_context_t *neighbor_ctx = NULL;
+  switch_neighbor_context_t* neighbor_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_NEIGHBOR, (void **)&neighbor_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_NEIGHBOR,
+                                         (void**)&neighbor_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("neighbor free failed for device %d: %s\n",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("neighbor free failed for device %d: %s\n", device,
+                      switch_error_to_string(status));
     return status;
   }
-  
+
   status = switch_handle_type_free(device, SWITCH_HANDLE_TYPE_NEIGHBOR);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("neighbor free failed for device %d: %s\n",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("neighbor free failed for device %d: %s\n", device,
+                      switch_error_to_string(status));
   }
-  
+
   SWITCH_FREE(device, neighbor_ctx);
   status =
       switch_device_api_context_set(device, SWITCH_API_TYPE_NEIGHBOR, NULL);
@@ -97,20 +91,19 @@ switch_status_t switch_neighbor_free(switch_device_t device) {
 }
 
 switch_status_t switch_api_neighbor_create(
-    switch_device_t device,
-    switch_api_neighbor_info_t *api_neighbor_info,
-    switch_handle_t *neighbor_handle) {
-  switch_neighbor_info_t *neighbor_info = NULL;
+    switch_device_t device, switch_api_neighbor_info_t* api_neighbor_info,
+    switch_handle_t* neighbor_handle) {
+  switch_neighbor_info_t* neighbor_info = NULL;
   switch_handle_t nhop_handle = SWITCH_API_INVALID_HANDLE;
-  switch_nhop_info_t *nhop_info = NULL;
+  switch_nhop_info_t* nhop_info = NULL;
   switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   switch_pd_routing_info_t pd_neighbor_info;
-  switch_rif_info_t *rif_info = NULL;
+  switch_rif_info_t* rif_info = NULL;
   switch_handle_t rmac_handle = SWITCH_API_INVALID_HANDLE;
-  switch_rmac_info_t *rmac_info = NULL;
-  switch_rmac_entry_t *rmac_entry = NULL;
-  switch_node_t *node = NULL;
+  switch_rmac_info_t* rmac_info = NULL;
+  switch_rmac_entry_t* rmac_entry = NULL;
+  switch_node_t* node = NULL;
 
   memset(&pd_neighbor_info, 0, sizeof(switch_pd_routing_info_t));
 
@@ -119,8 +112,7 @@ switch_status_t switch_api_neighbor_create(
     krnlmon_log_error(
         "neighbor create failed on device %d: "
         "neighbor info invalid:(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -129,9 +121,7 @@ switch_status_t switch_api_neighbor_create(
     krnlmon_log_error(
         "neighbor create failed on device %d nhop handle 0x%lx: "
         "nhop handle invalid:(%s)\n",
-        device,
-        api_neighbor_info->nhop_handle,
-        switch_error_to_string(status));
+        device, api_neighbor_info->nhop_handle, switch_error_to_string(status));
     return status;
   }
   nhop_handle = api_neighbor_info->nhop_handle;
@@ -142,8 +132,7 @@ switch_status_t switch_api_neighbor_create(
     krnlmon_log_error(
         "neighbor create failed on device %d: "
         "handle create failed:(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -152,8 +141,7 @@ switch_status_t switch_api_neighbor_create(
     krnlmon_log_error(
         "neighbor create failed on device %d: "
         "neighbor get failed:(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -163,80 +151,77 @@ switch_status_t switch_api_neighbor_create(
 
   neighbor_info->neighbor_handle = handle;
   neighbor_info->nhop_handle = nhop_handle;
-  SWITCH_MEMCPY(&neighbor_info->api_neighbor_info,
-                api_neighbor_info,
+  SWITCH_MEMCPY(&neighbor_info->api_neighbor_info, api_neighbor_info,
                 sizeof(switch_api_neighbor_info_t));
 
   *neighbor_handle = handle;
 
-  if((nhop_handle && handle))
-  {
-      pd_neighbor_info.neighbor_handle = handle;
-      pd_neighbor_info.nexthop_handle = nhop_handle;
+  if ((nhop_handle && handle)) {
+    pd_neighbor_info.neighbor_handle = handle;
+    pd_neighbor_info.nexthop_handle = nhop_handle;
 
-      /*get rif_info to access port_id */
-      pd_neighbor_info.rif_handle = api_neighbor_info->rif_handle;
-      status = switch_rif_get(device, pd_neighbor_info.rif_handle, &rif_info);
-      CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
-      if (rif_info->api_rif_info.phy_port_id == -1) {
-        switch_pd_to_get_port_id(&(rif_info->api_rif_info));
+    /*get rif_info to access port_id */
+    pd_neighbor_info.rif_handle = api_neighbor_info->rif_handle;
+    status = switch_rif_get(device, pd_neighbor_info.rif_handle, &rif_info);
+    CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
+    if (rif_info->api_rif_info.phy_port_id == -1) {
+      switch_pd_to_get_port_id(&(rif_info->api_rif_info));
+    }
+    pd_neighbor_info.port_id = rif_info->api_rif_info.phy_port_id;
+
+    SWITCH_MEMCPY(&pd_neighbor_info.dst_mac_addr, &api_neighbor_info->mac_addr,
+                  sizeof(switch_mac_addr_t));
+
+    status = switch_routing_table_entry(device, &pd_neighbor_info, true);
+    if (status != SWITCH_STATUS_SUCCESS) {
+      krnlmon_log_error("routing tables update failed \n");
+      return status;
+    }
+
+    /*rmac_handle will have source mac info. get rmac_info from rmac_handle */
+    rmac_handle = rif_info->api_rif_info.rmac_handle;
+    status = switch_rmac_get(device, rmac_handle, &rmac_info);
+    CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
+    SWITCH_LIST_GET_HEAD(rmac_info->rmac_list, node);
+    rmac_entry = (switch_rmac_entry_t*)node->data;
+
+    /* SRC MAC is picked from RMAC of RIF entry. This needs to be programmed
+     * only once, even though many neighbors learnt on same RIF. */
+    if (rmac_entry && !rmac_entry->is_rmac_pd_programmed) {
+      switch_api_l2_info_t api_l2_rx_info;
+      api_l2_rx_info.rif_handle = api_neighbor_info->rif_handle;
+      SWITCH_MEMCPY(&api_l2_rx_info.dst_mac, &(rmac_entry->mac),
+                    sizeof(switch_mac_addr_t));
+
+      status =
+          switch_pd_l2_rx_forward_table_entry(device, &api_l2_rx_info, true);
+      if (status != SWITCH_STATUS_SUCCESS) {
+        return status;
       }
-      pd_neighbor_info.port_id = rif_info->api_rif_info.phy_port_id;
 
-      SWITCH_MEMCPY(&pd_neighbor_info.dst_mac_addr,
-                    &api_neighbor_info->mac_addr, sizeof(switch_mac_addr_t));
-
-      status = switch_routing_table_entry(device, &pd_neighbor_info, true);
+      status = switch_pd_rmac_table_entry(device, rmac_entry,
+                                          api_neighbor_info->rif_handle, true);
       if (status != SWITCH_STATUS_SUCCESS) {
         krnlmon_log_error("routing tables update failed \n");
         return status;
       }
 
-      /*rmac_handle will have source mac info. get rmac_info from rmac_handle */
-      rmac_handle = rif_info->api_rif_info.rmac_handle;
-      status = switch_rmac_get(device, rmac_handle, &rmac_info);
-      CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
-      SWITCH_LIST_GET_HEAD(rmac_info->rmac_list, node);
-      rmac_entry = (switch_rmac_entry_t *)node->data;
-
-      /* SRC MAC is picked from RMAC of RIF entry. This needs to be programmed
-       * only once, even though many neighbors learnt on same RIF. */
-      if (rmac_entry && !rmac_entry->is_rmac_pd_programmed) {
-          switch_api_l2_info_t api_l2_rx_info;
-          api_l2_rx_info.rif_handle = api_neighbor_info->rif_handle;
-          SWITCH_MEMCPY(&api_l2_rx_info.dst_mac, &(rmac_entry->mac),
-                        sizeof(switch_mac_addr_t));
-
-          status = switch_pd_l2_rx_forward_table_entry(device, &api_l2_rx_info,
-                                                       true);
-          if (status != SWITCH_STATUS_SUCCESS) {
-            return status;
-          }
-
-          status = switch_pd_rmac_table_entry(device, rmac_entry,
-                                           api_neighbor_info->rif_handle, true);
-          if (status != SWITCH_STATUS_SUCCESS) {
-              krnlmon_log_error("routing tables update failed \n");
-              return status;
-          }
-
-          rmac_entry->is_rmac_pd_programmed = true;
-      }
+      rmac_entry->is_rmac_pd_programmed = true;
+    }
   }
 
-  SWITCH_MEMCPY(&neighbor_info->switch_pd_routing_info,
-                &pd_neighbor_info,
+  SWITCH_MEMCPY(&neighbor_info->switch_pd_routing_info, &pd_neighbor_info,
                 sizeof(switch_pd_routing_info_t));
-  krnlmon_log_info(
-      "neighbor created on device %d neighbor handle 0x%lx\n", device, handle);
+  krnlmon_log_info("neighbor created on device %d neighbor handle 0x%lx\n",
+                   device, handle);
 
   return status;
 }
 
-switch_status_t switch_api_neighbor_delete(
-    switch_device_t device, switch_handle_t neighbor_handle) {
-  switch_neighbor_info_t *neighbor_info = NULL;
-  switch_api_neighbor_info_t *api_neighbor_info = NULL;
+switch_status_t switch_api_neighbor_delete(switch_device_t device,
+                                           switch_handle_t neighbor_handle) {
+  switch_neighbor_info_t* neighbor_info = NULL;
+  switch_api_neighbor_info_t* api_neighbor_info = NULL;
   switch_handle_t nhop_handle = SWITCH_API_INVALID_HANDLE;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
@@ -245,9 +230,7 @@ switch_status_t switch_api_neighbor_delete(
     krnlmon_log_error(
         "neighbor delete failed on device %d neighbor handle 0x%lx: "
         "neighbor handle invalid(%s)\n",
-        device,
-        neighbor_handle,
-        switch_error_to_string(status));
+        device, neighbor_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -256,9 +239,7 @@ switch_status_t switch_api_neighbor_delete(
     krnlmon_log_error(
         "neighbor delete failed on device %d neighbor handle 0x%lx: "
         "neighbor get failed(%s)\n",
-        device,
-        neighbor_handle,
-        switch_error_to_string(status));
+        device, neighbor_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -266,10 +247,9 @@ switch_status_t switch_api_neighbor_delete(
   api_neighbor_info = &neighbor_info->api_neighbor_info;
 
   if (SWITCH_NHOP_HANDLE(nhop_handle)) {
-    status = switch_routing_table_entry(device,
-                                        &neighbor_info->switch_pd_routing_info,
-                                        false);
-    if(status != SWITCH_STATUS_SUCCESS)
+    status = switch_routing_table_entry(
+        device, &neighbor_info->switch_pd_routing_info, false);
+    if (status != SWITCH_STATUS_SUCCESS)
       krnlmon_log_error("routing tables update failed \n");
   }
 
@@ -277,8 +257,7 @@ switch_status_t switch_api_neighbor_delete(
   SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
 
   krnlmon_log_info("neighbor deleted on device %d neighbor handle 0x%lx\n",
-             device,
-             neighbor_handle);
+                   device, neighbor_handle);
 
   return status;
 }

--- a/switchapi/dpdk/switch_neighbor.c
+++ b/switchapi/dpdk/switch_neighbor.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/dpdk/switch_nhop.c
+++ b/switchapi/dpdk/switch_nhop.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/dpdk/switch_nhop.c
+++ b/switchapi/dpdk/switch_nhop.c
@@ -16,21 +16,19 @@
  */
 
 #include "switchapi/switch_nhop.h"
-#include "switchapi/switch_nhop_int.h"
 
+#include "switch_pd_routing.h"
 #include "switchapi/switch_handle_int.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_neighbor_int.h"
-#include "switchapi/switch_rif_int.h"
+#include "switchapi/switch_nhop_int.h"
 #include "switchapi/switch_rif.h"
+#include "switchapi/switch_rif_int.h"
 
-#include "switch_pd_routing.h"
-
-//add corresponding delete functions
+// add corresponding delete functions
 
 switch_status_t switch_nhop_add_to_group_member_list(
-    switch_device_t device,
-    switch_nhop_info_t *nhop_info,
+    switch_device_t device, switch_nhop_info_t* nhop_info,
     switch_handle_t nhop_mem_handle) {
   PWord_t PValue;
 
@@ -39,9 +37,7 @@ switch_status_t switch_nhop_add_to_group_member_list(
     krnlmon_log_error(
         "nhop add nhop member Failed on device %d, "
         "nhop handle 0x%lx: , nhop mem handle 0x%lx\n",
-        device,
-        nhop_info->nhop_handle,
-        nhop_mem_handle);
+        device, nhop_info->nhop_handle, nhop_mem_handle);
     return SWITCH_STATUS_FAILURE;
   }
 
@@ -49,9 +45,7 @@ switch_status_t switch_nhop_add_to_group_member_list(
   krnlmon_log_info(
       "nhop add nhop member success on device %d, "
       "nhop handle 0x%lx: , nhop mem handle 0x%lx: ref_cnt: %d\n",
-      device,
-      nhop_info->nhop_handle,
-      nhop_mem_handle,
+      device, nhop_info->nhop_handle, nhop_mem_handle,
       SWITCH_NHOP_NUM_NHOP_MEMBER_REF(nhop_info));
 
   return SWITCH_STATUS_SUCCESS;
@@ -60,23 +54,21 @@ switch_status_t switch_nhop_add_to_group_member_list(
 switch_status_t switch_nhop_member_handle_init(switch_device_t device) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
-  status = switch_handle_type_init(
-      device, SWITCH_HANDLE_TYPE_NHOP_MEMBER, NHOP_MEMBER_HASH_TABLE_SIZE);
+  status = switch_handle_type_init(device, SWITCH_HANDLE_TYPE_NHOP_MEMBER,
+                                   NHOP_MEMBER_HASH_TABLE_SIZE);
 
   if (status != SWITCH_STATUS_SUCCESS) {
-     krnlmon_log_error("nhop member handle init Failed for device %d: %s\n",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("nhop member handle init Failed for device %d: %s\n",
+                      device, switch_error_to_string(status));
     return status;
   }
 
   return SWITCH_STATUS_SUCCESS;
 }
 
-switch_status_t switch_nhop_hash_key_init(void *args,
-                                          switch_uint8_t *key,
-                                          switch_uint32_t *len) {
-  switch_nhop_key_t *nhop_key = NULL;
+switch_status_t switch_nhop_hash_key_init(void* args, switch_uint8_t* key,
+                                          switch_uint32_t* len) {
+  switch_nhop_key_t* nhop_key = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!args || !key || !len) {
@@ -84,7 +76,7 @@ switch_status_t switch_nhop_hash_key_init(void *args,
     return status;
   }
 
-  nhop_key = (switch_nhop_key_t *)args;
+  nhop_key = (switch_nhop_key_t*)args;
   *len = 0;
 
   SWITCH_MEMCPY((key + *len), &nhop_key->handle, sizeof(switch_handle_t));
@@ -101,53 +93,52 @@ switch_status_t switch_nhop_hash_key_init(void *args,
   return status;
 }
 
-switch_int32_t switch_nhop_hash_compare(const void *key1, const void *key2) {
-  switch_nhop_info_t *nhop_info = (switch_nhop_info_t *) key2;
+switch_int32_t switch_nhop_hash_compare(const void* key1, const void* key2) {
+  switch_nhop_info_t* nhop_info = (switch_nhop_info_t*)key2;
   switch_nhop_key_t nhop_key;
 
   SWITCH_MEMSET(&nhop_key, 0x0, sizeof(switch_nhop_key_t));
 
   if (nhop_info) {
-      SWITCH_MEMCPY(&nhop_key, &nhop_info->spath.nhop_key,
-                    sizeof(switch_nhop_key_t));
+    SWITCH_MEMCPY(&nhop_key, &nhop_info->spath.nhop_key,
+                  sizeof(switch_nhop_key_t));
   }
 
   return SWITCH_MEMCMP(key1, &nhop_key, SWITCH_NHOP_HASH_KEY_SIZE);
 }
 
 switch_status_t switch_nhop_init(switch_device_t device) {
-  switch_nhop_context_t *nhop_ctx = NULL;
+  switch_nhop_context_t* nhop_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   nhop_ctx = SWITCH_MALLOC(device, sizeof(switch_nhop_context_t), 0x1);
   if (!nhop_ctx) {
     status = SWITCH_STATUS_NO_MEMORY;
-    krnlmon_log_error("nhop init: Failed to allocate memory for switch_nhop_context_t"
-             " for device %d, error: %s\n",
-             device,
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "nhop init: Failed to allocate memory for switch_nhop_context_t"
+        " for device %d, error: %s\n",
+        device, switch_error_to_string(status));
     return status;
   }
 
-  status = switch_device_api_context_set(
-      device, SWITCH_API_TYPE_NHOP, (void *)nhop_ctx);
+  status = switch_device_api_context_set(device, SWITCH_API_TYPE_NHOP,
+                                         (void*)nhop_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("nhop init: Failed to set device api context for device %d,"
-             " error: %s\n",
-             device,
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "nhop init: Failed to set device api context for device %d,"
+        " error: %s\n",
+        device, switch_error_to_string(status));
     return status;
   }
-  
+
   nhop_ctx->nhop_hashtable.size = NEXTHOP_TABLE_SIZE;
   nhop_ctx->nhop_hashtable.compare_func = switch_nhop_hash_compare;
   nhop_ctx->nhop_hashtable.key_func = switch_nhop_hash_key_init;
   nhop_ctx->nhop_hashtable.hash_seed = SWITCH_NHOP_HASH_SEED;
-  
+
   status = SWITCH_HASHTABLE_INIT(&nhop_ctx->nhop_hashtable);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("nhop init Failed for device %d\n",
-                     device);
+    krnlmon_log_error("nhop init Failed for device %d\n", device);
     return status;
   }
 
@@ -155,8 +146,7 @@ switch_status_t switch_nhop_init(switch_device_t device) {
                                    NEXTHOP_TABLE_SIZE);
 
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("nhop init Failed for device %d\n",
-                     device);
+    krnlmon_log_error("nhop init Failed for device %d\n", device);
     return status;
   }
 
@@ -164,73 +154,65 @@ switch_status_t switch_nhop_init(switch_device_t device) {
                                    NHOP_GROUP_HASH_TABLE_SIZE);
 
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("NHOP group init Failed for device %d\n",
-                     device);
+    krnlmon_log_error("NHOP group init Failed for device %d\n", device);
     return status;
   }
 
   status = switch_nhop_member_handle_init(device);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("nhop member init Failed for device %d: %s\n",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("nhop member init Failed for device %d: %s\n", device,
+                      switch_error_to_string(status));
     return status;
   }
-  
+
   return SWITCH_STATUS_SUCCESS;
 }
 
 switch_status_t switch_nhop_free(switch_device_t device) {
-  switch_nhop_context_t *nhop_ctx = NULL;
+  switch_nhop_context_t* nhop_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_NHOP, (void **)&nhop_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_NHOP,
+                                         (void**)&nhop_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("nhop free Failed for device %d\n",
-                     device);
+    krnlmon_log_error("nhop free Failed for device %d\n", device);
     return status;
   }
 
   status = SWITCH_HASHTABLE_DONE(&nhop_ctx->nhop_hashtable);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("nhop free Failed for device %d: , error: %s\n",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("nhop free Failed for device %d: , error: %s\n", device,
+                      switch_error_to_string(status));
   }
 
   status = switch_handle_type_free(device, SWITCH_HANDLE_TYPE_NHOP);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("nhop free Failed for device %d\n",
-                     device);
+    krnlmon_log_error("nhop free Failed for device %d\n", device);
   }
 
   status = switch_handle_type_free(device, SWITCH_HANDLE_TYPE_NHOP_GROUP);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("NHOP group free Failed for device %d\n",
-                     device);
+    krnlmon_log_error("NHOP group free Failed for device %d\n", device);
   }
 
   status = switch_handle_type_free(device, SWITCH_HANDLE_TYPE_NHOP_MEMBER);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("nhop free Failed for device %d: %s\n",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("nhop free Failed for device %d: %s\n", device,
+                      switch_error_to_string(status));
     return status;
   }
-  
+
   SWITCH_FREE(device, nhop_ctx);
   status = switch_device_api_context_set(device, SWITCH_API_TYPE_NHOP, NULL);
   SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
   return status;
 }
 
-switch_status_t switch_api_nhop_handle_get(
-    const switch_device_t device,
-    const switch_nhop_key_t *nhop_key,
-    switch_handle_t *nhop_handle) {
-  switch_nhop_context_t *nhop_ctx = NULL;
-  switch_nhop_info_t *nhop_info = NULL;
+switch_status_t switch_api_nhop_handle_get(const switch_device_t device,
+                                           const switch_nhop_key_t* nhop_key,
+                                           switch_handle_t* nhop_handle) {
+  switch_nhop_context_t* nhop_ctx = NULL;
+  switch_nhop_info_t* nhop_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!nhop_key || !nhop_handle) {
@@ -239,15 +221,15 @@ switch_status_t switch_api_nhop_handle_get(
     return status;
   }
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_NHOP, (void **)&nhop_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_NHOP,
+                                         (void**)&nhop_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error("nhop_key find Failed \n");
     return status;
   }
 
-  status = SWITCH_HASHTABLE_SEARCH(
-      &nhop_ctx->nhop_hashtable, (void *)nhop_key, (void **)&nhop_info);
+  status = SWITCH_HASHTABLE_SEARCH(&nhop_ctx->nhop_hashtable, (void*)nhop_key,
+                                   (void**)&nhop_info);
   if (status == SWITCH_STATUS_SUCCESS) {
     *nhop_handle = nhop_info->nhop_handle;
   } else {
@@ -257,22 +239,19 @@ switch_status_t switch_api_nhop_handle_get(
   return status;
 }
 
-switch_status_t switch_api_neighbor_handle_get (
-    const switch_device_t device,
-    const switch_handle_t nhop_handle,
-    switch_handle_t *neighbor_handle) {
-  switch_nhop_info_t *nhop_info = NULL;
-  switch_spath_info_t *spath_info = NULL;
+switch_status_t switch_api_neighbor_handle_get(
+    const switch_device_t device, const switch_handle_t nhop_handle,
+    switch_handle_t* neighbor_handle) {
+  switch_nhop_info_t* nhop_info = NULL;
+  switch_spath_info_t* spath_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
-  
+
   if (!SWITCH_NHOP_HANDLE(nhop_handle)) {
     status = SWITCH_STATUS_INVALID_HANDLE;
     krnlmon_log_error(
         "neighbor handle get Failed for "
         "device %d handle 0x%lx: %s\n",
-        device,
-        nhop_handle,
-        switch_error_to_string(status));
+        device, nhop_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -282,9 +261,7 @@ switch_status_t switch_api_neighbor_handle_get (
     krnlmon_log_error(
         "neighbor handle get Failed for "
         "device %d handle 0x%lx: %s\n",
-        device,
-        nhop_handle,
-        switch_error_to_string(status));
+        device, nhop_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -294,9 +271,9 @@ switch_status_t switch_api_neighbor_handle_get (
   return status;
 }
 
-switch_status_t switch_api_create_nhop_group(const switch_device_t device,
-                                         switch_handle_t *nhop_group_handle) {
-  switch_nhop_group_info_t *nhop_group_info = NULL;
+switch_status_t switch_api_create_nhop_group(
+    const switch_device_t device, switch_handle_t* nhop_group_handle) {
+  switch_nhop_group_info_t* nhop_group_info = NULL;
   switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
@@ -306,8 +283,7 @@ switch_status_t switch_api_create_nhop_group(const switch_device_t device,
     krnlmon_log_error(
         "nhop create Failed on device %d "
         "handle create Failed:(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -316,8 +292,7 @@ switch_status_t switch_api_create_nhop_group(const switch_device_t device,
     krnlmon_log_error(
         "nhop group create Failed on device %d "
         "nhop group get Failed:(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -330,24 +305,22 @@ switch_status_t switch_api_create_nhop_group(const switch_device_t device,
 
   *nhop_group_handle = handle;
 
-  krnlmon_log_info("nhop group handle created on device %d nhop group handle 0x%lx\n",
-                   device,
-                   *nhop_group_handle);
+  krnlmon_log_info(
+      "nhop group handle created on device %d nhop group handle 0x%lx\n",
+      device, *nhop_group_handle);
 
   return status;
 }
 
-switch_status_t switch_api_add_nhop_member (
-    const switch_device_t device,
-    const switch_handle_t nhop_group_handle,
-    const switch_uint32_t num_nhops,
-    const switch_handle_t *nhop_handles,
-    switch_handle_t *member_handle) {
+switch_status_t switch_api_add_nhop_member(
+    const switch_device_t device, const switch_handle_t nhop_group_handle,
+    const switch_uint32_t num_nhops, const switch_handle_t* nhop_handles,
+    switch_handle_t* member_handle) {
   switch_uint32_t index = 0;
   switch_handle_t nhop_handle = 0;
-  switch_nhop_group_info_t *nhop_group_info = NULL;
-  switch_nhop_info_t *nhop_info = NULL;
-  switch_nhop_member_t *nhop_member = NULL;
+  switch_nhop_group_info_t* nhop_group_info = NULL;
+  switch_nhop_info_t* nhop_info = NULL;
+  switch_nhop_member_t* nhop_member = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   switch_handle_t nhop_member_handle = SWITCH_API_INVALID_HANDLE;
 
@@ -356,9 +329,7 @@ switch_status_t switch_api_add_nhop_member (
     krnlmon_log_error(
         "nhop member add Failed on device %d nhop group handle 0x%lx: "
         "parameters invalid:(%s)\n",
-        device,
-        nhop_group_handle,
-        switch_error_to_string(status));
+        device, nhop_group_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -368,9 +339,7 @@ switch_status_t switch_api_add_nhop_member (
     krnlmon_log_error(
         "nhop member add Failed on device %d nhop group handle 0x%lx: "
         "nhop group get Failed:(%s)\n",
-        device,
-        nhop_group_handle,
-        switch_error_to_string(status));
+        device, nhop_group_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -385,9 +354,7 @@ switch_status_t switch_api_add_nhop_member (
           "nhop member add Failed on device %d nhop group handle 0x%lx "
           "nhop handle 0x%lx: "
           "nhop get Failed:(%s)\n",
-          device,
-          nhop_group_handle,
-          nhop_handle,
+          device, nhop_group_handle, nhop_handle,
           switch_error_to_string(status));
       return status;
     }
@@ -399,9 +366,7 @@ switch_status_t switch_api_add_nhop_member (
           "nhop member add Failed on device %d nhop group handle 0x%lx "
           "nhop handle 0x%lx: "
           "nhop member create Failed:(%s)\n",
-          device,
-          nhop_group_handle,
-          nhop_handle,
+          device, nhop_group_handle, nhop_handle,
           switch_error_to_string(status));
       return status;
     }
@@ -412,9 +377,7 @@ switch_status_t switch_api_add_nhop_member (
           "nhop member add Failed on device %d nhop group handle 0x%lx "
           "nhop handle 0x%lx: "
           "nhop member get Failed:(%s)\n",
-          device,
-          nhop_group_handle,
-          nhop_handle,
+          device, nhop_group_handle, nhop_handle,
           switch_error_to_string(status));
       return status;
     }
@@ -425,17 +388,17 @@ switch_status_t switch_api_add_nhop_member (
     nhop_member->nhop_handle = nhop_handle;
     nhop_member->active = true;
 
-    status = SWITCH_LIST_INSERT(
-        &(nhop_group_info->members), &(nhop_member->node), nhop_member);
+    status = SWITCH_LIST_INSERT(&(nhop_group_info->members),
+                                &(nhop_member->node), nhop_member);
     SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
 
     status = switch_pd_handle_member(device, nhop_member, true);
     if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error("switch_pd_handle_member: Failed to create platform "
-                 "dependent action selector member entry %d: ,error :(%s)\n",
-                 device,
-                 switch_error_to_string(status));
-        return status;
+      krnlmon_log_error(
+          "switch_pd_handle_member: Failed to create platform "
+          "dependent action selector member entry %d: ,error :(%s)\n",
+          device, switch_error_to_string(status));
+      return status;
     }
 
     /* TODO: Since target doesnt support modify of members in groups, we delete
@@ -444,36 +407,31 @@ switch_status_t switch_api_add_nhop_member (
      */
     status = switch_pd_handle_group(device, nhop_group_info, false);
     if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error(
-            "switch_api_add_nhop_member: Failed to create platform dependent"
-            " nhop selector entry %d: ,error :(%s)\n",
-            device,
-            switch_error_to_string(status));
-        return status;
+      krnlmon_log_error(
+          "switch_api_add_nhop_member: Failed to create platform dependent"
+          " nhop selector entry %d: ,error :(%s)\n",
+          device, switch_error_to_string(status));
+      return status;
     }
 
     status = switch_pd_handle_group(device, nhop_group_info, true);
     if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error(
-            "switch_api_add_nhop_member: Failed to create platform dependent"
-            " nhop selector entry %d: ,error :(%s)\n",
-            device,
-            switch_error_to_string(status));
-        return status;
+      krnlmon_log_error(
+          "switch_api_add_nhop_member: Failed to create platform dependent"
+          " nhop selector entry %d: ,error :(%s)\n",
+          device, switch_error_to_string(status));
+      return status;
     }
 
-    status =
-        switch_nhop_add_to_group_member_list(device, nhop_info,
-                                             nhop_member_handle);
+    status = switch_nhop_add_to_group_member_list(device, nhop_info,
+                                                  nhop_member_handle);
     if (status != SWITCH_STATUS_SUCCESS) {
       krnlmon_log_error(
           "Failed to add nhop member_handle to nhop , device %d"
           " nhop handle 0x%lx: "
           " nhop_member_handle: 0x%lx"
           " with status (%s)\n",
-          device,
-          nhop_info->nhop_handle,
-          nhop_member_handle,
+          device, nhop_info->nhop_handle, nhop_member_handle,
           switch_error_to_string(status));
       return status;
     }
@@ -483,21 +441,19 @@ switch_status_t switch_api_add_nhop_member (
    * based on number of nhops here update the table for each hash-nhop entry */
   krnlmon_log_info(
       "nhop member add on device %d nhop_group handle 0x%lx num nhops %d\n",
-      device,
-      nhop_group_handle,
-      num_nhops);
+      device, nhop_group_handle, num_nhops);
 
   return status;
 }
 
-switch_status_t switch_api_delete_nhop_group(const switch_device_t device,
-                                       const switch_handle_t nhop_group_handle) {
+switch_status_t switch_api_delete_nhop_group(
+    const switch_device_t device, const switch_handle_t nhop_group_handle) {
   switch_uint32_t index = 0;
-  switch_node_t *node = NULL;
+  switch_node_t* node = NULL;
   switch_uint32_t num_nhops = 0;
-  switch_handle_t *nhop_handles = NULL;
-  switch_nhop_group_info_t *nhop_group_info = NULL;
-  switch_nhop_member_t *nhop_member = NULL;
+  switch_handle_t* nhop_handles = NULL;
+  switch_nhop_group_info_t* nhop_group_info = NULL;
+  switch_nhop_member_t* nhop_member = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!SWITCH_NHOP_GROUP_HANDLE(nhop_group_handle)) {
@@ -505,9 +461,7 @@ switch_status_t switch_api_delete_nhop_group(const switch_device_t device,
     krnlmon_log_error(
         "nhop_group delete failed on device %d nhop_group handle 0x%lx: "
         "nhop_group handle invalid:(%s)\n",
-        device,
-        nhop_group_handle,
-        switch_error_to_string(status));
+        device, nhop_group_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -516,9 +470,7 @@ switch_status_t switch_api_delete_nhop_group(const switch_device_t device,
     krnlmon_log_error(
         "nhop_group delete failed on device %d nhop_group handle 0x%lx: "
         "nhop_group get failed:(%s)\n",
-        device,
-        nhop_group_handle,
-        switch_error_to_string(status));
+        device, nhop_group_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -531,14 +483,12 @@ switch_status_t switch_api_delete_nhop_group(const switch_device_t device,
       krnlmon_log_error(
           "nhop_group delete failed on device %d nhop_group handle 0x%lx: "
           "memory allocation failed:(%s)\n",
-          device,
-          nhop_group_handle,
-          switch_error_to_string(status));
+          device, nhop_group_handle, switch_error_to_string(status));
       return status;
     }
 
     FOR_EACH_IN_LIST(nhop_group_info->members, node) {
-      nhop_member = (switch_nhop_member_t *)node->data;
+      nhop_member = (switch_nhop_member_t*)node->data;
       nhop_handles[index++] = nhop_member->nhop_handle;
     }
     FOR_EACH_IN_LIST_END();
@@ -546,23 +496,20 @@ switch_status_t switch_api_delete_nhop_group(const switch_device_t device,
     status = switch_pd_handle_group(device, nhop_group_info, false);
     if (status != SWITCH_STATUS_SUCCESS) {
       krnlmon_log_error(
-            "switch_api_add_nhop_member: Failed to create platform dependent"
-            " nhop_group selector entry %d: ,error :(%s)\n",
-            device,
-            switch_error_to_string(status));
-        return status;
+          "switch_api_add_nhop_member: Failed to create platform dependent"
+          " nhop_group selector entry %d: ,error :(%s)\n",
+          device, switch_error_to_string(status));
+      return status;
     }
 
     nhop_group_info->pd_nhop_group_deleted = true;
-    status = switch_api_delete_nhop_member(
-        device, nhop_group_handle, num_nhops, nhop_handles);
+    status = switch_api_delete_nhop_member(device, nhop_group_handle, num_nhops,
+                                           nhop_handles);
     if (status != SWITCH_STATUS_SUCCESS) {
       krnlmon_log_error(
           "nhop_group delete failed on device %d nhop_group handle 0x%lx: "
           "nhop_group member delete failed:(%s)\n",
-          device,
-          nhop_group_handle,
-          switch_error_to_string(status));
+          device, nhop_group_handle, switch_error_to_string(status));
       SWITCH_FREE(device, nhop_handles);
       return status;
     }
@@ -573,19 +520,17 @@ switch_status_t switch_api_delete_nhop_group(const switch_device_t device,
   status = switch_nhop_group_delete_handle(device, nhop_group_handle);
   SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
 
-  krnlmon_log_debug("nhop_group handle deleted on device %d nhop_group handle 0x%lx\n",
-                   device,
-                   nhop_group_handle);
+  krnlmon_log_debug(
+      "nhop_group handle deleted on device %d nhop_group handle 0x%lx\n",
+      device, nhop_group_handle);
 
   return status;
 }
 
 switch_status_t switch_api_nhop_group_get_by_nhop_member(
-    const switch_device_t device,
-    const switch_handle_t nhop_member_handle,
-    switch_handle_t *nhop_group_handle,
-    switch_handle_t *nhop_handle) {
-  switch_nhop_member_t *nhop_member = NULL;
+    const switch_device_t device, const switch_handle_t nhop_member_handle,
+    switch_handle_t* nhop_group_handle, switch_handle_t* nhop_handle) {
+  switch_nhop_member_t* nhop_member = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(SWITCH_NHOP_MEMBER_HANDLE(nhop_member_handle));
@@ -594,9 +539,7 @@ switch_status_t switch_api_nhop_group_get_by_nhop_member(
     krnlmon_log_error(
         "nhop member get failed on device %d "
         "nhop_group handle 0x%lx: invalid nhop_group handle(%s)",
-        device,
-        nhop_member_handle,
-        switch_error_to_string(status));
+        device, nhop_member_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -607,51 +550,45 @@ switch_status_t switch_api_nhop_group_get_by_nhop_member(
 }
 
 switch_status_t switch_nhop_member_get_from_nhop(
-    const switch_device_t device,
-    const switch_handle_t nhop_group_handle,
-    const switch_handle_t nhop_handle,
-    switch_nhop_member_t **nhop_member) {
-  switch_nhop_group_info_t *nhop_group_info = NULL;
-  switch_nhop_member_t *tmp_nhop_member = NULL;
-  switch_node_t *node = NULL;
+    const switch_device_t device, const switch_handle_t nhop_group_handle,
+    const switch_handle_t nhop_handle, switch_nhop_member_t** nhop_member) {
+  switch_nhop_group_info_t* nhop_group_info = NULL;
+  switch_nhop_member_t* tmp_nhop_member = NULL;
+  switch_node_t* node = NULL;
   bool member_found = FALSE;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!nhop_member) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
-    krnlmon_log_error("Failed to get nhop member on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("Failed to get nhop member on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
   if (!SWITCH_NHOP_GROUP_HANDLE(nhop_group_handle)) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("Failed to get nhop_group member on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+                      device, switch_error_to_string(status));
     return status;
   }
 
   SWITCH_ASSERT(SWITCH_NHOP_HANDLE(nhop_handle));
   if (!SWITCH_NHOP_HANDLE(nhop_handle)) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
-    krnlmon_log_error("Failed to get nhop member on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("Failed to get nhop member on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
   status = switch_nhop_get_group(device, nhop_group_handle, &nhop_group_info);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("Failed to get nhop member on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("Failed to get nhop member on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
   FOR_EACH_IN_LIST(nhop_group_info->members, node) {
-    tmp_nhop_member = (switch_nhop_member_t *)node->data;
+    tmp_nhop_member = (switch_nhop_member_t*)node->data;
     if (tmp_nhop_member->nhop_handle == nhop_handle) {
       member_found = TRUE;
       *nhop_member = tmp_nhop_member;
@@ -669,8 +606,7 @@ switch_status_t switch_nhop_member_get_from_nhop(
 }
 
 switch_status_t switch_nhop_remove_from_group_member_list(
-    switch_device_t device,
-    switch_nhop_info_t *nhop_info,
+    switch_device_t device, switch_nhop_info_t* nhop_info,
     switch_handle_t nhop_mem_handle) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
@@ -680,9 +616,7 @@ switch_status_t switch_nhop_remove_from_group_member_list(
     krnlmon_log_error(
         "nhop remove nhop mem Failed on device %d, "
         "nhop handle 0x%lx: , nhop mem handle 0x%lx\n",
-        device,
-        nhop_info->nhop_handle,
-        nhop_mem_handle);
+        device, nhop_info->nhop_handle, nhop_mem_handle);
     return SWITCH_STATUS_FAILURE;
   }
 
@@ -690,22 +624,18 @@ switch_status_t switch_nhop_remove_from_group_member_list(
   krnlmon_log_info(
       "nhop remove nhop mem success on device %d, "
       "nhop handle 0x%lx: , nhop mem handle 0x%lx: ref_cnt: %d\n",
-      device,
-      nhop_info->nhop_handle,
-      nhop_mem_handle,
+      device, nhop_info->nhop_handle, nhop_mem_handle,
       SWITCH_NHOP_NUM_NHOP_MEMBER_REF(nhop_info));
 
   return status;
 }
 
 switch_status_t switch_api_delete_nhop_member(
-    const switch_device_t device,
-    const switch_handle_t nhop_group_handle,
-    const switch_uint32_t num_nhops,
-    const switch_handle_t *nhop_handles) {
-  switch_nhop_info_t *nhop_info = NULL;
-  switch_nhop_group_info_t *nhop_group_info = NULL;
-  switch_nhop_member_t *nhop_member = NULL;
+    const switch_device_t device, const switch_handle_t nhop_group_handle,
+    const switch_uint32_t num_nhops, const switch_handle_t* nhop_handles) {
+  switch_nhop_info_t* nhop_info = NULL;
+  switch_nhop_group_info_t* nhop_group_info = NULL;
+  switch_nhop_member_t* nhop_member = NULL;
   switch_handle_t nhop_handle = 0;
   switch_handle_t member_handle = SWITCH_API_INVALID_HANDLE;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
@@ -716,9 +646,7 @@ switch_status_t switch_api_delete_nhop_member(
     krnlmon_log_error(
         "nhop member delete Failed on device %d nhop_group handle 0x%lx: "
         "parameters invalid:(%s)\n",
-        device,
-        nhop_group_handle,
-        switch_error_to_string(status));
+        device, nhop_group_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -727,9 +655,7 @@ switch_status_t switch_api_delete_nhop_member(
     krnlmon_log_error(
         "nhop member delete Failed on device %d nhop_group handle 0x%lx: "
         "nhop_group handle invalid:(%s)\n",
-        device,
-        nhop_group_handle,
-        switch_error_to_string(status));
+        device, nhop_group_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -738,9 +664,7 @@ switch_status_t switch_api_delete_nhop_member(
     krnlmon_log_error(
         "nhop member delete Failed on device %d nhop_group handle 0x%lx: "
         "nhop_group get Failed:(%s)\n",
-        device,
-        nhop_group_handle,
-        switch_error_to_string(status));
+        device, nhop_group_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -753,9 +677,7 @@ switch_status_t switch_api_delete_nhop_member(
           "nhop member delete Failed on device %d nhop_group handle 0x%lx "
           "nhop handle 0x%lx: "
           "nhop handle invalid:(%s)\n",
-          device,
-          nhop_group_handle,
-          nhop_handle,
+          device, nhop_group_handle, nhop_handle,
           switch_error_to_string(status));
       return status;
     }
@@ -766,38 +688,32 @@ switch_status_t switch_api_delete_nhop_member(
           "nhop member delete Failed on device %d nhop_group handle 0x%lx "
           "nhop handle 0x%lx: "
           "nhop get Failed:(%s)\n",
-          device,
-          nhop_group_handle,
-          nhop_handle,
+          device, nhop_group_handle, nhop_handle,
           switch_error_to_string(status));
       return status;
     }
 
-    status = switch_nhop_member_get_from_nhop(
-        device, nhop_group_handle, nhop_handle, &nhop_member);
+    status = switch_nhop_member_get_from_nhop(device, nhop_group_handle,
+                                              nhop_handle, &nhop_member);
     if (status != SWITCH_STATUS_SUCCESS) {
       krnlmon_log_error(
           "nhop member delete Failed on device %d nhop_group handle 0x%lx "
           "nhop handle 0x%lx: "
           "nhop_group member from nhop Failed:(%s)\n",
-          device,
-          nhop_group_handle,
-          nhop_handle,
+          device, nhop_group_handle, nhop_handle,
           switch_error_to_string(status));
       return status;
     }
 
     member_handle = nhop_member->member_handle;
-    status =
-        switch_nhop_remove_from_group_member_list(device, nhop_info, member_handle);
+    status = switch_nhop_remove_from_group_member_list(device, nhop_info,
+                                                       member_handle);
     if (status != SWITCH_STATUS_SUCCESS) {
       krnlmon_log_error(
           "nhop member delete Failed on device %d nhop_group handle 0x%lx "
           "nhop handle 0x%lx: "
           "nhop_group member list remove Failed:(%s)\n",
-          device,
-          nhop_group_handle,
-          nhop_handle,
+          device, nhop_group_handle, nhop_handle,
           switch_error_to_string(status));
       return status;
     }
@@ -806,25 +722,25 @@ switch_status_t switch_api_delete_nhop_member(
     if (!nhop_group_info->pd_nhop_group_deleted) {
       status = switch_pd_handle_group(device, nhop_group_info, true);
       if (status != SWITCH_STATUS_SUCCESS) {
-          krnlmon_log_error(
-              "switch_api_add_nhop_member: Failed to create platform dependent"
-              " nhop_group selector entry %d: ,error :(%s)\n",
-              device,
-              switch_error_to_string(status));
-          return status;
+        krnlmon_log_error(
+            "switch_api_add_nhop_member: Failed to create platform dependent"
+            " nhop_group selector entry %d: ,error :(%s)\n",
+            device, switch_error_to_string(status));
+        return status;
       }
     }
 
     status = switch_pd_handle_member(device, nhop_member, false);
     if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error("switch_pd_handle_member: Failed to create platform "
-                 "dependent action selector member entry %d: ,error :(%s)\n",
-                 device,
-                 switch_error_to_string(status));
-        return status;
+      krnlmon_log_error(
+          "switch_pd_handle_member: Failed to create platform "
+          "dependent action selector member entry %d: ,error :(%s)\n",
+          device, switch_error_to_string(status));
+      return status;
     }
 
-    status = SWITCH_LIST_DELETE(&(nhop_group_info->members), &(nhop_member->node));
+    status =
+        SWITCH_LIST_DELETE(&(nhop_group_info->members), &(nhop_member->node));
     SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
 
     status = switch_nhop_delete_member_handle(device, member_handle);
@@ -833,21 +749,19 @@ switch_status_t switch_api_delete_nhop_member(
 
   krnlmon_log_info(
       "nhop member deleted on device %d nhop_group handle 0x%lx num nhops %d\n",
-      device,
-      nhop_group_handle,
-      num_nhops);
+      device, nhop_group_handle, num_nhops);
 
   return status;
 }
 
-switch_status_t switch_api_delete_nhop_members (
+switch_status_t switch_api_delete_nhop_members(
     switch_device_t device, switch_handle_t nhop_group_handle) {
   switch_uint32_t index = 0;
   switch_uint32_t num_nhops = 0;
-  switch_node_t *node = NULL;
-  switch_nhop_group_info_t *nhop_group_info = NULL;
-  switch_handle_t *nhop_handles = NULL;
-  switch_nhop_member_t *nhop_member = NULL;
+  switch_node_t* node = NULL;
+  switch_nhop_group_info_t* nhop_group_info = NULL;
+  switch_handle_t* nhop_handles = NULL;
+  switch_nhop_member_t* nhop_member = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!SWITCH_NHOP_GROUP_HANDLE(nhop_group_handle)) {
@@ -855,9 +769,7 @@ switch_status_t switch_api_delete_nhop_members (
     krnlmon_log_error(
         "nhop members delete Failed on device %d nhop_group handle 0x%lx: "
         "nhop_group handle invalid:(%s)\n",
-        device,
-        nhop_group_handle,
-        switch_error_to_string(status));
+        device, nhop_group_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -866,9 +778,7 @@ switch_status_t switch_api_delete_nhop_members (
     krnlmon_log_error(
         "nhop members delete Failed on device %d nhop_group handle 0x%lx: "
         "nhop_group get Failed:(%s)\n",
-        device,
-        nhop_group_handle,
-        switch_error_to_string(status));
+        device, nhop_group_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -877,9 +787,7 @@ switch_status_t switch_api_delete_nhop_members (
     krnlmon_log_error(
         "nhop members delete Failed on device %d nhop_group handle 0x%lx: "
         "handle type not nhop_group:(%s)\n",
-        device,
-        nhop_group_handle,
-        switch_error_to_string(status));
+        device, nhop_group_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -892,62 +800,56 @@ switch_status_t switch_api_delete_nhop_members (
       krnlmon_log_error(
           "nhop members delete Failed on device %d nhop_group handle 0x%lx: "
           "nhop handles malloc Failed:(%s)\n",
-          device,
-          nhop_group_handle,
-          switch_error_to_string(status));
+          device, nhop_group_handle, switch_error_to_string(status));
       return status;
     }
 
     FOR_EACH_IN_LIST(nhop_group_info->members, node) {
-      nhop_member = (switch_nhop_member_t *)node->data;
+      nhop_member = (switch_nhop_member_t*)node->data;
       nhop_handles[index++] = nhop_member->nhop_handle;
     }
     FOR_EACH_IN_LIST_END();
 
-    status = switch_api_delete_nhop_member(
-        device, nhop_group_handle, num_nhops, nhop_handles);
+    status = switch_api_delete_nhop_member(device, nhop_group_handle, num_nhops,
+                                           nhop_handles);
     if (status != SWITCH_STATUS_SUCCESS) {
       krnlmon_log_error(
           "nhop members delete Failed on device %d nhop_group handle 0x%lx: "
           "nhop member delete Failed:(%s)\n",
-          device,
-          nhop_group_handle,
-          switch_error_to_string(status));
+          device, nhop_group_handle, switch_error_to_string(status));
       SWITCH_FREE(device, nhop_handles);
       return status;
     }
     SWITCH_FREE(device, nhop_handles);
   }
 
-  krnlmon_log_info("nhop members deleted on device %d nhop_group handle 0x%lx\n",
-                   device,
-                   nhop_group_handle);
+  krnlmon_log_info(
+      "nhop members deleted on device %d nhop_group handle 0x%lx\n", device,
+      nhop_group_handle);
 
   return status;
 }
 
 switch_status_t switch_api_nhop_create(
-    const switch_device_t device,
-    const switch_api_nhop_info_t *api_nhop_info,
-    switch_handle_t *nhop_handle) {
-  switch_nhop_context_t *nhop_ctx = NULL;
-  switch_nhop_info_t *nhop_info = NULL;
-  switch_spath_info_t *spath_info = NULL;
+    const switch_device_t device, const switch_api_nhop_info_t* api_nhop_info,
+    switch_handle_t* nhop_handle) {
+  switch_nhop_context_t* nhop_ctx = NULL;
+  switch_nhop_info_t* nhop_info = NULL;
+  switch_spath_info_t* spath_info = NULL;
   switch_nhop_key_t nhop_key = {0};
   switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
-  switch_pd_routing_info_t pd_routing_info; //TODO
+  switch_pd_routing_info_t pd_routing_info;  // TODO
 
   memset(&pd_routing_info, 0, sizeof(switch_pd_routing_info_t));
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_NHOP, (void **)&nhop_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_NHOP,
+                                         (void**)&nhop_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "nhop create Failed on device %d: "
         "nhop context get Failed:(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -958,8 +860,7 @@ switch_status_t switch_api_nhop_create(
     krnlmon_log_error(
         "nhop create Failed on device %d: "
         "parameters invalid:(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -972,8 +873,7 @@ switch_status_t switch_api_nhop_create(
     krnlmon_log_error(
         "nhop create Failed on device %d: "
         "nhop get Failed:(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -981,8 +881,7 @@ switch_status_t switch_api_nhop_create(
     krnlmon_log_info(
         "nhop create Failed on device %d nhop handle 0x%lx: "
         "nhop already exists\n",
-        device,
-        handle);
+        device, handle);
     status = switch_nhop_get(device, handle, &nhop_info);
     SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
     nhop_info->nhop_ref_count++;
@@ -996,8 +895,7 @@ switch_status_t switch_api_nhop_create(
     krnlmon_log_error(
         "nhop create Failed on device %d "
         "nhop handle create Failed:(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -1006,8 +904,7 @@ switch_status_t switch_api_nhop_create(
     krnlmon_log_error(
         "nhop create Failed on device %d "
         "nhop get Failed:(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -1025,54 +922,47 @@ switch_status_t switch_api_nhop_create(
   spath_info->nhop_handle = handle;
   spath_info->tunnel = FALSE;
 
-  SWITCH_MEMCPY(&spath_info->api_nhop_info,
-                api_nhop_info,
+  SWITCH_MEMCPY(&spath_info->api_nhop_info, api_nhop_info,
                 sizeof(switch_api_nhop_info_t));
   SWITCH_MEMCPY(&spath_info->nhop_key, &nhop_key, sizeof(nhop_key));
 
- /* Backend programming for nhop create is not needed because Neighbor
-  * create will call a nexthop create always before creating neighbor.
-  * So, backend programming should happen with Neighbor create only,
-  * by the time neighbor create happens already nexthop would have been created. 
-  * Vice-versa will not happen */
-  SWITCH_MEMCPY(&nhop_info->switch_pd_routing_info,
-                &pd_routing_info,
+  /* Backend programming for nhop create is not needed because Neighbor
+   * create will call a nexthop create always before creating neighbor.
+   * So, backend programming should happen with Neighbor create only,
+   * by the time neighbor create happens already nexthop would have been
+   * created. Vice-versa will not happen */
+  SWITCH_MEMCPY(&nhop_info->switch_pd_routing_info, &pd_routing_info,
                 sizeof(switch_pd_routing_info_t));
 
-  status = SWITCH_HASHTABLE_INSERT(&nhop_ctx->nhop_hashtable,
-                                   &(nhop_info->node),
-                                   (void *)&nhop_key,
-                                   (void *)nhop_info);
+  status =
+      SWITCH_HASHTABLE_INSERT(&nhop_ctx->nhop_hashtable, &(nhop_info->node),
+                              (void*)&nhop_key, (void*)nhop_info);
   SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
 
   *nhop_handle = handle;
 
-  krnlmon_log_info(
-      "nhop created on device %d nhop handle 0x%lx\n", device, handle);
+  krnlmon_log_info("nhop created on device %d nhop handle 0x%lx\n", device,
+                   handle);
 
   return status;
 }
 
-switch_status_t switch_api_nhop_delete(
-    const switch_device_t device, const switch_handle_t nhop_handle) {
-  switch_nhop_context_t *nhop_ctx = NULL;
-  switch_nhop_info_t *nhop_info = NULL;
-  switch_api_nhop_info_t *api_nhop_info = NULL;
-  switch_spath_info_t *spath_info = NULL;
+switch_status_t switch_api_nhop_delete(const switch_device_t device,
+                                       const switch_handle_t nhop_handle) {
+  switch_nhop_context_t* nhop_ctx = NULL;
+  switch_nhop_info_t* nhop_info = NULL;
+  switch_api_nhop_info_t* api_nhop_info = NULL;
+  switch_spath_info_t* spath_info = NULL;
   switch_nhop_key_t nhop_key = {0};
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
-
-
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_NHOP, (void **)&nhop_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_NHOP,
+                                         (void**)&nhop_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "nhop delete Failed on device %d nhop handle 0x%lx: "
         "nhop device context get Failed:(%s)\n",
-        device,
-        nhop_handle,
-        switch_error_to_string(status));
+        device, nhop_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -1081,9 +971,7 @@ switch_status_t switch_api_nhop_delete(
     krnlmon_log_error(
         "nhop delete Failed on device %d nhop handle 0x%lx: "
         "nhop handle invalid:(%s)\n",
-        device,
-        nhop_handle,
-        switch_error_to_string(status));
+        device, nhop_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -1092,9 +980,7 @@ switch_status_t switch_api_nhop_delete(
     krnlmon_log_error(
         "nhop delete Failed on device %d nhop handle 0x%lx: "
         "nhop get Failed:(%s)\n",
-        device,
-        nhop_handle,
-        switch_error_to_string(status));
+        device, nhop_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -1103,9 +989,7 @@ switch_status_t switch_api_nhop_delete(
     krnlmon_log_error(
         "nhop delete Failed on device %d nhop handle 0x%lx: "
         "nhop id type invalid:(%s)\n",
-        device,
-        nhop_handle,
-        switch_error_to_string(status));
+        device, nhop_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -1117,24 +1001,23 @@ switch_status_t switch_api_nhop_delete(
   spath_info = &(SWITCH_NHOP_SPATH_INFO(nhop_info));
   api_nhop_info = &spath_info->api_nhop_info;
   SWITCH_NHOP_KEY_GET(api_nhop_info, nhop_key);
-  status = SWITCH_HASHTABLE_DELETE(
-      &nhop_ctx->nhop_hashtable, (void *)(&nhop_key), (void **)&nhop_info);
+  status = SWITCH_HASHTABLE_DELETE(&nhop_ctx->nhop_hashtable,
+                                   (void*)(&nhop_key), (void**)&nhop_info);
   SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
 
   status = switch_nhop_handle_delete(device, nhop_handle, 1);
   SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
 
-  krnlmon_log_info(
-      "nhop deleted on device %d nhop handle 0x%lx\n", device, nhop_handle);
+  krnlmon_log_info("nhop deleted on device %d nhop handle 0x%lx\n", device,
+                   nhop_handle);
 
   return status;
 }
 
-switch_status_t switch_api_nhop_id_type_get(
-    const switch_device_t device,
-    const switch_handle_t nhop_handle,
-    switch_nhop_id_type_t *nhop_type) {
-  switch_nhop_info_t *nhop_info = NULL;
+switch_status_t switch_api_nhop_id_type_get(const switch_device_t device,
+                                            const switch_handle_t nhop_handle,
+                                            switch_nhop_id_type_t* nhop_type) {
+  switch_nhop_info_t* nhop_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!nhop_type || !nhop_handle) {
@@ -1150,24 +1033,21 @@ switch_status_t switch_api_nhop_id_type_get(
     krnlmon_log_error(
         "nhop id type get Failed for "
         "device %d handle 0x%lx: %s\n",
-        device,
-        nhop_handle,
-        switch_error_to_string(status));
+        device, nhop_handle, switch_error_to_string(status));
     return status;
   }
 
   status = switch_nhop_get(device, nhop_handle, &nhop_info);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error("Failed to get nhop info on handle 0x%lx, error: %s\n",
-             nhop_handle,
-             switch_error_to_string(status));
+                      nhop_handle, switch_error_to_string(status));
     return status;
   }
 
-  if(nhop_info) {
-     *nhop_type = nhop_info->id_type;
+  if (nhop_info) {
+    *nhop_type = nhop_info->id_type;
   } else {
-     krnlmon_log_error("nhop info was null, status = %d", status);
+    krnlmon_log_error("nhop info was null, status = %d", status);
   }
 
   return status;

--- a/switchapi/dpdk/switch_pd_fdb.c
+++ b/switchapi/dpdk/switch_pd_fdb.c
@@ -16,647 +16,616 @@
  */
 
 #include "switch_pd_fdb.h"
-#include "switchapi/switch_fdb.h"
 
 #include "bf_types.h"
 #include "port_mgr/dpdk/bf_dpdk_port_if.h"
-
+#include "switch_pd_p4_name_mapping.h"
+#include "switch_pd_utils.h"
 #include "switchapi/switch_base_types.h"
+#include "switchapi/switch_fdb.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_rif_int.h"
 
-#include "switch_pd_p4_name_mapping.h"
-#include "switch_pd_utils.h"
-
 switch_status_t switch_pd_l2_tx_forward_table_entry(
-    switch_device_t device,
-    const switch_api_l2_info_t *api_l2_tx_info,
-    const switch_api_tunnel_info_t *api_tunnel_info,
-    bool entry_add) {
+    switch_device_t device, const switch_api_l2_info_t* api_l2_tx_info,
+    const switch_api_tunnel_info_t* api_tunnel_info, bool entry_add) {
+  tdi_status_t status;
 
-    tdi_status_t status;
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
 
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
+  tdi_dev_id_t dev_id = device;
 
-    tdi_dev_id_t dev_id = device;
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
+  uint32_t network_byte_order;
 
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
-    uint32_t network_byte_order;
+  krnlmon_log_debug("%s", __func__);
 
-    krnlmon_log_debug("%s", __func__);
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
-    }
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_flags_create(0, &flags_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
-    }
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_device_get(dev_id, &dev_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
-    }
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_target_create(dev_hdl, &target_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
-    }
-    
-    status = tdi_session_create(dev_hdl, &session);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
-    }
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_L2_FWD_TX_TABLE,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                 LNW_L2_FWD_TX_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_L2_FWD_TX_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_L2_FWD_TX_TABLE_KEY_DST_MAC,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-                LNW_L2_FWD_TX_TABLE_KEY_DST_MAC, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_set_value_ptr(key_hdl, field_id, 
-                                         (const uint8_t *)
-                                         &api_l2_tx_info->dst_mac.mac_addr,
-                                         SWITCH_MAC_LENGTH);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d, error: %d",
-                 field_id, status);
-        goto dealloc_resources;
-    }
-
-    if (entry_add &&
-        api_l2_tx_info->learn_from == SWITCH_L2_FWD_LEARN_TUNNEL_INTERFACE) {
-
-        krnlmon_log_info("Populate set_tunnel action in %s for tunnel "
-                  "interface %x", LNW_L2_FWD_TX_TABLE,
-                  (unsigned int)api_l2_tx_info->rif_handle);
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_L2_FWD_TX_TABLE_ACTION_SET_TUNNEL,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_L2_FWD_TX_TABLE_ACTION_SET_TUNNEL, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id,
-                                                &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_SET_TUNNEL_PARAM_TUNNEL_ID,
-                                                   action_id,
-                                                   &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                    LNW_ACTION_SET_TUNNEL_PARAM_TUNNEL_ID, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value_ptr(data_hdl,
-                                              data_field_id,
-                                              0,
-                                              sizeof(uint32_t));
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_SET_TUNNEL_PARAM_DST_ADDR,
-                                                   action_id,
-                                                   &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_SET_TUNNEL_PARAM_DST_ADDR, status);
-            goto dealloc_resources;
-        }
-
-        network_byte_order = ntohl(api_tunnel_info->dst_ip.ip.v4addr);
-        status = tdi_data_field_set_value_ptr(data_hdl, data_field_id,
-                                              (const uint8_t *)
-                                              &network_byte_order,
-                                              sizeof(uint32_t));
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add %s table entry, error: %d", 
-                   LNW_L2_FWD_TX_TABLE, status);
-            goto dealloc_resources;
-        }
-
-    } else if (entry_add &&
-               api_l2_tx_info->learn_from ==
-               SWITCH_L2_FWD_LEARN_VLAN_INTERFACE) {
-
-        krnlmon_log_info("Populate l2_fwd action in %s "
-                  "for VLAN netdev: vlan%d",
-                  LNW_L2_FWD_TX_TABLE,
-                  api_l2_tx_info->port_id+1);
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl,
-                                                action_id,
-                                                &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_L2_FWD_PARAM_PORT,
-                                                   action_id,
-                                                   &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_L2_FWD_PARAM_PORT, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                          api_l2_tx_info->port_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add %s table entry, error: %d", 
-                    LNW_L2_FWD_TX_TABLE, status);
-            goto dealloc_resources;
-        }
-
-    } else if (entry_add &&
-               api_l2_tx_info->learn_from ==
-               SWITCH_L2_FWD_LEARN_PHYSICAL_INTERFACE) {
-
-        krnlmon_log_info("Populate l2_fwd action in %s "
-                  "for physical port: %d",
-                  LNW_L2_FWD_TX_TABLE, api_l2_tx_info->port_id);
-        
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id,
-                                                &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_L2_FWD_PARAM_PORT,
-                                                   action_id,
-                                                   &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_L2_FWD_PARAM_PORT, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                          api_l2_tx_info->port_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to add %s entry, error: %d",
+  status = tdi_table_from_name_get(info_hdl, LNW_L2_FWD_TX_TABLE, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
                       LNW_L2_FWD_TX_TABLE, status);
-            goto dealloc_resources;
-        }
-    } else {
-        /* Delete an entry from target */
-        status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                     flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete %s table entry, error: %d", 
-                     LNW_L2_FWD_TX_TABLE, status);
-            goto dealloc_resources;
-        }
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_L2_FWD_TX_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table, error: %d",
+                      status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(table_info_hdl, LNW_L2_FWD_TX_TABLE_KEY_DST_MAC,
+                                &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_L2_FWD_TX_TABLE_KEY_DST_MAC, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_set_value_ptr(
+      key_hdl, field_id, (const uint8_t*)&api_l2_tx_info->dst_mac.mac_addr,
+      SWITCH_MAC_LENGTH);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to set value for key ID: %d, error: %d", field_id,
+                      status);
+    goto dealloc_resources;
+  }
+
+  if (entry_add &&
+      api_l2_tx_info->learn_from == SWITCH_L2_FWD_LEARN_TUNNEL_INTERFACE) {
+    krnlmon_log_info(
+        "Populate set_tunnel action in %s for tunnel "
+        "interface %x",
+        LNW_L2_FWD_TX_TABLE, (unsigned int)api_l2_tx_info->rif_handle);
+
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_L2_FWD_TX_TABLE_ACTION_SET_TUNNEL, &action_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_L2_FWD_TX_TABLE_ACTION_SET_TUNNEL, status);
+      goto dealloc_resources;
     }
+
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_SET_TUNNEL_PARAM_TUNNEL_ID, action_id,
+        &data_field_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_SET_TUNNEL_PARAM_TUNNEL_ID, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_set_value_ptr(data_hdl, data_field_id, 0,
+                                          sizeof(uint32_t));
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_SET_TUNNEL_PARAM_DST_ADDR, action_id,
+        &data_field_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_SET_TUNNEL_PARAM_DST_ADDR, status);
+      goto dealloc_resources;
+    }
+
+    network_byte_order = ntohl(api_tunnel_info->dst_ip.ip.v4addr);
+    status = tdi_data_field_set_value_ptr(data_hdl, data_field_id,
+                                          (const uint8_t*)&network_byte_order,
+                                          sizeof(uint32_t));
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to add %s table entry, error: %d",
+                        LNW_L2_FWD_TX_TABLE, status);
+      goto dealloc_resources;
+    }
+
+  } else if (entry_add &&
+             api_l2_tx_info->learn_from == SWITCH_L2_FWD_LEARN_VLAN_INTERFACE) {
+    krnlmon_log_info(
+        "Populate l2_fwd action in %s "
+        "for VLAN netdev: vlan%d",
+        LNW_L2_FWD_TX_TABLE, api_l2_tx_info->port_id + 1);
+
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD, &action_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_id_with_action_get(table_info_hdl,
+                                               LNW_ACTION_L2_FWD_PARAM_PORT,
+                                               action_id, &data_field_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_L2_FWD_PARAM_PORT, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_set_value(data_hdl, data_field_id,
+                                      api_l2_tx_info->port_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to add %s table entry, error: %d",
+                        LNW_L2_FWD_TX_TABLE, status);
+      goto dealloc_resources;
+    }
+
+  } else if (entry_add && api_l2_tx_info->learn_from ==
+                              SWITCH_L2_FWD_LEARN_PHYSICAL_INTERFACE) {
+    krnlmon_log_info(
+        "Populate l2_fwd action in %s "
+        "for physical port: %d",
+        LNW_L2_FWD_TX_TABLE, api_l2_tx_info->port_id);
+
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD, &action_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_id_with_action_get(table_info_hdl,
+                                               LNW_ACTION_L2_FWD_PARAM_PORT,
+                                               action_id, &data_field_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_L2_FWD_PARAM_PORT, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_set_value(data_hdl, data_field_id,
+                                      api_l2_tx_info->port_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to add %s entry, error: %d",
+                        LNW_L2_FWD_TX_TABLE, status);
+      goto dealloc_resources;
+    }
+  } else {
+    /* Delete an entry from target */
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to delete %s table entry, error: %d",
+                        LNW_L2_FWD_TX_TABLE, status);
+      goto dealloc_resources;
+    }
+  }
 
 dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
 }
 
 switch_status_t switch_pd_l2_rx_forward_table_entry(
-    switch_device_t device,
-    const switch_api_l2_info_t *api_l2_rx_info,
+    switch_device_t device, const switch_api_l2_info_t* api_l2_rx_info,
     bool entry_add) {
+  tdi_status_t status;
 
-    tdi_status_t status;
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
 
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
+  tdi_dev_id_t dev_id = device;
 
-    tdi_dev_id_t dev_id = device;
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
 
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
+  switch_handle_t rif_handle;
+  switch_rif_info_t* rif_info = NULL;
+  switch_port_t port_id;
 
-    switch_handle_t rif_handle;
-    switch_rif_info_t *rif_info = NULL;
-    switch_port_t port_id;
+  krnlmon_log_debug("%s", __func__);
 
-    krnlmon_log_debug("%s", __func__);
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_from_name_get(info_hdl, LNW_L2_FWD_RX_TABLE, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_L2_FWD_RX_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_NEXTHOP_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table, error: %d",
+                      status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(table_info_hdl, LNW_L2_FWD_RX_TABLE_KEY_DST_MAC,
+                                &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_L2_FWD_RX_TABLE_KEY_DST_MAC, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_set_value_ptr(
+      key_hdl, field_id, (const uint8_t*)&api_l2_rx_info->dst_mac.mac_addr,
+      SWITCH_MAC_LENGTH);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to set value for key ID: %d, error: %d", field_id,
+                      status);
+    goto dealloc_resources;
+  }
+
+  if (entry_add) {
+    /* Add an entry to target */
+    krnlmon_log_info(
+        "Populate l2_fwd action in %s for rif handle "
+        "%x ",
+        LNW_L2_FWD_RX_TABLE, (unsigned int)api_l2_rx_info->rif_handle);
+
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_L2_FWD_RX_TABLE_ACTION_L2_FWD, &action_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_L2_FWD_RX_TABLE_ACTION_L2_FWD, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_flags_create(0, &flags_hdl);
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_device_get(dev_id, &dev_hdl);
+    rif_handle = api_l2_rx_info->rif_handle;
+    switch_status_t switch_status =
+        switch_rif_get(device, rif_handle, &rif_info);
+    if (switch_status != SWITCH_STATUS_SUCCESS) {
+      krnlmon_log_error("Unable to get rif info, error: %d", switch_status);
+      goto dealloc_resources;
+    }
+
+    if (rif_info->api_rif_info.port_id == -1) {
+      switch_pd_to_get_port_id(&(rif_info->api_rif_info));
+    }
+
+    /* While matching l2_fwd_rx_table should receive packet on phy-port
+     * and send to control port. */
+    port_id = rif_info->api_rif_info.port_id;
+
+    status = tdi_data_field_id_with_action_get(table_info_hdl,
+                                               LNW_ACTION_L2_FWD_PARAM_PORT,
+                                               action_id, &data_field_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_L2_FWD_PARAM_PORT, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_target_create(dev_hdl, &target_hdl);
+    status = tdi_data_field_set_value(data_hdl, data_field_id, port_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_session_create(dev_hdl, &session);
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to add %s table entry, error: %d",
+                        LNW_L2_FWD_RX_TABLE, status);
+      goto dealloc_resources;
     }
-
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_L2_FWD_RX_TABLE,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                 LNW_L2_FWD_RX_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  } else {
+    /* Delete an entry from target */
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_NEXTHOP_TABLE, status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to delete %s entry, error: %d",
+                        LNW_L2_FWD_RX_TABLE, status);
+      goto dealloc_resources;
     }
-
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_L2_FWD_RX_TABLE_KEY_DST_MAC,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_L2_FWD_RX_TABLE_KEY_DST_MAC, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_set_value_ptr(key_hdl, field_id, 
-                                         (const uint8_t *)
-                                         &api_l2_rx_info->dst_mac.mac_addr, 
-                                         SWITCH_MAC_LENGTH);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d, error: %d",
-                 field_id, status);
-        goto dealloc_resources;
-    }
-
-    if (entry_add) {
-        /* Add an entry to target */
-        krnlmon_log_info("Populate l2_fwd action in %s for rif handle "
-                  "%x ", LNW_L2_FWD_RX_TABLE,
-                  (unsigned int) api_l2_rx_info->rif_handle);
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_L2_FWD_RX_TABLE_ACTION_L2_FWD,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_L2_FWD_RX_TABLE_ACTION_L2_FWD, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id,
-                                                &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        rif_handle = api_l2_rx_info->rif_handle;
-        switch_status_t switch_status = switch_rif_get(device,
-                                                       rif_handle,
-                                                       &rif_info);
-        if (switch_status != SWITCH_STATUS_SUCCESS) {
-            krnlmon_log_error("Unable to get rif info, error: %d", switch_status);
-            goto dealloc_resources;
-        }
-
-        if (rif_info->api_rif_info.port_id == -1) {
-          switch_pd_to_get_port_id(&(rif_info->api_rif_info));
-        }
-
-        /* While matching l2_fwd_rx_table should receive packet on phy-port
-         * and send to control port. */
-        port_id = rif_info->api_rif_info.port_id;
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_L2_FWD_PARAM_PORT,
-                                                   action_id,
-                                                   &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_L2_FWD_PARAM_PORT, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id, port_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add %s table entry, error: %d", 
-                   LNW_L2_FWD_RX_TABLE, status);
-            goto dealloc_resources;
-        }
-    } else {
-        /* Delete an entry from target */
-        status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                    flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete %s entry, error: %d", 
-                     LNW_L2_FWD_RX_TABLE, status);
-            goto dealloc_resources;
-        }
-    }
+  }
 
 dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
 }
 
 switch_status_t switch_pd_l2_rx_forward_with_tunnel_table_entry(
-    switch_device_t device,
-    const switch_api_l2_info_t *api_l2_rx_info,
+    switch_device_t device, const switch_api_l2_info_t* api_l2_rx_info,
     bool entry_add) {
+  tdi_status_t status;
 
-    tdi_status_t status;
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
 
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
+  tdi_dev_id_t dev_id = device;
 
-    tdi_dev_id_t dev_id = device;
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
 
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
+  krnlmon_log_debug("%s", __func__);
 
-    krnlmon_log_debug("%s", __func__);
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_from_name_get(info_hdl, LNW_L2_FWD_RX_WITH_TUNNEL_TABLE,
+                                   &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_L2_FWD_RX_WITH_TUNNEL_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_L2_FWD_RX_WITH_TUNNEL_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table");
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(
+      table_info_hdl, LNW_L2_FWD_RX_WITH_TUNNEL_TABLE_KEY_DST_MAC, &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_L2_FWD_RX_WITH_TUNNEL_TABLE_KEY_DST_MAC, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_set_value_ptr(
+      key_hdl, field_id, (const uint8_t*)&api_l2_rx_info->dst_mac.mac_addr,
+      SWITCH_MAC_LENGTH);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to set value for key ID: %d", field_id);
+    goto dealloc_resources;
+  }
+
+  if (entry_add) {
+    /* Add an entry to target */
+    krnlmon_log_info("Populate l2_fwd action in %s for rif handle %x",
+                     LNW_L2_FWD_RX_WITH_TUNNEL_TABLE,
+                     (unsigned int)api_l2_rx_info->rif_handle);
+
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_L2_FWD_RX_WITH_TUNNEL_TABLE_ACTION_L2_FWD,
+        &action_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_L2_FWD_RX_WITH_TUNNEL_TABLE_ACTION_L2_FWD, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_flags_create(0, &flags_hdl);
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_device_get(dev_id, &dev_hdl);
+    status = tdi_data_field_id_with_action_get(table_info_hdl,
+                                               LNW_ACTION_L2_FWD_PARAM_PORT,
+                                               action_id, &data_field_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_L2_FWD_PARAM_PORT, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_target_create(dev_hdl, &target_hdl);
+    status = tdi_data_field_set_value(data_hdl, data_field_id,
+                                      api_l2_rx_info->port_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_session_create(dev_hdl, &session);
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to add %s entry, error: %d",
+                        LNW_L2_FWD_RX_WITH_TUNNEL_TABLE, status);
+      goto dealloc_resources;
     }
-
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_L2_FWD_RX_WITH_TUNNEL_TABLE,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                 LNW_L2_FWD_RX_WITH_TUNNEL_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  } else {
+    /* Delete an entry from target */
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_L2_FWD_RX_WITH_TUNNEL_TABLE, status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to delete %s entry, error: %d",
+                        LNW_L2_FWD_RX_WITH_TUNNEL_TABLE, status);
+      goto dealloc_resources;
     }
-
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table");
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_L2_FWD_RX_WITH_TUNNEL_TABLE_KEY_DST_MAC,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_L2_FWD_RX_WITH_TUNNEL_TABLE_KEY_DST_MAC, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_set_value_ptr(key_hdl, field_id, 
-                                         (const uint8_t *)
-                                         &api_l2_rx_info->dst_mac.mac_addr, 
-                                         SWITCH_MAC_LENGTH);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d", field_id);
-        goto dealloc_resources;
-    }
-
-    if (entry_add) {
-        /* Add an entry to target */
-        krnlmon_log_info("Populate l2_fwd action in %s for rif handle %x",
-                  LNW_L2_FWD_RX_WITH_TUNNEL_TABLE,
-                  (unsigned int) api_l2_rx_info->rif_handle);
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_L2_FWD_RX_WITH_TUNNEL_TABLE_ACTION_L2_FWD,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_L2_FWD_RX_WITH_TUNNEL_TABLE_ACTION_L2_FWD, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                    "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_L2_FWD_PARAM_PORT,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_L2_FWD_PARAM_PORT, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                          api_l2_rx_info->port_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add %s entry, error: %d", 
-                   LNW_L2_FWD_RX_WITH_TUNNEL_TABLE, status);
-            goto dealloc_resources;
-        }
-    } else {
-        /* Delete an entry from target */
-        status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                     flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete %s entry, error: %d", 
-                     LNW_L2_FWD_RX_WITH_TUNNEL_TABLE, status);
-            goto dealloc_resources;
-        }
-    }
+  }
 
 dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
 }

--- a/switchapi/dpdk/switch_pd_fdb.c
+++ b/switchapi/dpdk/switch_pd_fdb.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/dpdk/switch_pd_fdb.h
+++ b/switchapi/dpdk/switch_pd_fdb.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/dpdk/switch_pd_fdb.h
+++ b/switchapi/dpdk/switch_pd_fdb.h
@@ -18,34 +18,28 @@
 #ifndef __SWITCH_PD_FDB_H__
 #define __SWITCH_PD_FDB_H__
 
-#include "switchapi/switch_fdb.h"
-
 #include "switchapi/switch_base_types.h"
+#include "switchapi/switch_fdb.h"
 #include "switchapi/switch_handle.h"
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
 switch_status_t switch_pd_l2_tx_forward_table_entry(
-    switch_device_t device,
-    const switch_api_l2_info_t *api_l2_tx_info,
-    const switch_api_tunnel_info_t *api_tunnel_info_t,
-    bool entry_add);
+    switch_device_t device, const switch_api_l2_info_t* api_l2_tx_info,
+    const switch_api_tunnel_info_t* api_tunnel_info_t, bool entry_add);
 
 switch_status_t switch_pd_l2_rx_forward_table_entry(
-    switch_device_t device,
-    const switch_api_l2_info_t *api_l2_rx_info,
+    switch_device_t device, const switch_api_l2_info_t* api_l2_rx_info,
     bool entry_add);
 
 switch_status_t switch_pd_l2_rx_forward_with_tunnel_table_entry(
-    switch_device_t device,
-    const switch_api_l2_info_t *api_l2_rx_info,
+    switch_device_t device, const switch_api_l2_info_t* api_l2_rx_info,
     bool entry_add);
 
-
-#ifdef  __cplusplus
+#ifdef __cplusplus
 }
 #endif
 
-#endif 
+#endif

--- a/switchapi/dpdk/switch_pd_p4_name_mapping.h
+++ b/switchapi/dpdk/switch_pd_p4_name_mapping.h
@@ -25,179 +25,130 @@ extern "C" {
 
 /* VXLAN_ENCAP_MOD_TABLE */
 #define LNW_VXLAN_ENCAP_MOD_TABLE \
-        "linux_networking_control.vxlan_encap_mod_table"
+  "linux_networking_control.vxlan_encap_mod_table"
 
 #define LNW_VXLAN_ENCAP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR \
-        "vendormeta_mod_data_ptr"
+  "vendormeta_mod_data_ptr"
 
 #define LNW_VXLAN_ENCAP_MOD_TABLE_ACTION_VXLAN_ENCAP \
-        "linux_networking_control.vxlan_encap"
-#define LNW_ACTION_VXLAN_ENCAP_PARAM_SRC_ADDR \
-        "src_addr"
-#define LNW_ACTION_VXLAN_ENCAP_PARAM_DST_ADDR \
-        "dst_addr"
-#define LNW_ACTION_VXLAN_ENCAP_PARAM_DST_PORT \
-        "dst_port"
-#define LNW_ACTION_VXLAN_ENCAP_PARAM_VNI \
-        "vni"
-
+  "linux_networking_control.vxlan_encap"
+#define LNW_ACTION_VXLAN_ENCAP_PARAM_SRC_ADDR "src_addr"
+#define LNW_ACTION_VXLAN_ENCAP_PARAM_DST_ADDR "dst_addr"
+#define LNW_ACTION_VXLAN_ENCAP_PARAM_DST_PORT "dst_port"
+#define LNW_ACTION_VXLAN_ENCAP_PARAM_VNI "vni"
 
 /* RIF_MOD_TABLE */
-#define LNW_RIF_MOD_TABLE \
-        "linux_networking_control.rif_mod_table"
+#define LNW_RIF_MOD_TABLE "linux_networking_control.rif_mod_table"
 
-#define LNW_RIF_MOD_TABLE_KEY_RIF_MOD_MAP_ID \
-        "local_metadata.rif_mod_map_id"
+#define LNW_RIF_MOD_TABLE_KEY_RIF_MOD_MAP_ID "local_metadata.rif_mod_map_id"
 
 #define LNW_RIF_MOD_TABLE_ACTION_SET_SRC_MAC \
-        "linux_networking_control.set_src_mac"
-#define LNW_ACTION_SET_SRC_MAC_PARAM_SRC_MAC_ADDR \
-        "src_mac_addr"
-
+  "linux_networking_control.set_src_mac"
+#define LNW_ACTION_SET_SRC_MAC_PARAM_SRC_MAC_ADDR "src_mac_addr"
 
 /* NEIGHBOR_MOD_TABLE */
-#define LNW_NEIGHBOR_MOD_TABLE \
-        "linux_networking_control.neighbor_mod_table"
+#define LNW_NEIGHBOR_MOD_TABLE "linux_networking_control.neighbor_mod_table"
 
 #define LNW_NEIGHBOR_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR \
-        "vendormeta_mod_data_ptr"
+  "vendormeta_mod_data_ptr"
 
 #define LNW_NEIGHBOR_MOD_TABLE_ACTION_SET_OUTER_MAC \
-        "linux_networking_control.set_outer_mac"
-#define LNW_ACTION_SET_OUTER_MAC_PARAM_DST_MAC_ADDR \
-        "dst_mac_addr"
-
+  "linux_networking_control.set_outer_mac"
+#define LNW_ACTION_SET_OUTER_MAC_PARAM_DST_MAC_ADDR "dst_mac_addr"
 
 /* IPV4_TUNNEL_TERM_TABLE */
 #define LNW_IPV4_TUNNEL_TERM_TABLE \
-        "linux_networking_control.ipv4_tunnel_term_table"
+  "linux_networking_control.ipv4_tunnel_term_table"
 
-#define LNW_IPV4_TUNNEL_TERM_TABLE_KEY_TUNNEL_TYPE \
-        "tunnel_type"
-#define LNW_IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_SRC \
-        "ipv4_src"
-#define LNW_IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_DST \
-        "ipv4_dst"
+#define LNW_IPV4_TUNNEL_TERM_TABLE_KEY_TUNNEL_TYPE "tunnel_type"
+#define LNW_IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_SRC "ipv4_src"
+#define LNW_IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_DST "ipv4_dst"
 
 #define LNW_IPV4_TUNNEL_TERM_TABLE_ACTION_DECAP_OUTER_IPV4 \
-        "linux_networking_control.decap_outer_ipv4"
-#define LNW_ACTION_DECAP_OUTER_IPV4_PARAM_TUNNEL_ID \
-        "tunnel_id"
-
+  "linux_networking_control.decap_outer_ipv4"
+#define LNW_ACTION_DECAP_OUTER_IPV4_PARAM_TUNNEL_ID "tunnel_id"
 
 /* L2_FWD_RX_TABLE */
-#define LNW_L2_FWD_RX_TABLE \
-        "linux_networking_control.l2_fwd_rx_table"
+#define LNW_L2_FWD_RX_TABLE "linux_networking_control.l2_fwd_rx_table"
 
-#define LNW_L2_FWD_RX_TABLE_KEY_DST_MAC \
-        "dst_mac"
+#define LNW_L2_FWD_RX_TABLE_KEY_DST_MAC "dst_mac"
 
-#define LNW_L2_FWD_RX_TABLE_ACTION_L2_FWD \
-        "linux_networking_control.l2_fwd"
-#define LNW_ACTION_L2_FWD_PARAM_PORT \
-        "port"
-
+#define LNW_L2_FWD_RX_TABLE_ACTION_L2_FWD "linux_networking_control.l2_fwd"
+#define LNW_ACTION_L2_FWD_PARAM_PORT "port"
 
 /* L2_FWD_RX_WITH_TUNNEL_TABLE */
 #define LNW_L2_FWD_RX_WITH_TUNNEL_TABLE \
-        "linux_networking_control.l2_fwd_rx_with_tunnel_table"
+  "linux_networking_control.l2_fwd_rx_with_tunnel_table"
 
-#define LNW_L2_FWD_RX_WITH_TUNNEL_TABLE_KEY_DST_MAC \
-        "dst_mac"
+#define LNW_L2_FWD_RX_WITH_TUNNEL_TABLE_KEY_DST_MAC "dst_mac"
 
 #define LNW_L2_FWD_RX_WITH_TUNNEL_TABLE_ACTION_L2_FWD \
-        "linux_networking_control.l2_fwd"
-
+  "linux_networking_control.l2_fwd"
 
 /* L2_FWD_TX_TABLE */
-#define LNW_L2_FWD_TX_TABLE \
-        "linux_networking_control.l2_fwd_tx_table"
+#define LNW_L2_FWD_TX_TABLE "linux_networking_control.l2_fwd_tx_table"
 
-#define LNW_L2_FWD_TX_TABLE_KEY_DST_MAC \
-        "dst_mac"
+#define LNW_L2_FWD_TX_TABLE_KEY_DST_MAC "dst_mac"
 
-#define LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD \
-        "linux_networking_control.l2_fwd"
+#define LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD "linux_networking_control.l2_fwd"
 
 #define LNW_L2_FWD_TX_TABLE_ACTION_SET_TUNNEL \
-        "linux_networking_control.set_tunnel"
-#define LNW_ACTION_SET_TUNNEL_PARAM_TUNNEL_ID \
-        "tunnel_id"
-#define LNW_ACTION_SET_TUNNEL_PARAM_DST_ADDR \
-        "dst_addr"
-
+  "linux_networking_control.set_tunnel"
+#define LNW_ACTION_SET_TUNNEL_PARAM_TUNNEL_ID "tunnel_id"
+#define LNW_ACTION_SET_TUNNEL_PARAM_DST_ADDR "dst_addr"
 
 /* NEXTHOP_TABLE */
-#define LNW_NEXTHOP_TABLE \
-        "linux_networking_control.nexthop_table"
+#define LNW_NEXTHOP_TABLE "linux_networking_control.nexthop_table"
 
-#define LNW_NEXTHOP_TABLE_KEY_NEXTHOP_ID \
-        "local_metadata.nexthop_id"
+#define LNW_NEXTHOP_TABLE_KEY_NEXTHOP_ID "local_metadata.nexthop_id"
 
 #define LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP \
-        "linux_networking_control.set_nexthop"
-#define LNW_ACTION_SET_NEXTHOP_PARAM_RIF \
-        "router_interface_id"
-#define LNW_ACTION_SET_NEXTHOP_PARAM_NEIGHBOR_ID \
-        "neighbor_id"
-#define LNW_ACTION_SET_NEXTHOP_PARAM_EGRESS_PORT \
-        "egress_port"
+  "linux_networking_control.set_nexthop"
+#define LNW_ACTION_SET_NEXTHOP_PARAM_RIF "router_interface_id"
+#define LNW_ACTION_SET_NEXTHOP_PARAM_NEIGHBOR_ID "neighbor_id"
+#define LNW_ACTION_SET_NEXTHOP_PARAM_EGRESS_PORT "egress_port"
 
 /* ECMP_HASH_TABLE */
-#define LNW_ECMP_HASH_TABLE \
-        "linux_networking_control.ecmp_hash_table"
+#define LNW_ECMP_HASH_TABLE "linux_networking_control.ecmp_hash_table"
 
 #define LNW_ECMP_HASH_TABLE_KEY_HOST_INFO_TX_EXTENDED_FLEX_0 \
-        "local_metadata.host_info_tx_extended_flex_0"
-#define LNW_ECMP_HASH_TABLE_KEY_HASH \
-        "local_metadata.hash"
+  "local_metadata.host_info_tx_extended_flex_0"
+#define LNW_ECMP_HASH_TABLE_KEY_HASH "local_metadata.hash"
 
 #define LNW_ECMP_HASH_TABLE_ACTION_SET_NEXTHOP_ID \
-        "linux_networking_control.set_nexthop_id"
+  "linux_networking_control.set_nexthop_id"
 
 #define LNW_ECMP_HASH_SIZE 65536
 #define LNW_MAX_MEMBERS 512
 
 /* IPV4_TABLE */
-#define LNW_IPV4_TABLE \
-        "linux_networking_control.ipv4_table"
+#define LNW_IPV4_TABLE "linux_networking_control.ipv4_table"
 
-#define LNW_IPV4_TABLE_KEY_IPV4_DST_MATCH \
-        "local_metadata.ipv4_dst_match"
+#define LNW_IPV4_TABLE_KEY_IPV4_DST_MATCH "local_metadata.ipv4_dst_match"
 
 #define LNW_IPV4_TABLE_ACTION_SET_NEXTHOP_ID \
-        "linux_networking_control.set_nexthop_id"
-#define LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID \
-        "nexthop_id"
+  "linux_networking_control.set_nexthop_id"
+#define LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID "nexthop_id"
 
 #define LNW_IPV4_TABLE_ACTION_ECMP_HASH_ACTION \
-        "linux_networking_control.ecmp_hash_action"
-#define LNW_ACTION_ECMP_HASH_ACTION_PARAM_ECMP_GROUP_ID \
-        "ecmp_group_id"
+  "linux_networking_control.ecmp_hash_action"
+#define LNW_ACTION_ECMP_HASH_ACTION_PARAM_ECMP_GROUP_ID "ecmp_group_id"
 
 /* AS_ECMP_TABLE */
-#define LNW_AS_ECMP_TABLE \
-        "linux_networking_control.as_ecmp"
+#define LNW_AS_ECMP_TABLE "linux_networking_control.as_ecmp"
 
-#define LNW_AS_ECMP_SELECTOR_TABLE \
-        "linux_networking_control.as_ecmp_sel"
+#define LNW_AS_ECMP_SELECTOR_TABLE "linux_networking_control.as_ecmp_sel"
 
-#define LNW_SELECTOR_GROUP_ID \
-        "$SELECTOR_GROUP_ID"
+#define LNW_SELECTOR_GROUP_ID "$SELECTOR_GROUP_ID"
 
-#define LNW_SELECTOR_MEMBER_ID \
-        "$ACTION_MEMBER_ID"
+#define LNW_SELECTOR_MEMBER_ID "$ACTION_MEMBER_ID"
 
-#define LNW_ACTION_MEMBER_STATUS \
-        "$ACTION_MEMBER_STATUS"
+#define LNW_ACTION_MEMBER_STATUS "$ACTION_MEMBER_STATUS"
 
-#define LNW_ACTION_MAX_GROUP_SIZE \
-        "$MAX_GROUP_SIZE"
-#define LNW_SELECTOR_ACTION_ID \
-        0
+#define LNW_ACTION_MAX_GROUP_SIZE "$MAX_GROUP_SIZE"
+#define LNW_SELECTOR_ACTION_ID 0
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* __SWITCH_PD_P4_NAME_MAPPING__ */
-

--- a/switchapi/dpdk/switch_pd_p4_name_mapping.h
+++ b/switchapi/dpdk/switch_pd_p4_name_mapping.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/dpdk/switch_pd_routing.c
+++ b/switchapi/dpdk/switch_pd_routing.c
@@ -17,1158 +17,1147 @@
 
 #include "switch_pd_routing.h"
 
+#include "port_mgr/dpdk/bf_dpdk_port_if.h"
+#include "switch_pd_p4_name_mapping.h"
+#include "switch_pd_utils.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_nhop_int.h"
 
-#include "switch_pd_utils.h"
-#include "switch_pd_p4_name_mapping.h"
-
-#include "port_mgr/dpdk/bf_dpdk_port_if.h"
-
-switch_status_t switch_routing_table_entry (
-        switch_device_t device,
-        const switch_pd_routing_info_t *api_routing_info,
-        bool entry_type)
-{
+switch_status_t switch_routing_table_entry(
+    switch_device_t device, const switch_pd_routing_info_t* api_routing_info,
+    bool entry_type) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   krnlmon_log_debug("%s", __func__);
 
-  //update nexthop table
+  // update nexthop table
   status = switch_pd_nexthop_table_entry(device, api_routing_info, entry_type);
-  if (status != SWITCH_STATUS_SUCCESS){
-     krnlmon_log_error("nexthop table update failed, error: %d", status);
-     return status;
+  if (status != SWITCH_STATUS_SUCCESS) {
+    krnlmon_log_error("nexthop table update failed, error: %d", status);
+    return status;
   }
 
-  //update neighbor mod table
+  // update neighbor mod table
   status = switch_pd_neighbor_table_entry(device, api_routing_info, entry_type);
-  if (status != SWITCH_STATUS_SUCCESS){
-      krnlmon_log_error( "neighbor table update failed, error: %d", status);
-      return status;
+  if (status != SWITCH_STATUS_SUCCESS) {
+    krnlmon_log_error("neighbor table update failed, error: %d", status);
+    return status;
   }
   return status;
 }
 
-switch_status_t switch_pd_rmac_table_entry (
-        switch_device_t device,
-        switch_rmac_entry_t *rmac_entry,
-        switch_handle_t rif_handle,
-        bool entry_type)
-{
+switch_status_t switch_pd_rmac_table_entry(switch_device_t device,
+                                           switch_rmac_entry_t* rmac_entry,
+                                           switch_handle_t rif_handle,
+                                           bool entry_type) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   krnlmon_log_debug("%s", __func__);
 
   if (!rmac_entry) {
-      krnlmon_log_error("Empty router_mac entry, error: %d", status);
-      return status;
+    krnlmon_log_error("Empty router_mac entry, error: %d", status);
+    return status;
   }
 
-  //update rif mod tables
+  // update rif mod tables
   status = switch_pd_rif_mod_entry(device, rmac_entry, rif_handle, entry_type);
-  if (status != SWITCH_STATUS_SUCCESS){
-      krnlmon_log_error("rid mod table entry failed, error: %d", status);
-      return status;
+  if (status != SWITCH_STATUS_SUCCESS) {
+    krnlmon_log_error("rid mod table entry failed, error: %d", status);
+    return status;
   }
   return status;
 }
 
 switch_status_t switch_pd_nexthop_table_entry(
-    switch_device_t device,
-    const switch_pd_routing_info_t  *api_nexthop_pd_info,
+    switch_device_t device, const switch_pd_routing_info_t* api_nexthop_pd_info,
     bool entry_add) {
+  tdi_status_t status;
 
-    tdi_status_t status;
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
 
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
+  tdi_dev_id_t dev_id = device;
 
-    tdi_dev_id_t dev_id = device;
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
 
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
+  krnlmon_log_debug("%s", __func__);
 
-    krnlmon_log_debug("%s", __func__);
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_from_name_get(info_hdl, LNW_NEXTHOP_TABLE, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_NEXTHOP_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_NEXTHOP_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table, error: %d",
+                      status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(table_info_hdl,
+                                LNW_NEXTHOP_TABLE_KEY_NEXTHOP_ID, &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_NEXTHOP_TABLE_KEY_NEXTHOP_ID, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_set_value(
+      key_hdl, field_id,
+      (api_nexthop_pd_info->nexthop_handle &
+       ~(SWITCH_HANDLE_TYPE_NHOP << SWITCH_HANDLE_TYPE_SHIFT)));
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to set value for key ID: %d for nexthop_table,"
+        " error: %d",
+        field_id, status);
+    goto dealloc_resources;
+  }
+
+  if (entry_add) {
+    /* Add an entry to target */
+    krnlmon_log_info(
+        "Populate set_nexthop action with neighbor id: 0x%x in"
+        " nexthop_table for nexthop_id 0x%x",
+        (unsigned int)api_nexthop_pd_info->neighbor_handle,
+        (unsigned int)api_nexthop_pd_info->nexthop_handle);
+
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP, &action_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_flags_create(0, &flags_hdl);
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_device_get(dev_id, &dev_hdl);
+    status = tdi_data_field_id_with_action_get(table_info_hdl,
+                                               LNW_ACTION_SET_NEXTHOP_PARAM_RIF,
+                                               action_id, &data_field_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_SET_NEXTHOP_PARAM_RIF, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_target_create(dev_hdl, &target_hdl);
+    status = tdi_data_field_set_value(
+        data_hdl, data_field_id,
+        (api_nexthop_pd_info->rif_handle &
+         ~(SWITCH_HANDLE_TYPE_RIF << SWITCH_HANDLE_TYPE_SHIFT)));
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_session_create(dev_hdl, &session);
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_SET_NEXTHOP_PARAM_NEIGHBOR_ID, action_id,
+        &data_field_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_SET_NEXTHOP_PARAM_NEIGHBOR_ID, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_table_from_name_get(info_hdl,
-                                       LNW_NEXTHOP_TABLE,
-                                       &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                 LNW_NEXTHOP_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
+    status = tdi_data_field_set_value(
+        data_hdl, data_field_id,
+        (api_nexthop_pd_info->neighbor_handle &
+         ~(SWITCH_HANDLE_TYPE_NEIGHBOR << SWITCH_HANDLE_TYPE_SHIFT)));
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_NEXTHOP_TABLE, status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_SET_NEXTHOP_PARAM_EGRESS_PORT, action_id,
+        &data_field_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_SET_NEXTHOP_PARAM_EGRESS_PORT, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_NEXTHOP_TABLE_KEY_NEXTHOP_ID,
-                                  &field_id);
+    status = tdi_data_field_set_value(data_hdl, data_field_id,
+                                      api_nexthop_pd_info->port_id);
     if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_NEXTHOP_TABLE_KEY_NEXTHOP_ID, status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_key_field_set_value(key_hdl, field_id,
-                                     (api_nexthop_pd_info->nexthop_handle &
-                                     ~(SWITCH_HANDLE_TYPE_NHOP <<
-                                     SWITCH_HANDLE_TYPE_SHIFT)));
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d for nexthop_table,"
-                 " error: %d", field_id, status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to add %s entry, error: %d", LNW_NEXTHOP_TABLE,
+                        status);
+      goto dealloc_resources;
     }
 
-    if (entry_add) {
-        /* Add an entry to target */
-        krnlmon_log_info("Populate set_nexthop action with neighbor id: 0x%x in"
-                  " nexthop_table for nexthop_id 0x%x",
-                  (unsigned int) api_nexthop_pd_info->neighbor_handle,
-                  (unsigned int) api_nexthop_pd_info->nexthop_handle);
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_SET_NEXTHOP_PARAM_RIF,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_SET_NEXTHOP_PARAM_RIF, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                          (api_nexthop_pd_info->rif_handle &
-                                          ~(SWITCH_HANDLE_TYPE_RIF <<
-                                          SWITCH_HANDLE_TYPE_SHIFT)));
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_SET_NEXTHOP_PARAM_NEIGHBOR_ID,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_SET_NEXTHOP_PARAM_NEIGHBOR_ID, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                          (api_nexthop_pd_info->neighbor_handle &
-                                          ~(SWITCH_HANDLE_TYPE_NEIGHBOR <<
-                                          SWITCH_HANDLE_TYPE_SHIFT)));
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_SET_NEXTHOP_PARAM_EGRESS_PORT,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                   LNW_ACTION_SET_NEXTHOP_PARAM_EGRESS_PORT, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                          api_nexthop_pd_info->port_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d", 
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add %s entry, error: %d", 
-                   LNW_NEXTHOP_TABLE, status);
-            goto dealloc_resources;
-        }
-
-    } else {
-        /* Delete an entry from target */
-        krnlmon_log_info("Delete nexthop_table entry");
-        status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                     flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete %s entry, error: %d", 
-                     LNW_NEXTHOP_TABLE, status);
-            goto dealloc_resources;
-        }
+  } else {
+    /* Delete an entry from target */
+    krnlmon_log_info("Delete nexthop_table entry");
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to delete %s entry, error: %d",
+                        LNW_NEXTHOP_TABLE, status);
+      goto dealloc_resources;
+    }
   }
 
 dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
 }
 
 switch_status_t switch_pd_neighbor_table_entry(
     switch_device_t device,
-    const switch_pd_routing_info_t  *api_neighbor_pd_info,
+    const switch_pd_routing_info_t* api_neighbor_pd_info, bool entry_add) {
+  tdi_status_t status;
+
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
+
+  tdi_dev_id_t dev_id = device;
+
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
+
+  krnlmon_log_debug("%s", __func__);
+
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status =
+      tdi_table_from_name_get(info_hdl, LNW_NEIGHBOR_MOD_TABLE, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_NEIGHBOR_MOD_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_NEIGHBOR_MOD_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table, error: %d",
+                      status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(
+      table_info_hdl, LNW_NEIGHBOR_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR,
+      &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_NEIGHBOR_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR,
+                      status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_set_value(
+      key_hdl, field_id,
+      (api_neighbor_pd_info->neighbor_handle &
+       ~(SWITCH_HANDLE_TYPE_NEIGHBOR << SWITCH_HANDLE_TYPE_SHIFT)));
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to set value for key ID: %d for neighbor_mod_table", field_id);
+    goto dealloc_resources;
+  }
+
+  if (entry_add) {
+    /* Add an entry to target */
+    krnlmon_log_info(
+        "Populate set_outer_mac action in neighbor_mod_table for "
+        "neighbor handle %x",
+        (unsigned int)api_neighbor_pd_info->neighbor_handle);
+
+    status = tdi_action_name_to_id(table_info_hdl,
+                                   LNW_NEIGHBOR_MOD_TABLE_ACTION_SET_OUTER_MAC,
+                                   &action_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_NEIGHBOR_MOD_TABLE_ACTION_SET_OUTER_MAC, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_SET_OUTER_MAC_PARAM_DST_MAC_ADDR, action_id,
+        &data_field_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_SET_OUTER_MAC_PARAM_DST_MAC_ADDR, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_set_value_ptr(
+        data_hdl, data_field_id,
+        (const uint8_t*)&api_neighbor_pd_info->dst_mac_addr.mac_addr,
+        SWITCH_MAC_LENGTH);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to add neighbor_mod_table entry, error: %d",
+                        status);
+      goto dealloc_resources;
+    }
+  } else {
+    /* Delete an entry from target */
+    krnlmon_log_info("Delete neighbor_mod_table entry");
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to delete nexthop_table entry, error: %d",
+                        status);
+      goto dealloc_resources;
+    }
+  }
+
+dealloc_resources:
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
+}
+
+switch_status_t switch_pd_rif_mod_entry(switch_device_t device,
+                                        switch_rmac_entry_t* rmac_entry,
+                                        switch_handle_t rif_handle,
+                                        bool entry_add) {
+  tdi_status_t status;
+
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
+
+  tdi_dev_id_t dev_id = device;
+
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
+
+  krnlmon_log_debug("%s", __func__);
+
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_from_name_get(info_hdl, LNW_RIF_MOD_TABLE, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_RIF_MOD_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_RIF_MOD_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table, error: %d",
+                      status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(
+      table_info_hdl, LNW_RIF_MOD_TABLE_KEY_RIF_MOD_MAP_ID, &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_RIF_MOD_TABLE_KEY_RIF_MOD_MAP_ID, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_set_value(
+      key_hdl, field_id,
+      (rif_handle & ~(SWITCH_HANDLE_TYPE_RIF << SWITCH_HANDLE_TYPE_SHIFT)));
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to set value for key ID: %d for rif_mod_table_start", field_id);
+    goto dealloc_resources;
+  }
+
+  if (entry_add) {
+    /* Add an entry to target */
+    krnlmon_log_info(
+        "Populate set_src_mac_start action in rif_mod_table_start");
+
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_RIF_MOD_TABLE_ACTION_SET_SRC_MAC, &action_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_RIF_MOD_TABLE_ACTION_SET_SRC_MAC, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_SET_SRC_MAC_PARAM_SRC_MAC_ADDR, action_id,
+        &data_field_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_SET_SRC_MAC_PARAM_SRC_MAC_ADDR, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_set_value_ptr(
+        data_hdl, data_field_id, (const uint8_t*)&rmac_entry->mac.mac_addr,
+        SWITCH_MAC_LENGTH);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to add rif_mod_table_start entry, error: %d",
+                        status);
+      goto dealloc_resources;
+    }
+  } else {
+    /* Delete an entry from target */
+    krnlmon_log_info("Delete rif_mod_table_start entry");
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to delete rif_mod_table_start entry, error: %d",
+                        status);
+      goto dealloc_resources;
+    }
+  }
+
+dealloc_resources:
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
+}
+
+switch_status_t switch_pd_ipv4_table_entry(
+    switch_device_t device, const switch_api_route_entry_t* api_route_entry,
+    bool entry_add, switch_ipv4_table_action_t action) {
+  tdi_status_t status;
+
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
+
+  tdi_dev_id_t dev_id = device;
+
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
+  uint32_t network_byte_order;
+
+  krnlmon_log_debug("%s", __func__);
+
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_from_name_get(info_hdl, LNW_IPV4_TABLE, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_IPV4_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_IPV4_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table, error: %d",
+                      status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(table_info_hdl,
+                                LNW_IPV4_TABLE_KEY_IPV4_DST_MATCH, &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_IPV4_TABLE_KEY_IPV4_DST_MATCH, status);
+    goto dealloc_resources;
+  }
+
+  /* Use LPM API for LPM match type*/
+  network_byte_order = ntohl(api_route_entry->ip_address.ip.v4addr);
+  status = tdi_key_field_set_value_lpm_ptr(
+      key_hdl, field_id, (const uint8_t*)&network_byte_order,
+      (const uint16_t)api_route_entry->ip_address.prefix_len, sizeof(uint32_t));
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to set value for key ID: %d for ipv4_table, error: %d",
+        field_id, status);
+    goto dealloc_resources;
+  }
+
+  if (entry_add) {
+    if (action == SWITCH_ACTION_NHOP) {
+      krnlmon_log_info("Populate member ID 0x%x as action in ipv4_table key %x",
+                       (unsigned int)api_route_entry->nhop_member_handle,
+                       api_route_entry->ip_address.ip.v4addr);
+      status = tdi_table_data_allocate(table_hdl, &data_hdl);
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error(
+            "Unable to get action allocator for ID: %d, "
+            "error: %d",
+            action_id, status);
+        goto dealloc_resources;
+      }
+
+      /* Set MEMBER_ID value for the selector table */
+      status = tdi_data_field_id_with_action_get(
+          table_info_hdl, LNW_SELECTOR_MEMBER_ID, LNW_SELECTOR_ACTION_ID,
+          &data_field_id);
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error(
+            "Unable to get data field id param for: %s, error: %d",
+            LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID, status);
+        goto dealloc_resources;
+      }
+
+      status = tdi_data_field_set_value(
+          data_hdl, data_field_id,
+          (api_route_entry->nhop_member_handle &
+           ~(SWITCH_HANDLE_TYPE_NHOP_MEMBER << SWITCH_HANDLE_TYPE_SHIFT)));
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                          data_field_id, status);
+        goto dealloc_resources;
+      }
+    }
+    if (action == SWITCH_ACTION_NHOP_GROUP) {
+      krnlmon_log_info("Populate Group ID 0x%x as action in ipv4_table key %x",
+                       (unsigned int)api_route_entry->nhop_handle,
+                       api_route_entry->ip_address.ip.v4addr);
+
+      status = tdi_table_data_allocate(table_hdl, &data_hdl);
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error(
+            "Unable to get action allocator for ID: %d, "
+            "error: %d",
+            action_id, status);
+        goto dealloc_resources;
+      }
+
+      status = tdi_data_field_id_with_action_get(
+          table_info_hdl, LNW_SELECTOR_GROUP_ID, action_id, &data_field_id);
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error(
+            "Unable to get data field id param for: %s, error: %d",
+            "SELECTOR_GROUP_ID", status);
+        goto dealloc_resources;
+      }
+
+      status = tdi_data_field_set_value(
+          data_hdl, data_field_id,
+          (api_route_entry->nhop_handle &
+           ~(SWITCH_HANDLE_TYPE_NHOP_GROUP << SWITCH_HANDLE_TYPE_SHIFT)));
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                          data_field_id, status);
+        goto dealloc_resources;
+      }
+    }
+
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to add ipv4 table entry, error: %d", status);
+      goto dealloc_resources;
+    }
+  } else {
+    /* Delete an entry from target */
+    krnlmon_log_info("Delete ipv4_table entry");
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to delete ipv4_table entry, error: %d", status);
+      goto dealloc_resources;
+    }
+  }
+
+dealloc_resources:
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
+}
+
+switch_status_t switch_pd_handle_member(
+    switch_device_t device, const switch_nhop_member_t* nhop_member_pd_info,
     bool entry_add) {
+  tdi_status_t status;
 
-    tdi_status_t status;
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
 
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
+  tdi_dev_id_t dev_id = device;
 
-    tdi_dev_id_t dev_id = device;
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
+  uint32_t network_byte_order;
 
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
+  krnlmon_log_debug("%s", __func__);
 
-    krnlmon_log_debug("%s", __func__);
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_from_name_get(info_hdl, LNW_AS_ECMP_TABLE, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_IPV4_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_IPV4_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table, error: %d",
+                      status);
+    goto dealloc_resources;
+  }
+
+  status =
+      tdi_key_field_id_get(table_info_hdl, LNW_SELECTOR_MEMBER_ID, &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_SELECTOR_MEMBER_ID, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_set_value(
+      key_hdl, field_id,
+      (nhop_member_pd_info->member_handle &
+       ~(SWITCH_HANDLE_TYPE_NHOP_MEMBER << SWITCH_HANDLE_TYPE_SHIFT)));
+
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to set member for key ID: %d for ipv4_table,"
+        " error: %d",
+        field_id, status);
+    goto dealloc_resources;
+  }
+
+  if (entry_add) {
+    krnlmon_log_info(
+        "Populate set_nexthop_id action for nhop handle 0x%x"
+        " and member ID 0x%x",
+        (unsigned int)nhop_member_pd_info->nhop_handle,
+        (unsigned int)nhop_member_pd_info->member_handle);
+
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_IPV4_TABLE_ACTION_SET_NEXTHOP_ID, &action_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_IPV4_TABLE_ACTION_SET_NEXTHOP_ID, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_flags_create(0, &flags_hdl);
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_device_get(dev_id, &dev_hdl);
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID, action_id,
+        &data_field_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_target_create(dev_hdl, &target_hdl);
+    status = tdi_data_field_set_value(
+        data_hdl, data_field_id,
+        (nhop_member_pd_info->nhop_handle &
+         ~(SWITCH_HANDLE_TYPE_NHOP << SWITCH_HANDLE_TYPE_SHIFT)));
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_session_create(dev_hdl, &session);
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to add member entry, error: %d", status);
+      goto dealloc_resources;
     }
-
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_NEIGHBOR_MOD_TABLE,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                 LNW_NEIGHBOR_MOD_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  } else {
+    /* Delete an entry from target */
+    krnlmon_log_info("Delete member table entry");
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_NEIGHBOR_MOD_TABLE, status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to delete member table entry, error: %d",
+                        status);
+      goto dealloc_resources;
     }
-
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_NEIGHBOR_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_NEIGHBOR_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_set_value(key_hdl, field_id,
-                                     (api_neighbor_pd_info->neighbor_handle &
-                                     ~(SWITCH_HANDLE_TYPE_NEIGHBOR <<
-                                     SWITCH_HANDLE_TYPE_SHIFT)));
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d for neighbor_mod_table",
-                 field_id);
-        goto dealloc_resources;
-    }
-
-    if (entry_add) {
-        /* Add an entry to target */
-        krnlmon_log_info("Populate set_outer_mac action in neighbor_mod_table for "
-                  "neighbor handle %x",
-                  (unsigned int) api_neighbor_pd_info->neighbor_handle);
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_NEIGHBOR_MOD_TABLE_ACTION_SET_OUTER_MAC,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_NEIGHBOR_MOD_TABLE_ACTION_SET_OUTER_MAC, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_SET_OUTER_MAC_PARAM_DST_MAC_ADDR,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                   LNW_ACTION_SET_OUTER_MAC_PARAM_DST_MAC_ADDR, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value_ptr(data_hdl, data_field_id,
-                                              (const uint8_t *)
-                                              &api_neighbor_pd_info->dst_mac_addr.mac_addr,
-                                              SWITCH_MAC_LENGTH);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add neighbor_mod_table entry, error: %d", status);
-            goto dealloc_resources;
-        }
-    } else {
-        /* Delete an entry from target */
-        krnlmon_log_info("Delete neighbor_mod_table entry");
-        status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                     flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete nexthop_table entry, error: %d", status);
-            goto dealloc_resources;
-        }
-    }
+  }
 
 dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
 }
 
-switch_status_t switch_pd_rif_mod_entry(
-  switch_device_t device,
-  switch_rmac_entry_t *rmac_entry,
-  switch_handle_t rif_handle,
-  bool entry_add) {
+switch_status_t switch_pd_handle_group(
+    switch_device_t device, switch_nhop_group_info_t* nhop_group_pd_info,
+    bool entry_add) {
+  tdi_status_t status;
 
-    tdi_status_t status;
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
 
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
+  tdi_dev_id_t dev_id = device;
 
-    tdi_dev_id_t dev_id = device;
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
+  uint32_t member_ids[LNW_MAX_MEMBERS] = {0};
+  bool member_status[LNW_MAX_MEMBERS] = {0};
+  uint8_t index = 0;
 
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
+  krnlmon_log_debug("%s", __func__);
 
-    krnlmon_log_debug("%s", __func__);
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status =
+      tdi_table_from_name_get(info_hdl, LNW_AS_ECMP_SELECTOR_TABLE, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_IPV4_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_IPV4_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table, error: %d",
+                      status);
+    goto dealloc_resources;
+  }
+
+  status =
+      tdi_key_field_id_get(table_info_hdl, LNW_SELECTOR_GROUP_ID, &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_SELECTOR_MEMBER_ID, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_set_value(
+      key_hdl, field_id,
+      (nhop_group_pd_info->nhop_group_handle &
+       ~(SWITCH_HANDLE_TYPE_NHOP_GROUP << SWITCH_HANDLE_TYPE_SHIFT)));
+
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to set NHOP group for key ID: %d for ipv4_table, error: %d",
+        field_id, status);
+    goto dealloc_resources;
+  }
+
+  if (entry_add) {
+    krnlmon_log_info(
+        "Populate nhop member in selector table for "
+        "NHOP group handle %x",
+        (unsigned int)nhop_group_pd_info->nhop_group_handle);
+    tommy_node* node = tommy_list_head(&nhop_group_pd_info->members.list);
+
+    while (node) {
+      switch_nhop_member_t* nhop_member = NULL;
+      nhop_member = (switch_nhop_member_t*)node->data;
+      member_status[index] = nhop_member->active;
+      member_ids[index] =
+          (nhop_member->member_handle &
+           ~(SWITCH_HANDLE_TYPE_NHOP_MEMBER << SWITCH_HANDLE_TYPE_SHIFT));
+      node = node->next;
+      krnlmon_log_info("Populating member details %d:%s", member_ids[index],
+                       member_status[index] ? "TRUE" : "FALSE");
+      index++;
+    }
+    krnlmon_log_debug("Total number of members: %d", index);
+
+    /* As per spec action_id is 0 */
+    status = tdi_table_data_allocate(table_hdl, &data_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_flags_create(0, &flags_hdl);
+    /* Set MEMBER_ID value for the selector table */
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_SELECTOR_MEMBER_ID, LNW_SELECTOR_ACTION_ID,
+        &data_field_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_device_get(dev_id, &dev_hdl);
+    status = tdi_data_field_set_value_array(data_hdl, data_field_id, member_ids,
+                                            (const uint32_t)index);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_target_create(dev_hdl, &target_hdl);
+    /* Set MAXIMUM GROUP SIZE value for the selector table */
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_MAX_GROUP_SIZE, LNW_SELECTOR_ACTION_ID,
+        &data_field_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_session_create(dev_hdl, &session);
+    status = tdi_data_field_set_value(data_hdl, data_field_id, LNW_MAX_MEMBERS);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_RIF_MOD_TABLE,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                 LNW_RIF_MOD_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
+    /* Set ACTION MEMBER STATUS value for the selector table */
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_MEMBER_STATUS, LNW_SELECTOR_ACTION_ID,
+        &data_field_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_RIF_MOD_TABLE, status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
+    status = tdi_data_field_set_value_bool_array(
+        data_hdl, data_field_id, member_status, (const uint32_t)index);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_RIF_MOD_TABLE_KEY_RIF_MOD_MAP_ID,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_RIF_MOD_TABLE_KEY_RIF_MOD_MAP_ID, status);
+    /* Only for first insert of 'Group + Members' we will call Entry_add */
+    if (!nhop_group_pd_info->first_insert_complete) {
+      status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                   key_hdl, data_hdl);
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error("Unable to add group entry, error: %d", status);
         goto dealloc_resources;
-    }
-
-    status = tdi_key_field_set_value(key_hdl, field_id,
-                                     (rif_handle &
-                                     ~(SWITCH_HANDLE_TYPE_RIF <<
-                                     SWITCH_HANDLE_TYPE_SHIFT)));
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d for rif_mod_table_start",
-                 field_id);
-        goto dealloc_resources;
-    }
-
-    if (entry_add) {
-        /* Add an entry to target */
-        krnlmon_log_info("Populate set_src_mac_start action in rif_mod_table_start");
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_RIF_MOD_TABLE_ACTION_SET_SRC_MAC,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_RIF_MOD_TABLE_ACTION_SET_SRC_MAC, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_SET_SRC_MAC_PARAM_SRC_MAC_ADDR,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                   LNW_ACTION_SET_SRC_MAC_PARAM_SRC_MAC_ADDR, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value_ptr(data_hdl, data_field_id,
-                                (             const uint8_t *)
-                                              &rmac_entry->mac.mac_addr,
-                                              SWITCH_MAC_LENGTH);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add rif_mod_table_start entry, error: %d", status);
-            goto dealloc_resources;
-        }
+      }
+      /* Only during first Init of a group this value is false and during
+       * the life time of this nhop group this value is true.
+       * TODO: Uncomment below assignment when backend p4-driver supports
+       * modify for action selector
+       */
+      // nhop_group_pd_info->first_insert_complete = true;
     } else {
-        /* Delete an entry from target */
-        krnlmon_log_info("Delete rif_mod_table_start entry");
-        status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                     flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete rif_mod_table_start entry, error: %d", status);
-            goto dealloc_resources;
-        }
+      status = tdi_table_entry_mod(table_hdl, session, target_hdl, flags_hdl,
+                                   key_hdl, data_hdl);
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error("Unable to modify group entry, error: %d", status);
+        goto dealloc_resources;
+      }
     }
+  } else {
+    /* Delete an entry from target */
+    krnlmon_log_info("Delete selector group table");
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to delete group table entry, error: %d",
+                        status);
+      goto dealloc_resources;
+    }
+  }
 
 dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
-}
-
-switch_status_t switch_pd_ipv4_table_entry (switch_device_t device,
-    const switch_api_route_entry_t *api_route_entry,
-    bool entry_add, switch_ipv4_table_action_t action)
-{
-    tdi_status_t status;
-
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
-
-    tdi_dev_id_t dev_id = device;
-
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
-    uint32_t network_byte_order;
-
-    krnlmon_log_debug("%s", __func__);
-
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_flags_create(0, &flags_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_device_get(dev_id, &dev_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_target_create(dev_hdl, &target_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_session_create(dev_hdl, &session);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_IPV4_TABLE,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                LNW_IPV4_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_IPV4_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_IPV4_TABLE_KEY_IPV4_DST_MATCH,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_IPV4_TABLE_KEY_IPV4_DST_MATCH, status);
-        goto dealloc_resources;
-    }
-
-    /* Use LPM API for LPM match type*/
-    network_byte_order = ntohl(api_route_entry->ip_address.ip.v4addr);
-    status = tdi_key_field_set_value_lpm_ptr(key_hdl, field_id,
-                                             (const uint8_t *)&network_byte_order,
-                                             (const uint16_t)api_route_entry->ip_address.prefix_len,
-                                             sizeof(uint32_t));
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d for ipv4_table, error: %d",
-                 field_id, status);
-        goto dealloc_resources;
-    }
-
-    if (entry_add) {
-        if (action == SWITCH_ACTION_NHOP) {
-            krnlmon_log_info("Populate member ID 0x%x as action in ipv4_table key %x",
-                      (unsigned int) api_route_entry->nhop_member_handle,
-                      api_route_entry->ip_address.ip.v4addr);
-            status = tdi_table_data_allocate(table_hdl, &data_hdl);
-            if (status != TDI_SUCCESS) {
-                krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                         "error: %d", action_id, status);
-                goto dealloc_resources;
-            }
-
-            /* Set MEMBER_ID value for the selector table */
-            status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                       LNW_SELECTOR_MEMBER_ID,
-                                                       LNW_SELECTOR_ACTION_ID,
-                                                       &data_field_id);
-            if (status != TDI_SUCCESS) {
-                krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                         LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID, status);
-                    goto dealloc_resources;
-            }
- 
-            status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                              (api_route_entry->nhop_member_handle &
-                                              ~(SWITCH_HANDLE_TYPE_NHOP_MEMBER <<
-                                              SWITCH_HANDLE_TYPE_SHIFT)));
-            if (status != TDI_SUCCESS) {
-                krnlmon_log_error("Unable to set action value for ID: %d, error: %d", 
-                         data_field_id, status);
-                goto dealloc_resources;
-            }
-        }
-        if (action == SWITCH_ACTION_NHOP_GROUP) {
-            krnlmon_log_info("Populate Group ID 0x%x as action in ipv4_table key %x",
-                      (unsigned int) api_route_entry->nhop_handle,
-                      api_route_entry->ip_address.ip.v4addr);
-
-            status = tdi_table_data_allocate(table_hdl, &data_hdl);
-            if (status != TDI_SUCCESS) {
-                krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                         "error: %d", action_id, status);
-                goto dealloc_resources;
-            }
-
-            status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                       LNW_SELECTOR_GROUP_ID,
-                                                       action_id, &data_field_id);
-            if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     "SELECTOR_GROUP_ID", status);
-                goto dealloc_resources;
-            }
-
-            status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                              (api_route_entry->nhop_handle &
-                                              ~(SWITCH_HANDLE_TYPE_NHOP_GROUP <<
-                                               SWITCH_HANDLE_TYPE_SHIFT)));
-            if (status != TDI_SUCCESS) {
-                krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                         data_field_id, status);
-                goto dealloc_resources;
-            }
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add ipv4 table entry, error: %d", status);
-            goto dealloc_resources;
-        }
-    } else {
-        /* Delete an entry from target */
-        krnlmon_log_info("Delete ipv4_table entry");
-        status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                     flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete ipv4_table entry, error: %d", status);
-            goto dealloc_resources;
-        }
-    }
-
-dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
-}
-
-switch_status_t switch_pd_handle_member(switch_device_t device,
-    const switch_nhop_member_t *nhop_member_pd_info,
-    bool entry_add)
-{
-    tdi_status_t status;
-
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
-
-    tdi_dev_id_t dev_id = device;
-
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
-    uint32_t network_byte_order;
-
-    krnlmon_log_debug("%s", __func__);
-
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_flags_create(0, &flags_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_device_get(dev_id, &dev_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_target_create(dev_hdl, &target_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_session_create(dev_hdl, &session);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_AS_ECMP_TABLE,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                LNW_IPV4_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_IPV4_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_SELECTOR_MEMBER_ID,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_SELECTOR_MEMBER_ID, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_set_value(key_hdl, field_id,
-                                     (nhop_member_pd_info->member_handle &
-                                     ~(SWITCH_HANDLE_TYPE_NHOP_MEMBER <<
-                                     SWITCH_HANDLE_TYPE_SHIFT)));
-
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set member for key ID: %d for ipv4_table,"
-                 " error: %d", field_id, status);
-        goto dealloc_resources;
-    }
-
-    if (entry_add) {
-        krnlmon_log_info("Populate set_nexthop_id action for nhop handle 0x%x"
-                  " and member ID 0x%x",
-                  (unsigned int) nhop_member_pd_info->nhop_handle,
-                  (unsigned int) nhop_member_pd_info->member_handle);
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_IPV4_TABLE_ACTION_SET_NEXTHOP_ID,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_IPV4_TABLE_ACTION_SET_NEXTHOP_ID, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID, status);
-                goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                          (nhop_member_pd_info->nhop_handle &
-                                          ~(SWITCH_HANDLE_TYPE_NHOP <<
-                                          SWITCH_HANDLE_TYPE_SHIFT)));
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d", 
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add member entry, error: %d", status);
-            goto dealloc_resources;
-        }
-    } else {
-        /* Delete an entry from target */
-        krnlmon_log_info("Delete member table entry");
-        status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                     flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete member table entry, error: %d", status);
-            goto dealloc_resources;
-        }
-    }
-
-dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
-}
-
-switch_status_t switch_pd_handle_group(switch_device_t device,
-    switch_nhop_group_info_t *nhop_group_pd_info,
-    bool entry_add)
-{
-    tdi_status_t status;
-
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
-
-    tdi_dev_id_t dev_id = device;
-
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
-    uint32_t member_ids[LNW_MAX_MEMBERS] ={0};
-    bool member_status[LNW_MAX_MEMBERS] ={0};
-    uint8_t index = 0;
-
-    krnlmon_log_debug("%s", __func__);
-
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_flags_create(0, &flags_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_device_get(dev_id, &dev_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_target_create(dev_hdl, &target_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_session_create(dev_hdl, &session);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_AS_ECMP_SELECTOR_TABLE,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                LNW_IPV4_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_IPV4_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_SELECTOR_GROUP_ID,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_SELECTOR_MEMBER_ID, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_set_value(key_hdl, field_id,
-                                     (nhop_group_pd_info->nhop_group_handle &
-                                     ~(SWITCH_HANDLE_TYPE_NHOP_GROUP <<
-                                     SWITCH_HANDLE_TYPE_SHIFT)));
-
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set NHOP group for key ID: %d for ipv4_table, error: %d",
-                 field_id, status);
-        goto dealloc_resources;
-    }
-
-    if (entry_add) {
-        krnlmon_log_info("Populate nhop member in selector table for "
-                  "NHOP group handle %x",
-                  (unsigned int) nhop_group_pd_info->nhop_group_handle);
-        tommy_node* node = tommy_list_head(&nhop_group_pd_info->members.list);
-
-        while (node) {
-            switch_nhop_member_t *nhop_member = NULL;
-            nhop_member = (switch_nhop_member_t *)node->data;
-            member_status[index] = nhop_member->active;
-            member_ids[index] = (nhop_member->member_handle &
-                                 ~(SWITCH_HANDLE_TYPE_NHOP_MEMBER <<
-                                 SWITCH_HANDLE_TYPE_SHIFT));
-            node = node->next;
-            krnlmon_log_info("Populating member details %d:%s",
-                      member_ids[index],
-                      member_status[index] ? "TRUE" : "FALSE");
-            index++;
-        }
-        krnlmon_log_debug("Total number of members: %d", index);
-
-        /* As per spec action_id is 0 */
-        status = tdi_table_data_allocate(table_hdl, &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        /* Set MEMBER_ID value for the selector table */
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_SELECTOR_MEMBER_ID,
-                                                   LNW_SELECTOR_ACTION_ID,
-                                                   &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID, status);
-                goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value_array(data_hdl, data_field_id,
-                                                member_ids,
-                                                (const uint32_t) index);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d", 
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        /* Set MAXIMUM GROUP SIZE value for the selector table */
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_MAX_GROUP_SIZE,
-                                                   LNW_SELECTOR_ACTION_ID,
-                                                   &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID, status);
-                goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                          LNW_MAX_MEMBERS);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d", 
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        /* Set ACTION MEMBER STATUS value for the selector table */
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_MEMBER_STATUS,
-                                                   LNW_SELECTOR_ACTION_ID,
-                                                   &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID, status);
-                goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value_bool_array(data_hdl, data_field_id,
-                                                     member_status,
-                                                     (const uint32_t) index);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d", 
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        /* Only for first insert of 'Group + Members' we will call Entry_add */
-        if (!nhop_group_pd_info->first_insert_complete) {
-            status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                         flags_hdl, key_hdl, data_hdl);
-            if (status != TDI_SUCCESS) {
-                krnlmon_log_error("Unable to add group entry, error: %d", status);
-                goto dealloc_resources;
-            }
-            /* Only during first Init of a group this value is false and during
-             * the life time of this nhop group this value is true.
-             * TODO: Uncomment below assignment when backend p4-driver supports
-             * modify for action selector
-             */
-            //nhop_group_pd_info->first_insert_complete = true;
-        } else {
-            status = tdi_table_entry_mod(table_hdl, session, target_hdl,
-                                         flags_hdl, key_hdl, data_hdl);
-            if (status != TDI_SUCCESS) {
-                krnlmon_log_error("Unable to modify group entry, error: %d", status);
-                goto dealloc_resources;
-            }
-        }
-    } else {
-        /* Delete an entry from target */
-        krnlmon_log_info("Delete selector group table");
-        status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                     flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete group table entry, error: %d", status);
-            goto dealloc_resources;
-        }
-    }
-
-dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
 }

--- a/switchapi/dpdk/switch_pd_routing.c
+++ b/switchapi/dpdk/switch_pd_routing.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/dpdk/switch_pd_routing.h
+++ b/switchapi/dpdk/switch_pd_routing.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/dpdk/switch_pd_routing.h
+++ b/switchapi/dpdk/switch_pd_routing.h
@@ -24,25 +24,23 @@
 #include "switchapi/switch_nhop.h"
 #include "switchapi/switch_rmac_int.h"
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
 /** enum to decide the proper key and action based on ecmp or nhop
  * */
-typedef enum switch_pv4_table_action_s
-{
+typedef enum switch_pv4_table_action_s {
   SWITCH_ACTION_NHOP = 0,
   SWITCH_ACTION_NHOP_GROUP = 1,
   SWITCH_ACTION_NONE = 2
-}switch_ipv4_table_action_t;
+} switch_ipv4_table_action_t;
 
 /**
  * create pd_routing structure to hold
  * the data to be sent to
  * the backend to update the table */
-typedef struct switch_pd_routing_info_s
-{
+typedef struct switch_pd_routing_info_s {
   switch_handle_t neighbor_handle;
 
   switch_handle_t nexthop_handle;
@@ -56,45 +54,40 @@ typedef struct switch_pd_routing_info_s
 } switch_pd_routing_info_t;
 
 switch_status_t switch_pd_nexthop_table_entry(
-    switch_device_t device,
-    const switch_pd_routing_info_t  *api_nexthop_pd_info,
+    switch_device_t device, const switch_pd_routing_info_t* api_nexthop_pd_info,
     bool entry_add);
 
 switch_status_t switch_pd_neighbor_table_entry(
     switch_device_t device,
-    const switch_pd_routing_info_t  *api_neighbor_pd_info,
-    bool entry_add);
+    const switch_pd_routing_info_t* api_neighbor_pd_info, bool entry_add);
 
-switch_status_t switch_pd_rmac_table_entry (
-    switch_device_t device,
-    switch_rmac_entry_t *rmac_entry,
-    switch_handle_t rif_handle,
+switch_status_t switch_pd_rmac_table_entry(switch_device_t device,
+                                           switch_rmac_entry_t* rmac_entry,
+                                           switch_handle_t rif_handle,
+                                           bool entry_type);
+
+switch_status_t switch_pd_rif_mod_entry(switch_device_t device,
+                                        switch_rmac_entry_t* rmac_entry,
+                                        switch_handle_t rif_handle,
+                                        bool entry_add);
+
+switch_status_t switch_pd_ipv4_table_entry(
+    switch_device_t device, const switch_api_route_entry_t* api_route_entry,
+    bool entry_add, switch_ipv4_table_action_t action);
+switch_status_t switch_routing_table_entry(
+    switch_device_t device, const switch_pd_routing_info_t* api_routing_info,
     bool entry_type);
 
-switch_status_t switch_pd_rif_mod_entry(
-    switch_device_t device,
-    switch_rmac_entry_t *rmac_entry,
-    switch_handle_t rif_handle,
+switch_status_t switch_pd_handle_member(
+    switch_device_t device, const switch_nhop_member_t* nhop_member_pd_info,
     bool entry_add);
 
-switch_status_t switch_pd_ipv4_table_entry (switch_device_t device,
-    const switch_api_route_entry_t *api_route_entry,
-    bool entry_add, switch_ipv4_table_action_t action);
-switch_status_t switch_routing_table_entry (
-        switch_device_t device,
-        const switch_pd_routing_info_t *api_routing_info,
-        bool entry_type);
-
-switch_status_t switch_pd_handle_member(switch_device_t device,
-    const switch_nhop_member_t *nhop_member_pd_info,
+switch_status_t switch_pd_handle_group(
+    switch_device_t device, switch_nhop_group_info_t* nhop_group_pd_info,
     bool entry_add);
 
-switch_status_t switch_pd_handle_group(switch_device_t device,
-    switch_nhop_group_info_t *nhop_group_pd_info,
-    bool entry_add);
-
-#ifdef  __cplusplus
+#ifdef __cplusplus
 }
 #endif
 
-#endif 
+#endif

--- a/switchapi/dpdk/switch_pd_tunnel.c
+++ b/switchapi/dpdk/switch_pd_tunnel.c
@@ -16,426 +16,426 @@
  */
 
 #include "switch_pd_tunnel.h"
+
+#include "switch_pd_p4_name_mapping.h"
+#include "switch_pd_utils.h"
+#include "switchapi/switch_internal.h"
 #include "switchapi/switch_tunnel.h"
 
-#include "switchapi/switch_internal.h"
-
-#include "switch_pd_utils.h"
-#include "switch_pd_p4_name_mapping.h"
-
 switch_status_t switch_pd_tunnel_entry(
-    switch_device_t device,
-    const switch_api_tunnel_info_t *api_tunnel_info_t,
+    switch_device_t device, const switch_api_tunnel_info_t* api_tunnel_info_t,
     bool entry_add) {
+  tdi_status_t status;
 
-    tdi_status_t status;
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
 
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
+  tdi_dev_id_t dev_id = device;
 
-    tdi_dev_id_t dev_id = device;
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
+  uint32_t network_byte_order;
 
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
-    uint32_t network_byte_order;
+  krnlmon_log_debug("%s", __func__);
 
-    krnlmon_log_debug("%s", __func__);
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status =
+      tdi_table_from_name_get(info_hdl, LNW_VXLAN_ENCAP_MOD_TABLE, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_VXLAN_ENCAP_MOD_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_VXLAN_ENCAP_MOD_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table, error: %d",
+                      status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(
+      table_info_hdl, LNW_VXLAN_ENCAP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR,
+      &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_VXLAN_ENCAP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR,
+                      status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_set_value(key_hdl, field_id, 0 /*vni value*/);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to set value for key ID: %d for vxlan_encap_mod_table"
+        ", error: %d",
+        field_id, status);
+    goto dealloc_resources;
+  }
+
+  if (entry_add) {
+    /* Add an entry to target */
+    krnlmon_log_info(
+        "Populate vxlan encap action in vxlan_encap_mod_table for "
+        "tunnel interface %x",
+        (unsigned int)api_tunnel_info_t->overlay_rif_handle);
+
+    status = tdi_action_name_to_id(table_info_hdl,
+                                   LNW_VXLAN_ENCAP_MOD_TABLE_ACTION_VXLAN_ENCAP,
+                                   &action_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_VXLAN_ENCAP_MOD_TABLE_ACTION_VXLAN_ENCAP, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_flags_create(0, &flags_hdl);
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %s, "
+          "error: %d",
+          LNW_VXLAN_ENCAP_MOD_TABLE_ACTION_VXLAN_ENCAP, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_device_get(dev_id, &dev_hdl);
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_VXLAN_ENCAP_PARAM_SRC_ADDR, action_id,
+        &data_field_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_VXLAN_ENCAP_PARAM_SRC_ADDR, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_target_create(dev_hdl, &target_hdl);
+    network_byte_order = ntohl(api_tunnel_info_t->src_ip.ip.v4addr);
+    status = tdi_data_field_set_value_ptr(data_hdl, data_field_id,
+                                          (const uint8_t*)&network_byte_order,
+                                          sizeof(uint32_t));
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
     }
-    
-    status = tdi_session_create(dev_hdl, &session);
+
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_VXLAN_ENCAP_PARAM_DST_ADDR, action_id,
+        &data_field_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_VXLAN_ENCAP_PARAM_DST_ADDR, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_VXLAN_ENCAP_MOD_TABLE,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                 LNW_VXLAN_ENCAP_MOD_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
+    network_byte_order = ntohl(api_tunnel_info_t->dst_ip.ip.v4addr);
+    status = tdi_data_field_set_value_ptr(data_hdl, data_field_id,
+                                          (const uint8_t*)&network_byte_order,
+                                          sizeof(uint32_t));
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_VXLAN_ENCAP_MOD_TABLE, status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_VXLAN_ENCAP_PARAM_DST_PORT, action_id,
+        &data_field_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_VXLAN_ENCAP_PARAM_DST_PORT, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_VXLAN_ENCAP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR,
-                                  &field_id);
+    uint16_t network_byte_order_udp = ntohs(api_tunnel_info_t->udp_port);
+    status = tdi_data_field_set_value_ptr(
+        data_hdl, data_field_id, (const uint8_t*)&network_byte_order_udp,
+        sizeof(uint16_t));
     if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_VXLAN_ENCAP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR, status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_key_field_set_value(key_hdl, field_id, 0 /*vni value*/);
+    status = tdi_data_field_id_with_action_get(table_info_hdl,
+                                               LNW_ACTION_VXLAN_ENCAP_PARAM_VNI,
+                                               action_id, &data_field_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d for vxlan_encap_mod_table"
-                 ", error: %d", field_id, status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_VXLAN_ENCAP_PARAM_VNI, status);
+      goto dealloc_resources;
     }
 
-    if (entry_add) {
-        /* Add an entry to target */
-        krnlmon_log_info("Populate vxlan encap action in vxlan_encap_mod_table for "
-                  "tunnel interface %x",
-                  (unsigned int) api_tunnel_info_t->overlay_rif_handle);
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_VXLAN_ENCAP_MOD_TABLE_ACTION_VXLAN_ENCAP,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_VXLAN_ENCAP_MOD_TABLE_ACTION_VXLAN_ENCAP, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %s, "
-                     "error: %d", LNW_VXLAN_ENCAP_MOD_TABLE_ACTION_VXLAN_ENCAP, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_VXLAN_ENCAP_PARAM_SRC_ADDR,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_VXLAN_ENCAP_PARAM_SRC_ADDR, status);
-            goto dealloc_resources;
-        }
-
-        network_byte_order = ntohl(api_tunnel_info_t->src_ip.ip.v4addr);
-        status = tdi_data_field_set_value_ptr(data_hdl, data_field_id,
-                                              (const uint8_t *)&network_byte_order,
-                                              sizeof(uint32_t));
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_VXLAN_ENCAP_PARAM_DST_ADDR,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_VXLAN_ENCAP_PARAM_DST_ADDR, status);
-            goto dealloc_resources;
-        }
-
-        network_byte_order = ntohl(api_tunnel_info_t->dst_ip.ip.v4addr);
-        status = tdi_data_field_set_value_ptr(data_hdl, data_field_id,
-                                              (const uint8_t *)&network_byte_order,
-                                              sizeof(uint32_t));
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_VXLAN_ENCAP_PARAM_DST_PORT,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_VXLAN_ENCAP_PARAM_DST_PORT, status);
-            goto dealloc_resources;
-        }
-
-        uint16_t network_byte_order_udp = ntohs(api_tunnel_info_t->udp_port);
-        status = tdi_data_field_set_value_ptr(data_hdl, data_field_id,
-                                              (const uint8_t *)&network_byte_order_udp,
-                                              sizeof(uint16_t));
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_VXLAN_ENCAP_PARAM_VNI,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_VXLAN_ENCAP_PARAM_VNI, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value_ptr(data_hdl, data_field_id, 0,
-                                              sizeof(uint32_t));
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add %s entry, error: %d", 
-                   LNW_VXLAN_ENCAP_MOD_TABLE, status);
-            goto dealloc_resources;
-        }
-    } else {
-        /* Delete an entry from target */
-        krnlmon_log_info("Delete vxlan_encap_mod_table entry");
-        status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                     flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete %s entry, error: %d", 
-                     LNW_VXLAN_ENCAP_MOD_TABLE, status);
-            goto dealloc_resources;
-        }
+    status = tdi_data_field_set_value_ptr(data_hdl, data_field_id, 0,
+                                          sizeof(uint32_t));
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
     }
+
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to add %s entry, error: %d",
+                        LNW_VXLAN_ENCAP_MOD_TABLE, status);
+      goto dealloc_resources;
+    }
+  } else {
+    /* Delete an entry from target */
+    krnlmon_log_info("Delete vxlan_encap_mod_table entry");
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to delete %s entry, error: %d",
+                        LNW_VXLAN_ENCAP_MOD_TABLE, status);
+      goto dealloc_resources;
+    }
+  }
 
 dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
 }
 
 switch_status_t switch_pd_tunnel_term_entry(
     switch_device_t device,
-    const switch_api_tunnel_term_info_t *api_tunnel_term_info_t,
+    const switch_api_tunnel_term_info_t* api_tunnel_term_info_t,
     bool entry_add) {
+  tdi_status_t status;
 
-    tdi_status_t status;
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
 
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
+  tdi_dev_id_t dev_id = device;
 
-    tdi_dev_id_t dev_id = device;
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
+  uint32_t network_byte_order;
 
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
-    uint32_t network_byte_order;
+  krnlmon_log_debug("%s", __func__);
 
-    krnlmon_log_debug("%s", __func__);
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status =
+      tdi_table_from_name_get(info_hdl, LNW_IPV4_TUNNEL_TERM_TABLE, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_IPV4_TUNNEL_TERM_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_IPV4_TUNNEL_TERM_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table");
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(
+      table_info_hdl, LNW_IPV4_TUNNEL_TERM_TABLE_KEY_TUNNEL_TYPE, &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_IPV4_TUNNEL_TERM_TABLE_KEY_TUNNEL_TYPE, status);
+    goto dealloc_resources;
+  }
+
+  /* From p4 file the value expected is TUNNEL_TYPE_VXLAN=2 */
+  status = tdi_key_field_set_value(key_hdl, field_id, 2);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to set value for key ID: %d of ipv4_tunnel_term_table"
+        ", error: %d",
+        field_id, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(
+      table_info_hdl, LNW_IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_SRC, &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s",
+                      LNW_IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_SRC);
+    goto dealloc_resources;
+  }
+
+  /* This refers to incoming packet fields, where SIP will be the remote_ip
+   * configured while creating tunnel */
+  network_byte_order = ntohl(api_tunnel_term_info_t->dst_ip.ip.v4addr);
+  status = tdi_key_field_set_value_ptr(
+      key_hdl, field_id, (const uint8_t*)&network_byte_order, sizeof(uint32_t));
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to set value for key ID: %d", field_id);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(
+      table_info_hdl, LNW_IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_DST, &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s",
+                      LNW_IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_DST);
+    goto dealloc_resources;
+  }
+
+  /* This refers to incoming packet fields, where DIP will be the local_ip
+   * configured while creating tunnel */
+  network_byte_order = ntohl(api_tunnel_term_info_t->src_ip.ip.v4addr);
+  status = tdi_key_field_set_value_ptr(
+      key_hdl, field_id, (const uint8_t*)&network_byte_order, sizeof(uint32_t));
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to set value for key ID: %d", field_id);
+    goto dealloc_resources;
+  }
+
+  if (entry_add) {
+    krnlmon_log_info(
+        "Populate decap_outer_ipv4 action in ipv4_tunnel_term_table "
+        "for tunnel interface %x",
+        (unsigned int)api_tunnel_term_info_t->tunnel_handle);
+
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_IPV4_TUNNEL_TERM_TABLE_ACTION_DECAP_OUTER_IPV4,
+        &action_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_IPV4_TUNNEL_TERM_TABLE_ACTION_DECAP_OUTER_IPV4,
+                        status);
+      goto dealloc_resources;
     }
 
-    status = tdi_flags_create(0, &flags_hdl);
+    /* Add an entry to target */
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_device_get(dev_id, &dev_hdl);
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_DECAP_OUTER_IPV4_PARAM_TUNNEL_ID, action_id,
+        &data_field_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_DECAP_OUTER_IPV4_PARAM_TUNNEL_ID, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_target_create(dev_hdl, &target_hdl);
+    status = tdi_data_field_set_value(data_hdl, data_field_id,
+                                      api_tunnel_term_info_t->tunnel_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
     }
-    
-    status = tdi_session_create(dev_hdl, &session);
+
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to add %s entry, error: %d",
+                        LNW_IPV4_TUNNEL_TERM_TABLE, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_IPV4_TUNNEL_TERM_TABLE,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                 LNW_IPV4_TUNNEL_TERM_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  } else {
+    /* Delete an entry from target */
+    krnlmon_log_info("Delete ipv4_tunnel_term_table entry");
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_IPV4_TUNNEL_TERM_TABLE, status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to delete %s entry, error: %d",
+                        LNW_IPV4_TUNNEL_TERM_TABLE, status);
+      goto dealloc_resources;
     }
-
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table");
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_IPV4_TUNNEL_TERM_TABLE_KEY_TUNNEL_TYPE,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_IPV4_TUNNEL_TERM_TABLE_KEY_TUNNEL_TYPE, status);
-        goto dealloc_resources;
-    }
-
-    /* From p4 file the value expected is TUNNEL_TYPE_VXLAN=2 */
-    status = tdi_key_field_set_value(key_hdl, field_id, 2);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d of ipv4_tunnel_term_table"
-                 ", error: %d", field_id, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_SRC,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get field ID for key: %s",
-                 LNW_IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_SRC);
-        goto dealloc_resources;
-    }
-
-    /* This refers to incoming packet fields, where SIP will be the remote_ip
-     * configured while creating tunnel */
-    network_byte_order = ntohl(api_tunnel_term_info_t->dst_ip.ip.v4addr);
-    status = tdi_key_field_set_value_ptr(key_hdl, field_id,
-                                         (const uint8_t *)&network_byte_order,
-                                         sizeof(uint32_t));
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d", field_id);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_DST,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get field ID for key: %s",
-                 LNW_IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_DST);
-        goto dealloc_resources;
-    }
-
-    /* This refers to incoming packet fields, where DIP will be the local_ip
-     * configured while creating tunnel */
-    network_byte_order = ntohl(api_tunnel_term_info_t->src_ip.ip.v4addr);
-    status = tdi_key_field_set_value_ptr(key_hdl, field_id,
-                                         (const uint8_t *)&network_byte_order,
-                                         sizeof(uint32_t));
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d", field_id);
-        goto dealloc_resources;
-    }
-
-    if (entry_add) {
-        krnlmon_log_info("Populate decap_outer_ipv4 action in ipv4_tunnel_term_table "
-                  "for tunnel interface %x",
-                   (unsigned int) api_tunnel_term_info_t->tunnel_handle);
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_IPV4_TUNNEL_TERM_TABLE_ACTION_DECAP_OUTER_IPV4,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_IPV4_TUNNEL_TERM_TABLE_ACTION_DECAP_OUTER_IPV4, status);
-            goto dealloc_resources;
-        }
-
-        /* Add an entry to target */
-        status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_DECAP_OUTER_IPV4_PARAM_TUNNEL_ID,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_DECAP_OUTER_IPV4_PARAM_TUNNEL_ID, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                          api_tunnel_term_info_t->tunnel_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add %s entry, error: %d", 
-                   LNW_IPV4_TUNNEL_TERM_TABLE, status);
-            goto dealloc_resources;
-        }
-
-    } else {
-        /* Delete an entry from target */
-        krnlmon_log_info("Delete ipv4_tunnel_term_table entry");
-        status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                     flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete %s entry, error: %d", 
-                     LNW_IPV4_TUNNEL_TERM_TABLE, status);
-            goto dealloc_resources;
-        }
-    }
+  }
 
 dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
 }

--- a/switchapi/dpdk/switch_pd_tunnel.c
+++ b/switchapi/dpdk/switch_pd_tunnel.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/dpdk/switch_pd_tunnel.h
+++ b/switchapi/dpdk/switch_pd_tunnel.h
@@ -18,27 +18,25 @@
 #ifndef __SWITCH_PD_TUNNEL_H__
 #define __SWITCH_PD_TUNNEL_H__
 
-#include "switchapi/switch_tunnel.h"
-
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_handle.h"
+#include "switchapi/switch_tunnel.h"
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
 switch_status_t switch_pd_tunnel_entry(
-    switch_device_t device,
-    const switch_api_tunnel_info_t *api_tunnel_info_t,
+    switch_device_t device, const switch_api_tunnel_info_t* api_tunnel_info_t,
     bool entry_add);
 
 switch_status_t switch_pd_tunnel_term_entry(
     switch_device_t device,
-    const switch_api_tunnel_term_info_t *api_tunnel_term_info_t,
+    const switch_api_tunnel_term_info_t* api_tunnel_term_info_t,
     bool entry_add);
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 }
 #endif
 
-#endif 
+#endif

--- a/switchapi/dpdk/switch_pd_tunnel.h
+++ b/switchapi/dpdk/switch_pd_tunnel.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/dpdk/switch_pd_utils.c
+++ b/switchapi/dpdk/switch_pd_utils.c
@@ -15,147 +15,143 @@
  * limitations under the License.
  */
 
-#include <net/if.h>
-
 #include "switch_pd_utils.h"
 
-#include "bf_types.h"
-#include "bf_rt/bf_rt_common.h"
-#include "port_mgr/dpdk/bf_dpdk_port_if.h"
+#include <net/if.h>
 
+#include "bf_rt/bf_rt_common.h"
+#include "bf_types.h"
+#include "port_mgr/dpdk/bf_dpdk_port_if.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_internal.h"
 
-void
-switch_pd_to_get_port_id(switch_api_rif_info_t *port_rif_info)
-{
-    char if_name[16] = {0};
-    int i = 0;
-    bf_dev_id_t bf_dev_id = 0;
-    bf_dev_port_t bf_dev_port;
-    bf_status_t bf_status;
+void switch_pd_to_get_port_id(switch_api_rif_info_t* port_rif_info) {
+  char if_name[16] = {0};
+  int i = 0;
+  bf_dev_id_t bf_dev_id = 0;
+  bf_dev_port_t bf_dev_port;
+  bf_status_t bf_status;
 
-    if (!if_indextoname(port_rif_info->rif_ifindex, if_name)) {
-        krnlmon_log_error("Failed to get ifname for the index: %d",
-                 port_rif_info->rif_ifindex);
-        return;
-    }
-
-    for(i = 0; i < MAX_NO_OF_PORTS; i++) {
-        struct port_info_t *port_info = NULL;
-        bf_dev_port = (bf_dev_port_t)i;
-        bf_status = (bf_pal_port_info_get(bf_dev_id,
-                                          bf_dev_port,
-                                          &port_info));
-        if (port_info == NULL)
-            continue;
-
-        if (!strcmp((port_info)->port_attrib.port_name, if_name)) {
-            // With multi-pipeline support, return target dp index
-            // for both direction.
-            krnlmon_log_debug("found the target dp index %d for sdk port id %d",
-                      port_info->port_attrib.port_in_id, i);
-            port_rif_info->port_id = port_info->port_attrib.port_in_id;
-            if (i > CONFIG_PORT_INDEX) {
-                bf_dev_port_t bf_dev_port_control = i - CONFIG_PORT_INDEX;
-                port_info = NULL;
-                bf_pal_port_info_get(bf_dev_id, bf_dev_port_control,
-                                     &port_info);
-                if (port_info == NULL) {
-                    krnlmon_log_error("Failed to find the target dp index for "
-                             "physical port associated with : %s", if_name);
-                    return;
-                }
-                krnlmon_log_debug("Found phy port target dp index %d for sdk port id %d",
-                          port_info->port_attrib.port_in_id,
-                          bf_dev_port_control);
-                port_rif_info->phy_port_id =
-                                        port_info->port_attrib.port_in_id;
-            }
-            return;
-        }
-    }
-
-    krnlmon_log_error("Failed to find the target dp index for ifname : %s", if_name);
-
+  if (!if_indextoname(port_rif_info->rif_ifindex, if_name)) {
+    krnlmon_log_error("Failed to get ifname for the index: %d",
+                      port_rif_info->rif_ifindex);
     return;
+  }
+
+  for (i = 0; i < MAX_NO_OF_PORTS; i++) {
+    struct port_info_t* port_info = NULL;
+    bf_dev_port = (bf_dev_port_t)i;
+    bf_status = (bf_pal_port_info_get(bf_dev_id, bf_dev_port, &port_info));
+    if (port_info == NULL) continue;
+
+    if (!strcmp((port_info)->port_attrib.port_name, if_name)) {
+      // With multi-pipeline support, return target dp index
+      // for both direction.
+      krnlmon_log_debug("found the target dp index %d for sdk port id %d",
+                        port_info->port_attrib.port_in_id, i);
+      port_rif_info->port_id = port_info->port_attrib.port_in_id;
+      if (i > CONFIG_PORT_INDEX) {
+        bf_dev_port_t bf_dev_port_control = i - CONFIG_PORT_INDEX;
+        port_info = NULL;
+        bf_pal_port_info_get(bf_dev_id, bf_dev_port_control, &port_info);
+        if (port_info == NULL) {
+          krnlmon_log_error(
+              "Failed to find the target dp index for "
+              "physical port associated with : %s",
+              if_name);
+          return;
+        }
+        krnlmon_log_debug(
+            "Found phy port target dp index %d for sdk port id %d",
+            port_info->port_attrib.port_in_id, bf_dev_port_control);
+        port_rif_info->phy_port_id = port_info->port_attrib.port_in_id;
+      }
+      return;
+    }
+  }
+
+  krnlmon_log_error("Failed to find the target dp index for ifname : %s",
+                    if_name);
+
+  return;
 }
 
-tdi_status_t tdi_switch_pd_deallocate_resources(tdi_flags_hdl *flags_hdl,
-                                                tdi_target_hdl *target_hdl,
-                                                tdi_table_key_hdl *key_hdl,
-                                                tdi_table_data_hdl *data_hdl,
-                                                tdi_session_hdl *session,
+tdi_status_t tdi_switch_pd_deallocate_resources(tdi_flags_hdl* flags_hdl,
+                                                tdi_target_hdl* target_hdl,
+                                                tdi_table_key_hdl* key_hdl,
+                                                tdi_table_data_hdl* data_hdl,
+                                                tdi_session_hdl* session,
                                                 bool entry_type) {
-    tdi_status_t status = TDI_SUCCESS;
+  tdi_status_t status = TDI_SUCCESS;
 
-    status = tdi_deallocate_flag(flags_hdl);
+  status = tdi_deallocate_flag(flags_hdl);
 
-    status = tdi_deallocate_target(target_hdl);
+  status = tdi_deallocate_target(target_hdl);
 
-    if (entry_type) {
-        // Data handle is created only when entry is added to backend
-        status = tdi_deallocate_table_data(data_hdl);
-    }
+  if (entry_type) {
+    // Data handle is created only when entry is added to backend
+    status = tdi_deallocate_table_data(data_hdl);
+  }
 
-    status = tdi_deallocate_table_key(key_hdl);
+  status = tdi_deallocate_table_key(key_hdl);
 
-    status = tdi_deallocate_session(session);
+  status = tdi_deallocate_session(session);
 
-    return status;
+  return status;
 }
 
-tdi_status_t tdi_deallocate_flag(tdi_flags_hdl *flags_hdl) {
-    tdi_status_t status = TDI_SUCCESS;
-    if (flags_hdl) {
-        status = tdi_flags_delete(flags_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to deallocate flags handle, error: %d", status);
-        }
+tdi_status_t tdi_deallocate_flag(tdi_flags_hdl* flags_hdl) {
+  tdi_status_t status = TDI_SUCCESS;
+  if (flags_hdl) {
+    status = tdi_flags_delete(flags_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to deallocate flags handle, error: %d", status);
     }
-    return status;
+  }
+  return status;
 }
 
-tdi_status_t tdi_deallocate_target(tdi_target_hdl *target_hdl) {
-    tdi_status_t status = TDI_SUCCESS;
-    if (target_hdl) {
-        status = tdi_target_delete(target_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to deallocate target handle, error: %d", status);
-        }
+tdi_status_t tdi_deallocate_target(tdi_target_hdl* target_hdl) {
+  tdi_status_t status = TDI_SUCCESS;
+  if (target_hdl) {
+    status = tdi_target_delete(target_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to deallocate target handle, error: %d",
+                        status);
     }
-    return status;
+  }
+  return status;
 }
 
-tdi_status_t tdi_deallocate_table_data(tdi_table_data_hdl *data_hdl) {
-    tdi_status_t status = TDI_SUCCESS;
-    if (data_hdl) {
-        status = tdi_table_data_deallocate(data_hdl);
-        if(status != TDI_SUCCESS) {
-            krnlmon_log_error("Failed to deallocate data handle, error: %d", status);
-        }
+tdi_status_t tdi_deallocate_table_data(tdi_table_data_hdl* data_hdl) {
+  tdi_status_t status = TDI_SUCCESS;
+  if (data_hdl) {
+    status = tdi_table_data_deallocate(data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Failed to deallocate data handle, error: %d", status);
     }
-    return status;
+  }
+  return status;
 }
 
-tdi_status_t tdi_deallocate_table_key(tdi_table_key_hdl *key_hdl) {
-    tdi_status_t status = TDI_SUCCESS;
-    if (key_hdl) {
-        status = tdi_table_key_deallocate(key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Failed to deallocate key handle, error: %d", status);
-        }
+tdi_status_t tdi_deallocate_table_key(tdi_table_key_hdl* key_hdl) {
+  tdi_status_t status = TDI_SUCCESS;
+  if (key_hdl) {
+    status = tdi_table_key_deallocate(key_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Failed to deallocate key handle, error: %d", status);
     }
-    return status;
+  }
+  return status;
 }
 
-tdi_status_t tdi_deallocate_session(tdi_session_hdl *session) {
-    tdi_status_t status = TDI_SUCCESS;
-    if (session) {
-        status = tdi_session_destroy(session);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Failed to destroy session, error: %d", status);
-        }
+tdi_status_t tdi_deallocate_session(tdi_session_hdl* session) {
+  tdi_status_t status = TDI_SUCCESS;
+  if (session) {
+    status = tdi_session_destroy(session);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Failed to destroy session, error: %d", status);
     }
-    return status;
+  }
+  return status;
 }

--- a/switchapi/dpdk/switch_pd_utils.c
+++ b/switchapi/dpdk/switch_pd_utils.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/dpdk/switch_pd_utils.h
+++ b/switchapi/dpdk/switch_pd_utils.h
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 
+#ifndef __SWITCH_PD_UTILS_H__
+#define __SWITCH_PD_UTILS_H__
+
 #include "bf_pal/bf_pal_port_intf.h"
 #include "bf_rt/bf_rt_common.h"
 #include "bf_types.h"
@@ -22,15 +25,17 @@
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_handle.h"
 #include "switchapi/switch_rif.h"
+
+// clang-format off
+// tdi_info.h does not include the header files it depends on,
+// so we force tdi_defs.h to precede it.
+#include "tdi/common/tdi_defs.h"
 #include "tdi/common/c_frontend/tdi_info.h"
 #include "tdi/common/c_frontend/tdi_init.h"
 #include "tdi/common/c_frontend/tdi_session.h"
 #include "tdi/common/c_frontend/tdi_table.h"
 #include "tdi/common/c_frontend/tdi_table_info.h"
-#include "tdi/common/tdi_defs.h"
-
-#ifndef __SWITCH_PD_UTILS_H__
-#define __SWITCH_PD_UTILS_H__
+// clang-format on
 
 #ifdef __cplusplus
 extern "C" {

--- a/switchapi/dpdk/switch_pd_utils.h
+++ b/switchapi/dpdk/switch_pd_utils.h
@@ -15,26 +15,24 @@
  * limitations under the License.
  */
 
+#include "bf_pal/bf_pal_port_intf.h"
+#include "bf_rt/bf_rt_common.h"
+#include "bf_types.h"
+#include "port_mgr/dpdk/bf_dpdk_port_if.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_handle.h"
 #include "switchapi/switch_rif.h"
-
-#include "bf_types.h"
-#include "bf_rt/bf_rt_common.h"
-#include "bf_pal/bf_pal_port_intf.h"
-#include "port_mgr/dpdk/bf_dpdk_port_if.h"
-
-#include "tdi/common/tdi_defs.h"
+#include "tdi/common/c_frontend/tdi_info.h"
 #include "tdi/common/c_frontend/tdi_init.h"
 #include "tdi/common/c_frontend/tdi_session.h"
-#include "tdi/common/c_frontend/tdi_info.h"
 #include "tdi/common/c_frontend/tdi_table.h"
 #include "tdi/common/c_frontend/tdi_table_info.h"
+#include "tdi/common/tdi_defs.h"
 
 #ifndef __SWITCH_PD_UTILS_H__
 #define __SWITCH_PD_UTILS_H__
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -44,30 +42,29 @@ extern "C" {
 #define MAX_NO_OF_PORTS 312
 #define CONFIG_PORT_INDEX 256
 
-void switch_pd_to_get_port_id(switch_api_rif_info_t *port_rif_info);
+void switch_pd_to_get_port_id(switch_api_rif_info_t* port_rif_info);
 
-tdi_status_t tdi_switch_pd_deallocate_resources(tdi_flags_hdl *flags_hdl,
-                                                tdi_target_hdl *target_hdl,
-                                                tdi_table_key_hdl *key_hdl,
-                                                tdi_table_data_hdl *data_hdl,
-                                                tdi_session_hdl *session,
+tdi_status_t tdi_switch_pd_deallocate_resources(tdi_flags_hdl* flags_hdl,
+                                                tdi_target_hdl* target_hdl,
+                                                tdi_table_key_hdl* key_hdl,
+                                                tdi_table_data_hdl* data_hdl,
+                                                tdi_session_hdl* session,
                                                 bool entry_type);
 
 switch_status_t switch_pd_tdi_status_to_status(tdi_status_t pd_status);
 
-tdi_status_t tdi_deallocate_flag(tdi_flags_hdl *flags_hdl);
+tdi_status_t tdi_deallocate_flag(tdi_flags_hdl* flags_hdl);
 
-tdi_status_t tdi_deallocate_target(tdi_target_hdl *target_hdl);
+tdi_status_t tdi_deallocate_target(tdi_target_hdl* target_hdl);
 
-tdi_status_t tdi_deallocate_table_data(tdi_table_data_hdl *data_hdl);
+tdi_status_t tdi_deallocate_table_data(tdi_table_data_hdl* data_hdl);
 
-tdi_status_t tdi_deallocate_table_key(tdi_table_key_hdl *key_hdl);
+tdi_status_t tdi_deallocate_table_key(tdi_table_key_hdl* key_hdl);
 
-tdi_status_t tdi_deallocate_session(tdi_session_hdl *session);
+tdi_status_t tdi_deallocate_session(tdi_session_hdl* session);
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 }
 #endif
 
 #endif
-

--- a/switchapi/dpdk/switch_pd_utils.h
+++ b/switchapi/dpdk/switch_pd_utils.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/dpdk/switch_rif.c
+++ b/switchapi/dpdk/switch_rif.c
@@ -18,16 +18,14 @@
 #include <net/if.h>
 
 /* Local header includes */
-#include "switchapi/switch_rif.h"
-
+#include "bf_types.h"
+#include "switch_pd_utils.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_device.h"
 #include "switchapi/switch_internal.h"
+#include "switchapi/switch_rif.h"
 #include "switchapi/switch_rif_int.h"
 #include "switchapi/switch_status.h"
-#include "switch_pd_utils.h"
-
-#include "bf_types.h"
 
 /*
  * Routine Description:
@@ -75,11 +73,9 @@ switch_status_t switch_rif_free(switch_device_t device) {
 }
 
 switch_status_t switch_api_rif_attribute_get(
-    const switch_device_t device,
-    const switch_handle_t rif_handle,
-    const switch_uint64_t rif_flags,
-    switch_api_rif_info_t *api_rif_info) {
-  switch_rif_info_t *rif_info = NULL;
+    const switch_device_t device, const switch_handle_t rif_handle,
+    const switch_uint64_t rif_flags, switch_api_rif_info_t* api_rif_info) {
+  switch_rif_info_t* rif_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!SWITCH_RIF_HANDLE(rif_handle)) {
@@ -88,9 +84,7 @@ switch_status_t switch_api_rif_attribute_get(
         "rif attribute get: Invalid rif handle on device %d, "
         "rif handle 0x%lx: "
         "error: %s\n",
-        device,
-        rif_handle,
-        switch_error_to_string(status));
+        device, rif_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -103,12 +97,11 @@ switch_status_t switch_api_rif_attribute_get(
   return status;
 }
 
-switch_status_t switch_api_rif_create(
-    switch_device_t device,
-    switch_api_rif_info_t *api_rif_info,
-    switch_handle_t *rif_handle) {
+switch_status_t switch_api_rif_create(switch_device_t device,
+                                      switch_api_rif_info_t* api_rif_info,
+                                      switch_handle_t* rif_handle) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
-  switch_rif_info_t *rif_info = NULL;
+  switch_rif_info_t* rif_info = NULL;
 
   if (api_rif_info->rmac_handle == SWITCH_API_INVALID_HANDLE) {
     status = switch_api_device_default_rmac_handle_get(
@@ -121,8 +114,7 @@ switch_status_t switch_api_rif_create(
     krnlmon_log_error(
         "rif create: Invalid rmac handle on device %d: "
         "error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -132,24 +124,23 @@ switch_status_t switch_api_rif_create(
   status = switch_rif_get(device, *rif_handle, &rif_info);
   CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
 
-  /* When multipipe support is available in P4-OVS, make port_id as 
+  /* When multipipe support is available in P4-OVS, make port_id as
    * in_port_id and out_port_id. Use accordingly for respective pipelines. */
   api_rif_info->port_id = -1;
   api_rif_info->phy_port_id = -1;
 
   switch_pd_to_get_port_id(api_rif_info);
 
-  SWITCH_MEMCPY(&rif_info->api_rif_info,
-                api_rif_info,
+  SWITCH_MEMCPY(&rif_info->api_rif_info, api_rif_info,
                 sizeof(switch_api_rif_info_t));
-  
+
   return status;
 }
 
 switch_status_t switch_api_rif_delete(switch_device_t device,
-                                               switch_handle_t rif_handle) {
+                                      switch_handle_t rif_handle) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
-  switch_rif_info_t *rif_info = NULL;
+  switch_rif_info_t* rif_info = NULL;
 
   status = switch_rif_get(device, rif_handle, &rif_info);
   CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
@@ -159,4 +150,3 @@ switch_status_t switch_api_rif_delete(switch_device_t device,
 
   return status;
 }
-

--- a/switchapi/dpdk/switch_rif.c
+++ b/switchapi/dpdk/switch_rif.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/dpdk/switch_rmac.c
+++ b/switchapi/dpdk/switch_rmac.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/dpdk/switch_rmac.c
+++ b/switchapi/dpdk/switch_rmac.c
@@ -16,10 +16,10 @@
  */
 
 #include "switchapi/switch_rmac.h"
-#include "switchapi/switch_rmac_int.h"
 
-#include "switchapi/switch_internal.h"
 #include "switch_pd_routing.h"
+#include "switchapi/switch_internal.h"
+#include "switchapi/switch_rmac_int.h"
 
 /*
  * Routine Description:
@@ -33,7 +33,7 @@
  *             Failure status code on error
  */
 switch_status_t switch_rmac_init(switch_device_t device) {
-  switch_rmac_context_t *rmac_ctx = NULL;
+  switch_rmac_context_t* rmac_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   rmac_ctx = SWITCH_MALLOC(device, sizeof(switch_rmac_context_t), 0x1);
@@ -42,19 +42,17 @@ switch_status_t switch_rmac_init(switch_device_t device) {
     krnlmon_log_error(
         "rmac_init:Failed to allocate memory for switch_rmac_context_t "
         "on device %d ,error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
-  status = switch_device_api_context_set(
-      device, SWITCH_API_TYPE_RMAC, (void *)rmac_ctx);
+  status = switch_device_api_context_set(device, SWITCH_API_TYPE_RMAC,
+                                         (void*)rmac_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "rmac_init: Failed to set device api context on device %d "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -63,13 +61,13 @@ switch_status_t switch_rmac_init(switch_device_t device) {
 
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
-        "rmac init: Failed to initialize handle SWITCH_HANDLE_TYPE_RMAC on device %d "
+        "rmac init: Failed to initialize handle SWITCH_HANDLE_TYPE_RMAC on "
+        "device %d "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
-  
+
   krnlmon_log_info("rmac init successful on device %d\n", device);
   return status;
 }
@@ -86,17 +84,16 @@ switch_status_t switch_rmac_init(switch_device_t device) {
  *             Failure status code on error
  */
 switch_status_t switch_rmac_free(switch_device_t device) {
-  switch_rmac_context_t *rmac_ctx = NULL;
+  switch_rmac_context_t* rmac_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_RMAC, (void **)&rmac_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_RMAC,
+                                         (void**)&rmac_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "rmac free: Failed to get device api context on device %d "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -105,10 +102,9 @@ switch_status_t switch_rmac_free(switch_device_t device) {
     krnlmon_log_error(
         "rmac free: Failed to free handle SWITCH_HANDLE_TYPE_RMAC on device %d "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
   }
-  
+
   SWITCH_FREE(device, rmac_ctx);
   status = switch_device_api_context_set(device, SWITCH_API_TYPE_RMAC, NULL);
   SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
@@ -117,10 +113,9 @@ switch_status_t switch_rmac_free(switch_device_t device) {
 }
 
 switch_status_t switch_api_router_mac_group_create(
-    const switch_device_t device,
-    const switch_rmac_type_t rmac_type,
-    switch_handle_t *rmac_handle) {
-  switch_rmac_info_t *rmac_info = NULL;
+    const switch_device_t device, const switch_rmac_type_t rmac_type,
+    switch_handle_t* rmac_handle) {
+  switch_rmac_info_t* rmac_info = NULL;
   switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
@@ -130,8 +125,7 @@ switch_status_t switch_api_router_mac_group_create(
     krnlmon_log_error(
         "rmac group create: Failed to create rmac handle on device %d "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -140,8 +134,7 @@ switch_status_t switch_api_router_mac_group_create(
     krnlmon_log_error(
         "rmac group create: Failed to get rmac info on device %d "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -155,8 +148,7 @@ switch_status_t switch_api_router_mac_group_create(
   krnlmon_log_info(
       "rmac group created on device %d, "
       "rmac handle 0x%lx \n",
-      device,
-      handle);
+      device, handle);
 
   return status;
 }
@@ -164,19 +156,17 @@ switch_status_t switch_api_router_mac_group_create(
 switch_status_t switch_api_router_mac_group_delete(
     const switch_device_t device, const switch_handle_t rif_handle,
     const switch_handle_t rmac_handle) {
-  switch_rmac_info_t *rmac_info = NULL;
-  switch_rmac_entry_t *rmac_entry = NULL;
-  switch_node_t *node = NULL;
+  switch_rmac_info_t* rmac_info = NULL;
+  switch_rmac_entry_t* rmac_entry = NULL;
+  switch_node_t* node = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
-  
+
   if (!SWITCH_RMAC_HANDLE(rmac_handle)) {
     status = SWITCH_STATUS_INVALID_HANDLE;
     krnlmon_log_error(
         "rmac group delete: Invalid rmac handle 0x%lx: on device %d "
         ",error: %s\n",
-        rmac_handle,
-        device,
-        switch_error_to_string(status));
+        rmac_handle, device, switch_error_to_string(status));
     return status;
   }
 
@@ -186,24 +176,19 @@ switch_status_t switch_api_router_mac_group_delete(
     krnlmon_log_error(
         "rmac group delete: Failed to get rmac info on device %d rmac hadle "
         "0x%lx: ,error: %s\n",
-        device,
-        rmac_handle,
-        switch_error_to_string(status));
+        device, rmac_handle, switch_error_to_string(status));
     return status;
   }
 
   FOR_EACH_IN_LIST(rmac_info->rmac_list, node) {
     rmac_entry = node->data;
-    status =
-        switch_api_router_mac_delete(device, rif_handle, rmac_handle,
-                                     &rmac_entry->mac);
+    status = switch_api_router_mac_delete(device, rif_handle, rmac_handle,
+                                          &rmac_entry->mac);
     if (status != SWITCH_STATUS_SUCCESS) {
       krnlmon_log_error(
           "rmac group delete: Failed to delete router mac on device %d "
           "rmac handle 0x%lx: ,error: %s\n",
-          device,
-          rmac_handle,
-          switch_error_to_string(status));
+          device, rmac_handle, switch_error_to_string(status));
     }
   }
   FOR_EACH_IN_LIST_END();
@@ -213,29 +198,25 @@ switch_status_t switch_api_router_mac_group_delete(
     krnlmon_log_error(
         "rmac group delete: Failed to delete rmac handle 0x%lx: on device %d "
         ",error: %s\n",
-        rmac_handle,
-        device,
-        switch_error_to_string(status));
+        rmac_handle, device, switch_error_to_string(status));
     return status;
   }
 
   krnlmon_log_info(
       "rmac group deleted on device %d, "
       "rmac handle 0x%lx\n",
-      device,
-      rmac_handle);
+      device, rmac_handle);
 
   return status;
 }
 
-switch_status_t switch_api_router_mac_delete(
-    const switch_device_t device,
-    const switch_handle_t rif_handle,
-    const switch_handle_t rmac_handle,
-    const switch_mac_addr_t *mac) {
-  switch_rmac_info_t *rmac_info = NULL;
-  switch_rmac_entry_t *rmac_entry = NULL;
-  switch_node_t *node = NULL;
+switch_status_t switch_api_router_mac_delete(const switch_device_t device,
+                                             const switch_handle_t rif_handle,
+                                             const switch_handle_t rmac_handle,
+                                             const switch_mac_addr_t* mac) {
+  switch_rmac_info_t* rmac_info = NULL;
+  switch_rmac_entry_t* rmac_entry = NULL;
+  switch_node_t* node = NULL;
   bool entry_found = FALSE;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
@@ -244,9 +225,7 @@ switch_status_t switch_api_router_mac_delete(
     krnlmon_log_error(
         "router mac delete: Invalid rmac handle 0x%lx, mac %s: on device %d "
         ",error: %s\n",
-        rmac_handle,
-        switch_macaddress_to_string(mac),
-        device,
+        rmac_handle, switch_macaddress_to_string(mac), device,
         switch_error_to_string(status));
     return status;
   }
@@ -257,13 +236,12 @@ switch_status_t switch_api_router_mac_delete(
     krnlmon_log_error(
         "router mac delete: Failed to get rmac info, handle 0x%lx "
         ",error: %s\n",
-        rmac_handle,
-        switch_error_to_string(status));
+        rmac_handle, switch_error_to_string(status));
     return status;
   }
 
   FOR_EACH_IN_LIST(rmac_info->rmac_list, node) {
-    rmac_entry = (switch_rmac_entry_t *)node->data;
+    rmac_entry = (switch_rmac_entry_t*)node->data;
     if (SWITCH_MEMCMP(&(rmac_entry->mac), mac, sizeof(switch_mac_addr_t)) ==
         0) {
       entry_found = TRUE;
@@ -277,9 +255,7 @@ switch_status_t switch_api_router_mac_delete(
     krnlmon_log_error(
         "router mac delete: Failed to find rmac entry on device %d, rmac "
         "handle 0x%lx, mac %s: ,error: %s\n",
-        device,
-        rmac_handle,
-        switch_macaddress_to_string(mac),
+        device, rmac_handle, switch_macaddress_to_string(mac),
         switch_error_to_string(status));
     return status;
   }
@@ -288,13 +264,11 @@ switch_status_t switch_api_router_mac_delete(
     status = switch_pd_rmac_table_entry(device, rmac_entry, rif_handle, false);
     if (status != SWITCH_STATUS_SUCCESS) {
       krnlmon_log_error(
-        "router mac delete: Failed to delete PD rmac entry on device %d ,"
-        "rmac handle 0x%lx, mac %s: "
-        ",error: %s\n",
-        device,
-        rmac_handle,
-        switch_macaddress_to_string(mac),
-        switch_error_to_string(status));
+          "router mac delete: Failed to delete PD rmac entry on device %d ,"
+          "rmac handle 0x%lx, mac %s: "
+          ",error: %s\n",
+          device, rmac_handle, switch_macaddress_to_string(mac),
+          switch_error_to_string(status));
       return status;
     }
   }
@@ -305,17 +279,13 @@ switch_status_t switch_api_router_mac_delete(
         "router mac delete: Failed to delete from switch list on device %d ,"
         "rmac handle 0x%lx, mac %s: "
         ",error: %s\n",
-        device,
-        rmac_handle,
-        switch_macaddress_to_string(mac),
+        device, rmac_handle, switch_macaddress_to_string(mac),
         switch_error_to_string(status));
     return status;
   }
 
   krnlmon_log_info("rmac deleted on device %d, rmac handle 0x%lx, mac %s\n",
-                   device,
-                   rmac_handle,
-                   switch_macaddress_to_string(mac));
+                   device, rmac_handle, switch_macaddress_to_string(mac));
 
   if (rmac_entry) {
     SWITCH_FREE(device, rmac_entry);
@@ -324,13 +294,12 @@ switch_status_t switch_api_router_mac_delete(
   return status;
 }
 
-switch_status_t switch_api_router_mac_add(
-    const switch_device_t device,
-    const switch_handle_t rmac_handle,
-    const switch_mac_addr_t *mac) {
-  switch_rmac_info_t *rmac_info = NULL;
-  switch_rmac_entry_t *rmac_entry = NULL;
-  switch_node_t *node = NULL;
+switch_status_t switch_api_router_mac_add(const switch_device_t device,
+                                          const switch_handle_t rmac_handle,
+                                          const switch_mac_addr_t* mac) {
+  switch_rmac_info_t* rmac_info = NULL;
+  switch_rmac_entry_t* rmac_entry = NULL;
+  switch_node_t* node = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!SWITCH_RMAC_HANDLE(rmac_handle)) {
@@ -338,9 +307,7 @@ switch_status_t switch_api_router_mac_add(
     krnlmon_log_error(
         "router mac add: Invalid rmac handle 0x%lx: on device %d "
         ",error: %s\n",
-        rmac_handle,
-        device,
-        switch_error_to_string(status));
+        rmac_handle, device, switch_error_to_string(status));
     return status;
   }
 
@@ -350,9 +317,7 @@ switch_status_t switch_api_router_mac_add(
     krnlmon_log_error(
         "router mac add: Failed to get rmac info on device %d, rmac "
         "handle 0x%lx: ,error: %s\n",
-        device,
-        rmac_handle,
-        switch_error_to_string(status));
+        device, rmac_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -361,14 +326,12 @@ switch_status_t switch_api_router_mac_add(
     krnlmon_log_error(
         "router mac add: Invalid mac on device %d, rmac handle 0x%lx: "
         ",error: %s\n",
-        device,
-        rmac_handle,
-        switch_error_to_string(status));
+        device, rmac_handle, switch_error_to_string(status));
     return status;
   }
 
   FOR_EACH_IN_LIST(rmac_info->rmac_list, node) {
-    rmac_entry = (switch_rmac_entry_t *)node->data;
+    rmac_entry = (switch_rmac_entry_t*)node->data;
     if (SWITCH_MEMCMP(&(rmac_entry->mac), mac, sizeof(switch_mac_addr_t)) ==
         0) {
       return SWITCH_STATUS_ITEM_ALREADY_EXISTS;
@@ -382,9 +345,7 @@ switch_status_t switch_api_router_mac_add(
     krnlmon_log_error(
         "router mac add: Failed to allocate memory for switch_rmac_entry_t "
         "on device %d rmac handle 0x%lx: ,error: %s\n",
-        device,
-        rmac_handle,
-        switch_error_to_string(status));
+        device, rmac_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -394,8 +355,9 @@ switch_status_t switch_api_router_mac_add(
 
   SWITCH_LIST_INSERT(&(rmac_info->rmac_list), &(rmac_entry->node), rmac_entry);
 
-  krnlmon_log_info("RMAC added on device %d, rmac handle 0x%lx, mac %s\n", device,
-             rmac_handle, switch_macaddress_to_string(&rmac_entry->mac));
+  krnlmon_log_info("RMAC added on device %d, rmac handle 0x%lx, mac %s\n",
+                   device, rmac_handle,
+                   switch_macaddress_to_string(&rmac_entry->mac));
 
   return status;
 }

--- a/switchapi/dpdk/switch_table.c
+++ b/switchapi/dpdk/switch_table.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022-2023 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/dpdk/switch_table.c
+++ b/switchapi/dpdk/switch_table.c
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-#include "switchapi/switch_internal.h"
 #include "switchapi/switch_table.h"
+
+#include "switchapi/switch_internal.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -24,7 +25,7 @@ extern "C" {
 
 #define __FILE_ID__ SWITCH_TABLE
 
-static const char *switch_table_id_to_string(switch_table_id_t table_id) {
+static const char* switch_table_id_to_string(switch_table_id_t table_id) {
   switch (table_id) {
     case SWITCH_TABLE_INGRESS_PORT_MAPPING:
       return "ingress port mapping";
@@ -101,33 +102,33 @@ static const char *switch_table_id_to_string(switch_table_id_t table_id) {
     case SWITCH_TABLE_TUNNEL_MPLS:
       return "mpls";
     case SWITCH_TABLE_IPV4_VTEP:
-          return "ipv4 vtep";
+      return "ipv4 vtep";
     case SWITCH_TABLE_IPV6_VTEP:
-          return "ipv4 vtep";
+      return "ipv4 vtep";
     case SWITCH_TABLE_TUNNEL_TERM:
-          return "tunnel term";
+      return "tunnel term";
     case SWITCH_TABLE_EGRESS_IPV4_ACL:
-          return "egress ipv4 acl";
+      return "egress ipv4 acl";
     case SWITCH_TABLE_EGRESS_IPV6_ACL:
-          return "egress ipv6 acl";
+      return "egress ipv6 acl";
     case SWITCH_TABLE_ECN_ACL:
-          return "ecn acl";
+      return "ecn acl";
     case SWITCH_TABLE_PFC_ACL:
-          return "pfc acl";
+      return "pfc acl";
     case SWITCH_TABLE_EGRESS_PFC_ACL:
-          return "egress pfc acl";
+      return "egress pfc acl";
     case SWITCH_TABLE_MAX_ACL:
-          return "max acl";
+      return "max acl";
     case SWITCH_TABLE_INGRESS_QOS_MAP:
-          return "ingress qos map";
+      return "ingress qos map";
     case SWITCH_TABLE_WRED:
-          return "wred";
+      return "wred";
     case SWITCH_TABLE_NEIGHBOR:
-          return "neighbor";
+      return "neighbor";
     case SWITCH_TABLE_TUNNEL_SIP_REWRITE:
-          return "tunnel sip rewrite";
+      return "tunnel sip rewrite";
     case SWITCH_TABLE_MAX:
-          return "none";
+      return "none";
     /* BD */
     case SWITCH_TABLE_PORT_VLAN_TO_BD_MAPPING:
       return "port vlan bd mapping";
@@ -288,16 +289,15 @@ static void set_table_name(char* dest, size_t destsize, const char* src) {
 }
 
 switch_status_t switch_table_init(switch_device_t device,
-                                  switch_size_t *table_sizes) {
-  switch_table_t *table_info = NULL;
+                                  switch_size_t* table_sizes) {
+  switch_table_t* table_info = NULL;
   switch_uint32_t index = 0;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   status = switch_device_table_get(device, &table_info);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error("table init: Failed to get table info on device %d:%s",
-              device,
-              switch_error_to_string(status));
+                      device, switch_error_to_string(status));
     return status;
   }
 
@@ -317,14 +317,13 @@ switch_status_t switch_table_init(switch_device_t device,
 }
 
 switch_status_t switch_table_free(switch_device_t device) {
-  switch_table_t *table_info = NULL;
+  switch_table_t* table_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   status = switch_device_table_get(device, &table_info);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error("table free: Failed to get table info on device %d:%s",
-             device,
-             switch_error_to_string(status));
+                      device, switch_error_to_string(status));
     return status;
   }
 
@@ -334,8 +333,8 @@ switch_status_t switch_table_free(switch_device_t device) {
 
 switch_status_t switch_api_table_size_get_internal(switch_device_t device,
                                                    switch_table_id_t table_id,
-                                                   switch_size_t *table_size) {
-  switch_table_t *table_info = NULL;
+                                                   switch_size_t* table_size) {
+  switch_table_t* table_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(SWITCH_TABLE_ID_VALID(table_id));
@@ -344,16 +343,15 @@ switch_status_t switch_api_table_size_get_internal(switch_device_t device,
   if (!table_size) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("Failed to get table size on device %d, error: %s",
-              device,
-              switch_error_to_string(status));
+                      device, switch_error_to_string(status));
     return status;
   }
 
   status = switch_device_table_get(device, &table_info);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("get table size: Failed to get table info on device %d, error: %s",
-             device,
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "get table size: Failed to get table info on device %d, error: %s",
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -362,14 +360,14 @@ switch_status_t switch_api_table_size_get_internal(switch_device_t device,
   return status;
 }
 
-switch_status_t switch_table_default_sizes_get(switch_size_t *table_sizes) {
+switch_status_t switch_table_default_sizes_get(switch_size_t* table_sizes) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   switch_uint16_t index = 0;
 
   if (!table_sizes) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("Failed to get table default size, error: %s",
-             switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -807,13 +805,12 @@ switch_status_t switch_table_default_sizes_get(switch_size_t *table_sizes) {
   return status;
 }
 
-
 #ifdef __cplusplus
 }
 #endif
 
 switch_status_t switch_api_table_size_get(switch_device_t device,
                                           switch_table_id_t table_id,
-                                          switch_size_t *table_size) {
-    return switch_api_table_size_get_internal(device, table_id, table_size);
+                                          switch_size_t* table_size) {
+  return switch_api_table_size_get_internal(device, table_id, table_size);
 }

--- a/switchapi/dpdk/switch_tunnel.c
+++ b/switchapi/dpdk/switch_tunnel.c
@@ -16,17 +16,15 @@
  */
 
 #include "switchapi/switch_tunnel.h"
-#include "switch_pd_tunnel.h"
 
+#include "switch_pd_tunnel.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_status.h"
 
-switch_status_t switch_api_tunnel_delete(
-    const switch_handle_t tunnel_handle) {
-
+switch_status_t switch_api_tunnel_delete(const switch_handle_t tunnel_handle) {
   switch_device_t device = 0;
-  switch_tunnel_info_t *tunnel_info = NULL;
+  switch_tunnel_info_t* tunnel_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(SWITCH_TUNNEL_HANDLE(tunnel_handle));
@@ -34,9 +32,7 @@ switch_status_t switch_api_tunnel_delete(
     krnlmon_log_error(
         "Failed to delete tunnel on device %d due to invalid, "
         "tunnel handle 0x%lx: ,error: %s",
-        device,
-        tunnel_handle,
-        switch_error_to_string(status));
+        device, tunnel_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -45,40 +41,36 @@ switch_status_t switch_api_tunnel_delete(
     krnlmon_log_error(
         "Failed to get tunnel info on device %d of tunnel handle 0x%lx: "
         "error: %s\n",
-        device,
-        tunnel_handle,
-        switch_error_to_string(status));
+        device, tunnel_handle, switch_error_to_string(status));
     return status;
   }
 
   status = switch_pd_tunnel_entry(device, &tunnel_info->api_tunnel_info, false);
   if (status != SWITCH_STATUS_SUCCESS) {
-      krnlmon_log_error(
-          "Failed to delete tunnel entry on device %d: ,"
-          "error: %s\n",
-          device,
-          switch_error_to_string(status));
-      return status;
+    krnlmon_log_error(
+        "Failed to delete tunnel entry on device %d: ,"
+        "error: %s\n",
+        device, switch_error_to_string(status));
+    return status;
   }
 
   status = switch_tunnel_handle_delete(device, tunnel_handle);
   if (status != SWITCH_STATUS_SUCCESS) {
-      krnlmon_log_error(
-          "Failed to delete tunnel handle on device %d: "
-          ",error: %s\n",
-          device,
-          switch_error_to_string(status));
-      return status;
+    krnlmon_log_error(
+        "Failed to delete tunnel handle on device %d: "
+        ",error: %s\n",
+        device, switch_error_to_string(status));
+    return status;
   }
 
   return status;
 }
 
 // Stubbed code to enabe compilation
-switch_status_t switch_api_tunnel_term_delete (
+switch_status_t switch_api_tunnel_term_delete(
     switch_handle_t tunnel_term_handle) {
-  switch_tunnel_term_info_t *tunnel_term_info = NULL;
-  switch_api_tunnel_term_info_t *api_tunnel_term_info = NULL;
+  switch_tunnel_term_info_t* tunnel_term_info = NULL;
+  switch_api_tunnel_term_info_t* api_tunnel_term_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   switch_device_t device = 0;
 
@@ -89,29 +81,26 @@ switch_status_t switch_api_tunnel_term_delete (
     krnlmon_log_error(
         "Failed to get tunnel term info on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
   api_tunnel_term_info = &tunnel_term_info->api_tunnel_term_info;
 
   status = switch_pd_tunnel_term_entry(device, api_tunnel_term_info, false);
   if (status != SWITCH_STATUS_SUCCESS) {
-      krnlmon_log_error(
-          "Failed to delete tunnel term entry on device %d: "
-          ",error: %s\n",
-          device,
-          switch_error_to_string(status));
-      return status;
+    krnlmon_log_error(
+        "Failed to delete tunnel term entry on device %d: "
+        ",error: %s\n",
+        device, switch_error_to_string(status));
+    return status;
   }
   status = switch_tunnel_term_handle_delete(device, tunnel_term_handle);
   if (status != SWITCH_STATUS_SUCCESS) {
-      krnlmon_log_error(
-          "Failed to delete tunnel term handle on device %d: "
-          ",error: %s\n",
-          device,
-          switch_error_to_string(status));
-      return status;
+    krnlmon_log_error(
+        "Failed to delete tunnel term handle on device %d: "
+        ",error: %s\n",
+        device, switch_error_to_string(status));
+    return status;
   }
 
   return status;
@@ -119,101 +108,94 @@ switch_status_t switch_api_tunnel_term_delete (
 
 switch_status_t switch_api_tunnel_create(
     const switch_device_t device,
-    const switch_api_tunnel_info_t *api_tunnel_info,
-    switch_handle_t *tunnel_handle) {
+    const switch_api_tunnel_info_t* api_tunnel_info,
+    switch_handle_t* tunnel_handle) {
+  switch_status_t status = SWITCH_STATUS_SUCCESS;
+  switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
+  switch_tunnel_info_t* tunnel_info = NULL;
 
-    switch_status_t status = SWITCH_STATUS_SUCCESS;
-    switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
-    switch_tunnel_info_t *tunnel_info = NULL;
+  handle = switch_tunnel_handle_create(device);
+  if (handle == SWITCH_API_INVALID_HANDLE) {
+    status = SWITCH_STATUS_NO_MEMORY;
+    krnlmon_log_error(
+        "Failed to create tunnel handle on device %d: "
+        ",error: %s\n",
+        device, switch_error_to_string(status));
+    return status;
+  }
 
-    handle = switch_tunnel_handle_create(device);
-    if (handle == SWITCH_API_INVALID_HANDLE) {
-        status = SWITCH_STATUS_NO_MEMORY;
-        krnlmon_log_error("Failed to create tunnel handle on device %d: "
-                 ",error: %s\n",
-                 device, switch_error_to_string(status));
-        return status;
-    }
+  status = switch_tunnel_get(device, handle, &tunnel_info);
+  if (status != SWITCH_STATUS_SUCCESS) {
+    krnlmon_log_error(
+        "Failed to get tunnel info on device %d: "
+        ",error: %s\n",
+        device, switch_error_to_string(status));
+    return status;
+  }
 
-    status = switch_tunnel_get(device, handle, &tunnel_info);
-    if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error(
-            "Failed to get tunnel info on device %d: "
-            ",error: %s\n",
-            device,
-            switch_error_to_string(status));
-        return status;
-    }
+  status = switch_pd_tunnel_entry(device, api_tunnel_info, true);
+  if (status != SWITCH_STATUS_SUCCESS) {
+    krnlmon_log_error(
+        "Failed to create tunnel entry on device %d: "
+        ",error: %s\n",
+        device, switch_error_to_string(status));
+    return status;
+  }
 
-    status = switch_pd_tunnel_entry(device, api_tunnel_info, true);
-    if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error(
-            "Failed to create tunnel entry on device %d: "
-            ",error: %s\n",
-            device,
-            switch_error_to_string(status));
-        return status;
-    }
-
-    SWITCH_MEMCPY(&tunnel_info->api_tunnel_info,
-                api_tunnel_info,
+  SWITCH_MEMCPY(&tunnel_info->api_tunnel_info, api_tunnel_info,
                 sizeof(switch_api_tunnel_info_t));
 
-    *tunnel_handle = handle;
-    return SWITCH_STATUS_SUCCESS;
+  *tunnel_handle = handle;
+  return SWITCH_STATUS_SUCCESS;
 }
 
 switch_status_t switch_api_tunnel_term_create(
     const switch_device_t device,
-    const switch_api_tunnel_term_info_t *api_tunnel_term_info,
-    switch_handle_t *tunnel_term_handle) {
-    switch_status_t status = SWITCH_STATUS_SUCCESS;
-    switch_tunnel_term_info_t *tunnel_term_info = NULL;
+    const switch_api_tunnel_term_info_t* api_tunnel_term_info,
+    switch_handle_t* tunnel_term_handle) {
+  switch_status_t status = SWITCH_STATUS_SUCCESS;
+  switch_tunnel_term_info_t* tunnel_term_info = NULL;
 
-    switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
+  switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
 
-    handle = switch_tunnel_term_handle_create(device);
-    if (handle == SWITCH_API_INVALID_HANDLE) {
-        status = SWITCH_STATUS_NO_MEMORY;
-        krnlmon_log_error(
-            "Failed to create tunnel term handle on device %d: "
-            ",error: %s\n",
-            device,
-            switch_error_to_string(status));
-        return status;
-    }
+  handle = switch_tunnel_term_handle_create(device);
+  if (handle == SWITCH_API_INVALID_HANDLE) {
+    status = SWITCH_STATUS_NO_MEMORY;
+    krnlmon_log_error(
+        "Failed to create tunnel term handle on device %d: "
+        ",error: %s\n",
+        device, switch_error_to_string(status));
+    return status;
+  }
 
-    status = switch_tunnel_term_get(device, handle, &tunnel_term_info);
-    if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error(
-            "Failed to get tunnel term info on device %d: "
-            ",error: %s\n",
-            device,
-            switch_error_to_string(status));
-        return status;
-    }
+  status = switch_tunnel_term_get(device, handle, &tunnel_term_info);
+  if (status != SWITCH_STATUS_SUCCESS) {
+    krnlmon_log_error(
+        "Failed to get tunnel term info on device %d: "
+        ",error: %s\n",
+        device, switch_error_to_string(status));
+    return status;
+  }
 
-    status = switch_pd_tunnel_term_entry(device, api_tunnel_term_info, true);
-    if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error(
-            "Failed to create tunnel term entry on device %d: "
-            ",error: %s\n",
-            device,
-            switch_error_to_string(status));
-        return status;
-    }
+  status = switch_pd_tunnel_term_entry(device, api_tunnel_term_info, true);
+  if (status != SWITCH_STATUS_SUCCESS) {
+    krnlmon_log_error(
+        "Failed to create tunnel term entry on device %d: "
+        ",error: %s\n",
+        device, switch_error_to_string(status));
+    return status;
+  }
 
-    SWITCH_MEMCPY(&tunnel_term_info->api_tunnel_term_info,
-                api_tunnel_term_info,
+  SWITCH_MEMCPY(&tunnel_term_info->api_tunnel_term_info, api_tunnel_term_info,
                 sizeof(switch_api_tunnel_term_info_t));
 
-    *tunnel_term_handle = handle;
+  *tunnel_term_handle = handle;
 
-    return SWITCH_STATUS_SUCCESS;
+  return SWITCH_STATUS_SUCCESS;
 }
 
 switch_status_t switch_tunnel_init(switch_device_t device) {
-  switch_tunnel_context_t *tunnel_ctx = NULL;
+  switch_tunnel_context_t* tunnel_ctx = NULL;
   switch_size_t tunnel_table_size = 0;
   switch_size_t tunnel_term_table_size = 0;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
@@ -225,30 +207,28 @@ switch_status_t switch_tunnel_init(switch_device_t device) {
     krnlmon_log_error(
         "Failed to allocate memory for switch_tunnel_context_t on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
   SWITCH_MEMSET(tunnel_ctx, 0x0, sizeof(switch_tunnel_context_t));
 
-  status = switch_device_api_context_set(
-      device, SWITCH_API_TYPE_TUNNEL, (void *)tunnel_ctx);
+  status = switch_device_api_context_set(device, SWITCH_API_TYPE_TUNNEL,
+                                         (void*)tunnel_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "Failed to set device api context on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
-  status = switch_api_table_size_get(
-      device, SWITCH_TABLE_TUNNEL, &tunnel_table_size);
+  status = switch_api_table_size_get(device, SWITCH_TABLE_TUNNEL,
+                                     &tunnel_table_size);
   SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
 
-  status = switch_api_table_size_get(
-      device, SWITCH_TABLE_TUNNEL_TERM, &tunnel_term_table_size);
+  status = switch_api_table_size_get(device, SWITCH_TABLE_TUNNEL_TERM,
+                                     &tunnel_term_table_size);
   SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
 
 #if 0
@@ -266,25 +246,23 @@ switch_status_t switch_tunnel_init(switch_device_t device) {
   }
 #endif
 
-  status = switch_handle_type_init(
-      device, SWITCH_HANDLE_TYPE_TUNNEL, tunnel_table_size);
+  status = switch_handle_type_init(device, SWITCH_HANDLE_TYPE_TUNNEL,
+                                   tunnel_table_size);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "Failed to init handle SWITCH_HANDLE_TYPE_TUNNEL on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     goto cleanup;
   }
 
-  status = switch_handle_type_init(
-      device, SWITCH_HANDLE_TYPE_TUNNEL_TERM, tunnel_term_table_size);
+  status = switch_handle_type_init(device, SWITCH_HANDLE_TYPE_TUNNEL_TERM,
+                                   tunnel_term_table_size);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "Failed to init handle SWITCH_HANDLE_TYPE_TUNNEL_TERM on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     goto cleanup;
   }
 
@@ -297,17 +275,16 @@ cleanup:
 }
 
 switch_status_t switch_tunnel_free(switch_device_t device) {
-  switch_tunnel_context_t *tunnel_ctx = NULL;
+  switch_tunnel_context_t* tunnel_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_TUNNEL, (void **)&tunnel_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_TUNNEL,
+                                         (void**)&tunnel_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "Failed to get device api context on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -316,8 +293,7 @@ switch_status_t switch_tunnel_free(switch_device_t device) {
     krnlmon_log_error(
         "Failed to free handle SWITCH_HANDLE_TYPE_TUNNEL on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
   }
 
   status = switch_handle_type_free(device, SWITCH_HANDLE_TYPE_TUNNEL_TERM);
@@ -325,8 +301,7 @@ switch_status_t switch_tunnel_free(switch_device_t device) {
     krnlmon_log_error(
         "Failed to free handle SWITCH_HANDLE_TYPE_TUNNEL_TERM on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
   }
 
   SWITCH_FREE(device, tunnel_ctx);

--- a/switchapi/dpdk/switch_tunnel.c
+++ b/switchapi/dpdk/switch_tunnel.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/dpdk/switch_vrf.c
+++ b/switchapi/dpdk/switch_vrf.c
@@ -22,7 +22,7 @@
 #include "switchapi/switch_status.h"
 
 switch_status_t switch_vrf_init(switch_device_t device) {
-  switch_vrf_context_t *vrf_ctx = NULL;
+  switch_vrf_context_t* vrf_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   vrf_ctx = SWITCH_MALLOC(device, sizeof(switch_vrf_context_t), 0x1);
@@ -31,21 +31,19 @@ switch_status_t switch_vrf_init(switch_device_t device) {
     krnlmon_log_error(
         "vrf init: Failed to allocate memory switch_vrf_context_t on device %d:"
         " , error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
   SWITCH_MEMSET(vrf_ctx, 0x0, sizeof(switch_vrf_context_t));
 
-  status = switch_device_api_context_set(
-      device, SWITCH_API_TYPE_VRF, (void *)vrf_ctx);
+  status = switch_device_api_context_set(device, SWITCH_API_TYPE_VRF,
+                                         (void*)vrf_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "vrf init: Failed to get device context on device %d: "
         ", error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -55,8 +53,7 @@ switch_status_t switch_vrf_init(switch_device_t device) {
     krnlmon_log_error(
         "vrf init: Failed to init handle on device %d: "
         ", error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -66,17 +63,16 @@ switch_status_t switch_vrf_init(switch_device_t device) {
 }
 
 switch_status_t switch_vrf_free(switch_device_t device) {
-  switch_vrf_context_t *vrf_ctx = NULL;
+  switch_vrf_context_t* vrf_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_VRF, (void **)&vrf_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_VRF,
+                                         (void**)&vrf_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "vrf free: Failed to get device context on device %d: "
         ", error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -85,8 +81,7 @@ switch_status_t switch_vrf_free(switch_device_t device) {
     krnlmon_log_error(
         "vrf free: Failed to fre handle on device %d: "
         ", error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
   }
 
   SWITCH_FREE(device, vrf_ctx);
@@ -99,49 +94,42 @@ switch_status_t switch_vrf_free(switch_device_t device) {
 }
 
 switch_status_t switch_api_vrf_create(const switch_device_t device,
-                                               const switch_vrf_t vrf_id,
-                                               switch_handle_t *vrf_handle) {
-  switch_vrf_context_t *vrf_ctx = NULL;
-  switch_vrf_info_t *vrf_info = NULL;
+                                      const switch_vrf_t vrf_id,
+                                      switch_handle_t* vrf_handle) {
+  switch_vrf_context_t* vrf_ctx = NULL;
+  switch_vrf_info_t* vrf_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
-  switch_handle_t *tmp_vrf_handle = NULL;
+  switch_handle_t* tmp_vrf_handle = NULL;
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_VRF, (void **)&vrf_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_VRF,
+                                         (void**)&vrf_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "vrf create:: Failed to get device context on device %d, vrf id %d: "
         ", error: %s\n",
-        device,
-        vrf_id,
-        switch_error_to_string(status));
+        device, vrf_id, switch_error_to_string(status));
     return status;
   }
 
   *vrf_handle = SWITCH_API_INVALID_HANDLE;
-  
-  if(vrf_id)
-  {
-    status = SWITCH_ARRAY_GET(
-        &vrf_ctx->vrf_id_array, vrf_id, (void **)&tmp_vrf_handle);
+
+  if (vrf_id) {
+    status = SWITCH_ARRAY_GET(&vrf_ctx->vrf_id_array, vrf_id,
+                              (void**)&tmp_vrf_handle);
     if (status != SWITCH_STATUS_ITEM_NOT_FOUND &&
         status != SWITCH_STATUS_SUCCESS) {
       krnlmon_log_error(
           "vrf create Failed to get vrf handle on device %d, vrf id %d: "
           ", error: %s\n",
-          device,
-          vrf_id,
-          switch_error_to_string(status));
+          device, vrf_id, switch_error_to_string(status));
       return status;
     }
 
     if (status == SWITCH_STATUS_SUCCESS) {
       *vrf_handle = *tmp_vrf_handle;
       krnlmon_log_info("vrf id %x, (handle: 0x%lx) already exists on device %d",
-                vrf_id,
-                *vrf_handle,
-                device);
+                       vrf_id, *vrf_handle, device);
       return status;
     }
   }
@@ -152,24 +140,20 @@ switch_status_t switch_api_vrf_create(const switch_device_t device,
     krnlmon_log_error(
         "vrf create: Failed to create handle on device %d, vrf id %d: "
         ", error: %s\n",
-        device,
-        vrf_id,
-        switch_error_to_string(status));
+        device, vrf_id, switch_error_to_string(status));
     return status;
   }
 
   *vrf_handle = handle;
 
-  status = SWITCH_ARRAY_INSERT(
-        &vrf_ctx->vrf_id_array, vrf_id, (void *)(vrf_handle));
+  status =
+      SWITCH_ARRAY_INSERT(&vrf_ctx->vrf_id_array, vrf_id, (void*)(vrf_handle));
 
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "vrf create Failed to get vrf handle on device %d, vrf id %d: "
         ", error: %s\n",
-        device,
-        vrf_id,
-        switch_error_to_string(status));
+        device, vrf_id, switch_error_to_string(status));
     status = switch_vrf_handle_delete(device, handle);
     SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
     return status;
@@ -180,29 +164,24 @@ switch_status_t switch_api_vrf_create(const switch_device_t device,
     krnlmon_log_error(
         "vrf create: Failed to get vrf info on device %d, vrf id %d: "
         ", error: %s\n",
-        device,
-        vrf_id,
-        switch_error_to_string(status));
+        device, vrf_id, switch_error_to_string(status));
     status = switch_vrf_handle_delete(device, handle);
     return status;
   }
 
   vrf_info->vrf_id = vrf_id;
 
-  krnlmon_log_info(
-      "vrf created on device %d vrf id %d handle 0x%lx ",
-      device,
-      vrf_id,
-      handle);
+  krnlmon_log_info("vrf created on device %d vrf id %d handle 0x%lx ", device,
+                   vrf_id, handle);
 
   return status;
 }
 
-switch_status_t switch_api_vrf_delete(
-    const switch_device_t device, const switch_handle_t vrf_handle) {
-  switch_vrf_context_t *vrf_ctx = NULL;
-  switch_vrf_info_t *vrf_info = NULL;
-  switch_handle_t *tmp_vrf_handle = NULL;
+switch_status_t switch_api_vrf_delete(const switch_device_t device,
+                                      const switch_handle_t vrf_handle) {
+  switch_vrf_context_t* vrf_ctx = NULL;
+  switch_vrf_info_t* vrf_info = NULL;
+  switch_handle_t* tmp_vrf_handle = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!SWITCH_VRF_HANDLE(vrf_handle)) {
@@ -210,21 +189,17 @@ switch_status_t switch_api_vrf_delete(
     krnlmon_log_error(
         "vrf delete failed on device %d, vrf handle 0x%lx: "
         ", error: %s\n",
-        device,
-        vrf_handle,
-        switch_error_to_string(status));
+        device, vrf_handle, switch_error_to_string(status));
     return status;
   }
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_VRF, (void **)&vrf_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_VRF,
+                                         (void**)&vrf_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "vrf delete: Failed to get device context on device %d, vrf "
         "handle 0x%lx: , error: %s\n",
-        device,
-        vrf_handle,
-        switch_error_to_string(status));
+        device, vrf_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -233,24 +208,19 @@ switch_status_t switch_api_vrf_delete(
     krnlmon_log_error(
         "vrf delete: Failed to get vrf info on device %d, vrf handle 0x%lx: "
         ", error: %s\n",
-        device,
-        vrf_handle,
-        switch_error_to_string(status));
+        device, vrf_handle, switch_error_to_string(status));
     return status;
   }
 
   if (vrf_info->vrf_id) {
-    SWITCH_ARRAY_GET(
-        &vrf_ctx->vrf_id_array, vrf_info->vrf_id, (void **)&tmp_vrf_handle);
+    SWITCH_ARRAY_GET(&vrf_ctx->vrf_id_array, vrf_info->vrf_id,
+                     (void**)&tmp_vrf_handle);
     status = SWITCH_ARRAY_DELETE(&vrf_ctx->vrf_id_array, vrf_info->vrf_id);
     if (status != SWITCH_STATUS_SUCCESS) {
       krnlmon_log_error(
           "vrf delete: Failed to get vrf info for vrf handle 0x%lx vrf id %d: "
           "on device %d, error: %s\n",
-          vrf_handle,
-          vrf_info->vrf_id,
-          device,
-          switch_error_to_string(status));
+          vrf_handle, vrf_info->vrf_id, device, switch_error_to_string(status));
       return status;
     }
 
@@ -264,14 +234,12 @@ switch_status_t switch_api_vrf_delete(
     krnlmon_log_error(
         "vrf delete: Failed to delete vrf handle 0x%lx: on device %d "
         ", error: %s\n",
-        vrf_handle,
-        device,
-        switch_error_to_string(status));
+        vrf_handle, device, switch_error_to_string(status));
     return status;
   }
 
-  krnlmon_log_info(
-      "vrf deleted on device %d, vrf handle 0x%lx\n", device, vrf_handle);
+  krnlmon_log_info("vrf deleted on device %d, vrf handle 0x%lx\n", device,
+                   vrf_handle);
 
   return status;
 }

--- a/switchapi/dpdk/switch_vrf.c
+++ b/switchapi/dpdk/switch_vrf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/dpdk/switchapi_utils.c
+++ b/switchapi/dpdk/switchapi_utils.c
@@ -25,9 +25,8 @@ extern "C" {
 
 #define __FILE_ID__ SWITCHAPI_UTILS
 
-static switch_uint32_t MurmurHash(const void *key,
-                           switch_uint32_t length,
-                           switch_uint32_t seed) {
+static switch_uint32_t MurmurHash(const void* key, switch_uint32_t length,
+                                  switch_uint32_t seed) {
 // 'm' and 'r' are mixing constants generated offline.
 // They're not really 'magic', they just happen to work well.
 #define m 0x5bd1e995
@@ -37,10 +36,10 @@ static switch_uint32_t MurmurHash(const void *key,
   switch_uint32_t h = seed ^ length;
 
   // Mix 4 bytes at a time into the hash
-  const unsigned char *data = (const unsigned char *)key;
+  const unsigned char* data = (const unsigned char*)key;
 
   while (length >= 4) {
-    uint32_t k = *(uint32_t *)data;
+    uint32_t k = *(uint32_t*)data;
 
     k *= m;
     k ^= k >> r;
@@ -76,25 +75,24 @@ static switch_uint32_t MurmurHash(const void *key,
   return h;
 }
 
-switch_status_t SWITCH_ARRAY_INIT(switch_array_t *array) {
+switch_status_t SWITCH_ARRAY_INIT(switch_array_t* array) {
   SWITCH_ASSERT(array != NULL);
   array->array = NULL;
   array->num_entries = 0;
   return SWITCH_STATUS_SUCCESS;
 }
 
-switch_uint32_t SWITCH_ARRAY_COUNT(switch_array_t *array) {
+switch_uint32_t SWITCH_ARRAY_COUNT(switch_array_t* array) {
   SWITCH_ASSERT(array != NULL);
   return array->num_entries;
 }
 
-switch_status_t SWITCH_ARRAY_INSERT(switch_array_t *array,
-                                    switch_uint64_t index,
-                                    void *data) {
+switch_status_t SWITCH_ARRAY_INSERT(switch_array_t* array,
+                                    switch_uint64_t index, void* data) {
   SWITCH_ASSERT(array != NULL);
   SWITCH_ASSERT(data != NULL);
 
-  Word_t *p = NULL;
+  Word_t* p = NULL;
   JLI(p, array->array, (switch_uint64_t)index);
   if (p) {
     *p = (Word_t)data;
@@ -105,38 +103,36 @@ switch_status_t SWITCH_ARRAY_INSERT(switch_array_t *array,
   }
 }
 
-switch_status_t SWITCH_ARRAY_GET(switch_array_t *array,
-                                 switch_uint64_t index,
-                                 void **data) {
+switch_status_t SWITCH_ARRAY_GET(switch_array_t* array, switch_uint64_t index,
+                                 void** data) {
   SWITCH_ASSERT(array != NULL);
   SWITCH_ASSERT(data != NULL);
 
-  Word_t *p = NULL;
+  Word_t* p = NULL;
   JLG(p, array->array, (switch_uint64_t)index);
   if (p) {
-    *(Word_t *)data = *(Word_t *)p;
+    *(Word_t*)data = *(Word_t*)p;
     return SWITCH_STATUS_SUCCESS;
   } else {
     return SWITCH_STATUS_ITEM_NOT_FOUND;
   }
 }
 
-switch_status_t SWITCH_ARRAY_NEXT(switch_array_t *array,
-                                  switch_uint64_t *index,
-                                  void **data) {
+switch_status_t SWITCH_ARRAY_NEXT(switch_array_t* array, switch_uint64_t* index,
+                                  void** data) {
   Word_t tmp_index = (Word_t)*index;
 
   SWITCH_ASSERT(array != NULL);
   SWITCH_ASSERT(data != NULL);
 
-  Word_t *p = NULL;
+  Word_t* p = NULL;
   if (tmp_index == 0) {
     JLF(p, array->array, tmp_index);
   } else {
     JLN(p, array->array, tmp_index);
   }
   if (p) {
-    *(Word_t *)data = *(Word_t *)p;
+    *(Word_t*)data = *(Word_t*)p;
     *index = (switch_uint64_t)tmp_index;
     return SWITCH_STATUS_SUCCESS;
   } else {
@@ -144,7 +140,7 @@ switch_status_t SWITCH_ARRAY_NEXT(switch_array_t *array,
   }
 }
 
-switch_status_t SWITCH_ARRAY_DELETE(switch_array_t *array,
+switch_status_t SWITCH_ARRAY_DELETE(switch_array_t* array,
                                     switch_uint64_t index) {
   SWITCH_ASSERT(array != NULL);
 
@@ -158,7 +154,7 @@ switch_status_t SWITCH_ARRAY_DELETE(switch_array_t *array,
   }
 }
 
-switch_status_t SWITCH_LIST_INIT(switch_list_t *list) {
+switch_status_t SWITCH_LIST_INIT(switch_list_t* list) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(list != NULL);
@@ -166,7 +162,7 @@ switch_status_t SWITCH_LIST_INIT(switch_list_t *list) {
   if (!list) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("list insert failed, error: %s\n",
-              switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
   tommy_list_init(&list->list);
@@ -174,7 +170,7 @@ switch_status_t SWITCH_LIST_INIT(switch_list_t *list) {
   return SWITCH_STATUS_SUCCESS;
 }
 
-switch_status_t SWITCH_LIST_SORT(switch_list_t *list,
+switch_status_t SWITCH_LIST_SORT(switch_list_t* list,
                                  switch_list_compare_func_t compare_func) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
@@ -183,14 +179,14 @@ switch_status_t SWITCH_LIST_SORT(switch_list_t *list,
   if (!list) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("list insert failed, error: %s\n",
-              switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
   tommy_list_sort(&list->list, compare_func);
   return SWITCH_STATUS_SUCCESS;
 }
 
-bool SWITCH_LIST_EMPTY(switch_list_t *list) {
+bool SWITCH_LIST_EMPTY(switch_list_t* list) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   bool is_empty = false;
 
@@ -199,7 +195,7 @@ bool SWITCH_LIST_EMPTY(switch_list_t *list) {
   if (!list) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("list empty get failed, error: %s\n",
-             switch_error_to_string(status));
+                      switch_error_to_string(status));
     return FALSE;
   }
 
@@ -207,7 +203,7 @@ bool SWITCH_LIST_EMPTY(switch_list_t *list) {
   return is_empty;
 }
 
-switch_size_t SWITCH_LIST_COUNT(switch_list_t *list) {
+switch_size_t SWITCH_LIST_COUNT(switch_list_t* list) {
   SWITCH_ASSERT(list != NULL);
 
   if (!list) {
@@ -217,9 +213,8 @@ switch_size_t SWITCH_LIST_COUNT(switch_list_t *list) {
   return list->num_entries;
 }
 
-switch_status_t SWITCH_LIST_INSERT(switch_list_t *list,
-                                   switch_node_t *node,
-                                   void *data) {
+switch_status_t SWITCH_LIST_INSERT(switch_list_t* list, switch_node_t* node,
+                                   void* data) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(list != NULL);
@@ -229,7 +224,7 @@ switch_status_t SWITCH_LIST_INSERT(switch_list_t *list,
   if (!list || !node || !data) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("list insert failed, error: %s\n",
-             switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
   tommy_list_insert_head(&list->list, node, data);
@@ -237,7 +232,7 @@ switch_status_t SWITCH_LIST_INSERT(switch_list_t *list,
   return SWITCH_STATUS_SUCCESS;
 }
 
-switch_status_t SWITCH_LIST_DELETE(switch_list_t *list, switch_node_t *node) {
+switch_status_t SWITCH_LIST_DELETE(switch_list_t* list, switch_node_t* node) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(list != NULL);
@@ -246,7 +241,7 @@ switch_status_t SWITCH_LIST_DELETE(switch_list_t *list, switch_node_t *node) {
   if (!list || !node) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("list delete failed, error: %s\n",
-              switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
   tommy_list_remove_existing(&list->list, node);
@@ -254,7 +249,7 @@ switch_status_t SWITCH_LIST_DELETE(switch_list_t *list, switch_node_t *node) {
   return SWITCH_STATUS_SUCCESS;
 }
 
-switch_status_t SWITCH_HASHTABLE_INIT(switch_hashtable_t *hashtable) {
+switch_status_t SWITCH_HASHTABLE_INIT(switch_hashtable_t* hashtable) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(hashtable != NULL);
@@ -263,7 +258,7 @@ switch_status_t SWITCH_HASHTABLE_INIT(switch_hashtable_t *hashtable) {
   if (!hashtable || hashtable->size == 0) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("hashtable init failed, error: %s\n",
-              switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
   tommy_hashtable_init(&hashtable->table, hashtable->size);
@@ -271,7 +266,7 @@ switch_status_t SWITCH_HASHTABLE_INIT(switch_hashtable_t *hashtable) {
   return SWITCH_STATUS_SUCCESS;
 }
 
-switch_size_t SWITCH_HASHTABLE_COUNT(switch_hashtable_t *hashtable) {
+switch_size_t SWITCH_HASHTABLE_COUNT(switch_hashtable_t* hashtable) {
   SWITCH_ASSERT(hashtable != NULL);
 
   if (!hashtable) {
@@ -281,10 +276,9 @@ switch_size_t SWITCH_HASHTABLE_COUNT(switch_hashtable_t *hashtable) {
   return hashtable->num_entries;
 }
 
-switch_status_t SWITCH_HASHTABLE_INSERT(switch_hashtable_t *hashtable,
-                                        switch_hashnode_t *node,
-                                        void *key,
-                                        void *data) {
+switch_status_t SWITCH_HASHTABLE_INSERT(switch_hashtable_t* hashtable,
+                                        switch_hashnode_t* node, void* key,
+                                        void* data) {
   switch_uint8_t hash_key[SWITCH_API_BUFFER_SIZE];
   switch_uint32_t hash_length = 0;
   switch_uint32_t hash = 0;
@@ -298,7 +292,7 @@ switch_status_t SWITCH_HASHTABLE_INSERT(switch_hashtable_t *hashtable,
   if (!hashtable || !node || !key || !data) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("hashtable insert failed, error: %s\n",
-             switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -307,7 +301,7 @@ switch_status_t SWITCH_HASHTABLE_INSERT(switch_hashtable_t *hashtable,
   status = hashtable->key_func(key, hash_key, &hash_length);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error("hashtable insert failed, error: %s\n",
-             switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -317,9 +311,8 @@ switch_status_t SWITCH_HASHTABLE_INSERT(switch_hashtable_t *hashtable,
   return SWITCH_STATUS_SUCCESS;
 }
 
-switch_status_t SWITCH_HASHTABLE_DELETE(switch_hashtable_t *hashtable,
-                                        void *key,
-                                        void **data) {
+switch_status_t SWITCH_HASHTABLE_DELETE(switch_hashtable_t* hashtable,
+                                        void* key, void** data) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   switch_uint8_t hash_key[SWITCH_API_BUFFER_SIZE];
   switch_uint32_t hash_length = 0;
@@ -332,7 +325,7 @@ switch_status_t SWITCH_HASHTABLE_DELETE(switch_hashtable_t *hashtable,
   if (!hashtable || !key || !data) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("hashtable delete failed, error: %s\n",
-             switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -341,17 +334,17 @@ switch_status_t SWITCH_HASHTABLE_DELETE(switch_hashtable_t *hashtable,
   status = hashtable->key_func(key, hash_key, &hash_length);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error("hashtable delete failed, error: %s\n",
-             switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
   hash = MurmurHash(hash_key, hash_length, hashtable->hash_seed);
-  *data = (void *)tommy_hashtable_remove(
+  *data = (void*)tommy_hashtable_remove(
       &hashtable->table, hashtable->compare_func, hash_key, hash);
   if (!(*data)) {
     status = SWITCH_STATUS_ITEM_NOT_FOUND;
     krnlmon_log_error("hashtable delete failed, error: %s\n",
-              switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -359,8 +352,8 @@ switch_status_t SWITCH_HASHTABLE_DELETE(switch_hashtable_t *hashtable,
   return SWITCH_STATUS_SUCCESS;
 }
 
-switch_status_t SWITCH_HASHTABLE_DELETE_NODE(switch_hashtable_t *hashtable,
-                                             switch_hashnode_t *node) {
+switch_status_t SWITCH_HASHTABLE_DELETE_NODE(switch_hashtable_t* hashtable,
+                                             switch_hashnode_t* node) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(hashtable != NULL);
@@ -369,7 +362,7 @@ switch_status_t SWITCH_HASHTABLE_DELETE_NODE(switch_hashtable_t *hashtable,
   if (!hashtable || !node) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("hashtable delete node failed, error: %s\n",
-              switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
   tommy_hashtable_remove_existing(&hashtable->table, node);
@@ -377,9 +370,8 @@ switch_status_t SWITCH_HASHTABLE_DELETE_NODE(switch_hashtable_t *hashtable,
   return SWITCH_STATUS_SUCCESS;
 }
 
-switch_status_t SWITCH_HASHTABLE_SEARCH(switch_hashtable_t *hashtable,
-                                        void *key,
-                                        void **data) {
+switch_status_t SWITCH_HASHTABLE_SEARCH(switch_hashtable_t* hashtable,
+                                        void* key, void** data) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   switch_uint8_t hash_key[SWITCH_API_BUFFER_SIZE];
   switch_uint32_t hash_length = 0;
@@ -392,7 +384,7 @@ switch_status_t SWITCH_HASHTABLE_SEARCH(switch_hashtable_t *hashtable,
   if (!hashtable || !key || !data) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_debug("hashtable search failed, error: %s\n",
-              switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -401,26 +393,25 @@ switch_status_t SWITCH_HASHTABLE_SEARCH(switch_hashtable_t *hashtable,
   status = hashtable->key_func(key, hash_key, &hash_length);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_debug("hashtable search failed, error: %s\n",
-              switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
   hash = MurmurHash(hash_key, hash_length, hashtable->hash_seed);
-  *data = (void *)tommy_hashtable_search(
+  *data = (void*)tommy_hashtable_search(
       &hashtable->table, hashtable->compare_func, hash_key, hash);
   if (!(*data)) {
     status = SWITCH_STATUS_ITEM_NOT_FOUND;
     krnlmon_log_debug("hashtable search failed, error: %s\n",
-              switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
   return status;
 }
 
-switch_status_t SWITCH_HASHTABLE_FOREACH_ARG(switch_hashtable_t *hashtable,
-                                             void *func,
-                                             void *arg) {
+switch_status_t SWITCH_HASHTABLE_FOREACH_ARG(switch_hashtable_t* hashtable,
+                                             void* func, void* arg) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(hashtable != NULL);
@@ -430,7 +421,7 @@ switch_status_t SWITCH_HASHTABLE_FOREACH_ARG(switch_hashtable_t *hashtable,
   if (!hashtable || !func || !arg) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("hashtable foreach arg failed, error: %s\n",
-              switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
   tommy_hashtable_foreach_arg(&hashtable->table, func, arg);
@@ -438,7 +429,7 @@ switch_status_t SWITCH_HASHTABLE_FOREACH_ARG(switch_hashtable_t *hashtable,
   return SWITCH_STATUS_SUCCESS;
 }
 
-switch_status_t SWITCH_HASHTABLE_DONE(switch_hashtable_t *hashtable) {
+switch_status_t SWITCH_HASHTABLE_DONE(switch_hashtable_t* hashtable) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(hashtable != NULL);
@@ -446,14 +437,14 @@ switch_status_t SWITCH_HASHTABLE_DONE(switch_hashtable_t *hashtable) {
   if (!hashtable) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("hashtable done failed, error: %s\n",
-              switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
   tommy_hashtable_done(&hashtable->table);
   return SWITCH_STATUS_SUCCESS;
 }
 
-char *switch_error_to_string(switch_status_t status) {
+char* switch_error_to_string(switch_status_t status) {
   switch (status) {
     case SWITCH_STATUS_ITEM_NOT_FOUND:
       return "err: entry not found";
@@ -496,7 +487,7 @@ char *switch_error_to_string(switch_status_t status) {
   }
 }
 
-char *switch_handle_type_to_string(switch_handle_type_t handle_type) {
+char* switch_handle_type_to_string(switch_handle_type_t handle_type) {
   switch (handle_type) {
     case SWITCH_HANDLE_TYPE_NONE:
       return "none";
@@ -598,7 +589,7 @@ char *switch_handle_type_to_string(switch_handle_type_t handle_type) {
       return "pktdriver rx filter";
     case SWITCH_HANDLE_TYPE_PKTDRIVER_TX_FILTER:
       return "pktdriver tx filter";
-   case SWITCH_HANDLE_TYPE_ROUTE:
+    case SWITCH_HANDLE_TYPE_ROUTE:
       return "route";
     case SWITCH_HANDLE_TYPE_DEVICE:
       return "device";
@@ -752,8 +743,7 @@ switch_status_t switch_pd_tdi_status_to_status(tdi_status_t pd_status) {
   return status;
 }
 
-
-static bool switch_l3_host_entry(const switch_ip_addr_t *ip_addr) {
+static bool switch_l3_host_entry(const switch_ip_addr_t* ip_addr) {
   SWITCH_ASSERT(ip_addr != NULL);
 
   if (ip_addr->type == SWITCH_API_IP_ADDR_V4) {
@@ -765,10 +755,9 @@ static bool switch_l3_host_entry(const switch_ip_addr_t *ip_addr) {
   }
 }
 
-switch_status_t switch_ipv4_to_string(switch_ip4_t ip4,
-                                      char *buffer,
+switch_status_t switch_ipv4_to_string(switch_ip4_t ip4, char* buffer,
                                       switch_int32_t buffer_size,
-                                      switch_int32_t *length) {
+                                      switch_int32_t* length) {
   SWITCH_ASSERT(buffer != NULL);
 
   char tmp_buffer[SWITCH_API_BUFFER_SIZE];
@@ -779,10 +768,9 @@ switch_status_t switch_ipv4_to_string(switch_ip4_t ip4,
   return SWITCH_STATUS_SUCCESS;
 }
 
-switch_status_t switch_ipv6_to_string(switch_ip6_t ip6,
-                                      char *buffer,
+switch_status_t switch_ipv6_to_string(switch_ip6_t ip6, char* buffer,
                                       switch_int32_t buffer_size,
-                                      switch_int32_t *length) {
+                                      switch_int32_t* length) {
   SWITCH_ASSERT(buffer != NULL);
 
   char tmp_buffer[SWITCH_API_BUFFER_SIZE];
@@ -792,22 +780,16 @@ switch_status_t switch_ipv6_to_string(switch_ip6_t ip6,
   return SWITCH_STATUS_SUCCESS;
 }
 
-switch_status_t switch_mac_to_string(switch_mac_addr_t *mac,
-                                     char *buffer,
+switch_status_t switch_mac_to_string(switch_mac_addr_t* mac, char* buffer,
                                      switch_int32_t buffer_size,
-                                     switch_int32_t *length_out) {
+                                     switch_int32_t* length_out) {
   SWITCH_ASSERT(buffer != NULL);
   SWITCH_ASSERT(mac != NULL);
 
-  switch_int32_t length = snprintf(buffer,
-                                   buffer_size,
-                                   "%02x:%02x:%02x:%02x:%02x:%02x",
-                                   mac->mac_addr[0],
-                                   mac->mac_addr[1],
-                                   mac->mac_addr[2],
-                                   mac->mac_addr[3],
-                                   mac->mac_addr[4],
-                                   mac->mac_addr[5]);
+  switch_int32_t length =
+      snprintf(buffer, buffer_size, "%02x:%02x:%02x:%02x:%02x:%02x",
+               mac->mac_addr[0], mac->mac_addr[1], mac->mac_addr[2],
+               mac->mac_addr[3], mac->mac_addr[4], mac->mac_addr[5]);
   if (length_out) {
     *length_out = length;
   }
@@ -815,7 +797,7 @@ switch_status_t switch_mac_to_string(switch_mac_addr_t *mac,
 }
 
 static switch_status_t switch_ipv4_prefix_to_mask(switch_uint32_t prefix,
-                                           switch_uint32_t *mask) {
+                                                  switch_uint32_t* mask) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!mask) {
@@ -832,7 +814,7 @@ static switch_status_t switch_ipv4_prefix_to_mask(switch_uint32_t prefix,
 }
 
 static switch_status_t switch_ipv6_prefix_to_mask(switch_uint32_t prefix,
-                                           switch_uint8_t *mask) {
+                                                  switch_uint8_t* mask) {
   switch_uint32_t prefix_bytes = 0;
   switch_uint32_t index = 0;
 
@@ -972,7 +954,7 @@ switch_direction_t switch_table_id_to_direction(switch_table_id_t table_id) {
   }
 }
 
-char *switch_api_type_to_string(switch_api_type_t api_type) {
+char* switch_api_type_to_string(switch_api_type_t api_type) {
   switch (api_type) {
     case SWITCH_API_TYPE_PORT:
       return "port";
@@ -1054,7 +1036,7 @@ char *switch_api_type_to_string(switch_api_type_t api_type) {
   }
 }
 
-static char *switch_packet_type_to_string(switch_packet_type_t packet_type) {
+static char* switch_packet_type_to_string(switch_packet_type_t packet_type) {
   switch (packet_type) {
     case SWITCH_PACKET_TYPE_UNICAST:
       return "unicast";
@@ -1068,8 +1050,8 @@ static char *switch_packet_type_to_string(switch_packet_type_t packet_type) {
   }
 }
 
-switch_int32_t switch_convert_string_to_ipv4(const char *v4_string,
-                                             switch_ip4_t *ip) {
+switch_int32_t switch_convert_string_to_ipv4(const char* v4_string,
+                                             switch_ip4_t* ip) {
   switch_int32_t ret_val;
 
   if (!v4_string || !ip) {
@@ -1085,8 +1067,8 @@ switch_int32_t switch_convert_string_to_ipv4(const char *v4_string,
   return 1;
 }
 
-switch_int32_t switch_convert_string_to_ipv6(const char *v6_string,
-                                             switch_ip6_t *ip) {
+switch_int32_t switch_convert_string_to_ipv6(const char* v6_string,
+                                             switch_ip6_t* ip) {
   switch_int32_t ret_val;
 
   if (!v6_string || !ip) {

--- a/switchapi/es2k/switch_config.c
+++ b/switchapi/es2k/switch_config.c
@@ -25,12 +25,13 @@ extern "C" {
 #define __FILE_ID__ SWITCH_CONFIG
 switch_config_info_t config_info;
 
-switch_status_t switch_config_init(switch_config_t *switch_config) {
+switch_status_t switch_config_init(switch_config_t* switch_config) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (config_info.config_inited) {
     status = SWITCH_STATUS_ITEM_ALREADY_EXISTS;
-    krnlmon_log_error("config init failed, error: %s", switch_error_to_string(status));
+    krnlmon_log_error("config init failed, error: %s",
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -68,14 +69,13 @@ switch_status_t switch_config_free(void) {
 }
 
 switch_status_t switch_config_device_context_set(
-    switch_device_t device, switch_device_context_t *device_ctx) {
+    switch_device_t device, switch_device_context_t* device_ctx) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (device_ctx && config_info.device_inited[device]) {
     status = SWITCH_STATUS_ITEM_ALREADY_EXISTS;
-    krnlmon_log_error("config free failed for device %d, error: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("config free failed for device %d, error: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -91,14 +91,13 @@ switch_status_t switch_config_device_context_set(
 }
 
 switch_status_t switch_config_device_context_get(
-    switch_device_t device, switch_device_context_t **device_ctx) {
+    switch_device_t device, switch_device_context_t** device_ctx) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!config_info.device_inited[device]) {
     status = SWITCH_STATUS_UNINITIALIZED;
     krnlmon_log_error("Failed to get device context for device %d, error: %s\n",
-              device,
-              switch_error_to_string(status));
+                      device, switch_error_to_string(status));
     return status;
   }
 
@@ -108,14 +107,14 @@ switch_status_t switch_config_device_context_get(
 }
 
 switch_status_t switch_config_table_sizes_get(switch_device_t device,
-                                              switch_size_t *table_sizes) {
+                                              switch_size_t* table_sizes) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   status = switch_table_default_sizes_get(table_sizes);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("Failed to get config table sizes for device %d, error: %s\n",
-              device,
-              switch_error_to_string(status));
+    krnlmon_log_error(
+        "Failed to get config table sizes for device %d, error: %s\n", device,
+        switch_error_to_string(status));
     return status;
   }
 

--- a/switchapi/es2k/switch_config.c
+++ b/switchapi/es2k/switch_config.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/es2k/switch_device.c
+++ b/switchapi/es2k/switch_device.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/es2k/switch_device.c
+++ b/switchapi/es2k/switch_device.c
@@ -51,25 +51,22 @@ switch_status_t switch_api_init(switch_device_t device) {
 
   status = switch_config_init(&api_config);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("switch api init failed on device %d: %s\n",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("switch api init failed on device %d: %s\n", device,
+                      switch_error_to_string(status));
   }
 
   status = switch_api_device_add(device);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("switch api init failed on device %d: %s\n",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("switch api init failed on device %d: %s\n", device,
+                      switch_error_to_string(status));
     return status;
   }
 
 #ifdef THRIFT_ENABLED
   status = start_switch_api_rpc_server();
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("start_switch_api_rpc_server on device %d",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("start_switch_api_rpc_server on device %d", device,
+                      switch_error_to_string(status));
     return status;
   }
 #endif  // THRIFT_ENABLED
@@ -78,7 +75,7 @@ switch_status_t switch_api_init(switch_device_t device) {
 }
 
 switch_status_t switch_device_context_get(
-    switch_device_t device, switch_device_context_t **device_ctx) {
+    switch_device_t device, switch_device_context_t** device_ctx) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   status = switch_config_device_context_get(device, device_ctx);
@@ -86,8 +83,7 @@ switch_status_t switch_device_context_get(
     krnlmon_log_error(
         "device context get failed on device %d: "
         "device config context get failed(%s)",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -95,7 +91,7 @@ switch_status_t switch_device_context_get(
 }
 
 switch_status_t switch_device_api_init(switch_device_t device) {
-  switch_device_context_t *device_ctx = NULL;
+  switch_device_context_t* device_ctx = NULL;
   switch_api_type_t api_type = 0;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   switch_status_t tmp_status = SWITCH_STATUS_SUCCESS;
@@ -105,8 +101,7 @@ switch_status_t switch_device_api_init(switch_device_t device) {
     krnlmon_log_error(
         "device api init failed on device %d: "
         "device context get failed(%s)",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -189,9 +184,7 @@ switch_status_t switch_device_api_init(switch_device_t device) {
       krnlmon_log_error(
           "device init failed on device %d "
           "for api type %d %s: (%s)",
-          device,
-          api_type,
-          switch_api_type_to_string(api_type),
+          device, api_type, switch_api_type_to_string(api_type),
           switch_error_to_string(status));
       goto cleanup;
     }
@@ -210,15 +203,14 @@ cleanup:
 }
 
 switch_status_t switch_device_api_free(switch_device_t device) {
-  switch_device_context_t *device_ctx = NULL;
+  switch_device_context_t* device_ctx = NULL;
   switch_api_type_t api_type = 0;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("device init failed on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device init failed on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -303,8 +295,7 @@ switch_status_t switch_device_api_free(switch_device_t device) {
       krnlmon_log_error(
           "device free failed on device %d "
           "for api type %s: (%s)",
-          device,
-          switch_api_type_to_string(api_type),
+          device, switch_api_type_to_string(api_type),
           switch_error_to_string(status));
       continue;
     }
@@ -316,8 +307,8 @@ switch_status_t switch_device_api_free(switch_device_t device) {
 }
 
 switch_status_t switch_device_init(switch_device_t device,
-                                   switch_size_t *table_sizes) {
-  switch_device_context_t *device_ctx = NULL;
+                                   switch_size_t* table_sizes) {
+  switch_device_context_t* device_ctx = NULL;
   switch_api_type_t api_type = 0;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
@@ -326,8 +317,7 @@ switch_status_t switch_device_init(switch_device_t device,
     krnlmon_log_error(
         "device init failed on device %d: "
         "device context get failed(%s)",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -336,8 +326,7 @@ switch_status_t switch_device_init(switch_device_t device,
     krnlmon_log_error(
         "device init failed on device %d: "
         "table init failed(%s)",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -345,14 +334,13 @@ switch_status_t switch_device_init(switch_device_t device,
     device_ctx->api_inited[api_type] = false;
   }
 
-  status = switch_api_id_allocator_new(
-      device, SWITCH_IFINDEX_SIZE, FALSE, &device_ctx->ifindex_allocator);
+  status = switch_api_id_allocator_new(device, SWITCH_IFINDEX_SIZE, FALSE,
+                                       &device_ctx->ifindex_allocator);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "device init failed on device %d: "
         "ifindex allocator init failed(%s)",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -361,8 +349,7 @@ switch_status_t switch_device_init(switch_device_t device,
     krnlmon_log_error(
         "device init failed on device %d: "
         "device api init failed(%s)",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -372,19 +359,17 @@ switch_status_t switch_device_init(switch_device_t device,
     krnlmon_log_error(
         "device init failed on device %d: "
         "rmac group create failed(%s)",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
-  status = switch_api_create_nhop_group(
-      device, &device_ctx->device_info.group_handle);
+  status = switch_api_create_nhop_group(device,
+                                        &device_ctx->device_info.group_handle);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "device init failed on device %d: "
         "nhop group create failed(%s)",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -394,7 +379,7 @@ switch_status_t switch_device_init(switch_device_t device,
 }
 
 switch_status_t switch_device_free(switch_device_t device) {
-  switch_device_context_t *device_ctx = NULL;
+  switch_device_context_t* device_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   status = switch_device_context_get(device, &device_ctx);
@@ -402,8 +387,7 @@ switch_status_t switch_device_free(switch_device_t device) {
     krnlmon_log_error(
         "device free failed on device %d: "
         "device context get failed(%s)",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -412,8 +396,7 @@ switch_status_t switch_device_free(switch_device_t device) {
     krnlmon_log_error(
         "device free failed on device %d: "
         "table free failed(%s)",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -422,8 +405,7 @@ switch_status_t switch_device_free(switch_device_t device) {
     krnlmon_log_error(
         "device free failed on device %d: "
         "device api free failed(%s)",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -433,8 +415,7 @@ switch_status_t switch_device_free(switch_device_t device) {
     krnlmon_log_error(
         "device free failed on device %d: "
         "ifindex allocator free failed(%s)",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
   }
 
   krnlmon_log_debug("device free done on device %d", device);
@@ -443,17 +424,16 @@ switch_status_t switch_device_free(switch_device_t device) {
 }
 
 switch_status_t switch_device_table_get(switch_device_t device,
-                                        switch_table_t **table_info) {
-  switch_device_context_t *device_ctx = NULL;
+                                        switch_table_t** table_info) {
+  switch_device_context_t* device_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(table_info != NULL);
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("device context get failed on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device context get failed on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -463,15 +443,14 @@ switch_status_t switch_device_table_get(switch_device_t device,
 
 switch_status_t switch_device_api_context_set(switch_device_t device,
                                               switch_api_type_t api_type,
-                                              void *context) {
-  switch_device_context_t *device_ctx = NULL;
+                                              void* context) {
+  switch_device_context_t* device_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("device context get failed on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device context get failed on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -482,17 +461,16 @@ switch_status_t switch_device_api_context_set(switch_device_t device,
 
 switch_status_t switch_device_api_context_get(switch_device_t device,
                                               switch_api_type_t api_type,
-                                              void **context) {
-  switch_device_context_t *device_ctx = NULL;
+                                              void** context) {
+  switch_device_context_t* device_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(context != NULL);
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("device context get failed on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device context get failed on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -501,7 +479,7 @@ switch_status_t switch_device_api_context_get(switch_device_t device,
 }
 
 switch_status_t switch_api_device_add(switch_device_t device) {
-  switch_device_context_t *device_ctx = NULL;
+  switch_device_context_t* device_ctx = NULL;
   switch_size_t table_sizes[SWITCH_TABLE_MAX];
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   char cpuif_netdev_name[IFNAMSIZ] = "";
@@ -510,18 +488,16 @@ switch_status_t switch_api_device_add(switch_device_t device) {
 
   if (SWITCH_CONFIG_DEVICE_INITED(device)) {
     status = SWITCH_STATUS_ITEM_ALREADY_EXISTS;
-    krnlmon_log_error("device add failed for device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device add failed for device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
   device_ctx = SWITCH_MALLOC(device, sizeof(switch_device_context_t), 0x1);
   if (!device_ctx) {
     status = SWITCH_STATUS_NO_MEMORY;
-    krnlmon_log_error("device add failed on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device add failed on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -534,17 +510,15 @@ switch_status_t switch_api_device_add(switch_device_t device) {
 
   status = switch_config_table_sizes_get(device, table_sizes);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("device add failed for device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device add failed for device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("device add failed on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device add failed on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -554,40 +528,37 @@ switch_status_t switch_api_device_add(switch_device_t device) {
 
   status = switch_device_init(device, table_sizes);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("device add failed for device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device add failed for device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
   return status;
 }
 
-static switch_status_t switch_api_device_remove_internal(switch_device_t device) {
-  switch_device_context_t *device_ctx = NULL;
+static switch_status_t switch_api_device_remove_internal(
+    switch_device_t device) {
+  switch_device_context_t* device_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!SWITCH_CONFIG_DEVICE_INITED(device)) {
     status = SWITCH_STATUS_ITEM_ALREADY_EXISTS;
-    krnlmon_log_error("device add failed for device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device add failed for device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("device context get failed on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device context get failed on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
   status = switch_device_free(device);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("device context get failed on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device context get failed on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -600,15 +571,14 @@ static switch_status_t switch_api_device_remove_internal(switch_device_t device)
 }
 
 switch_status_t switch_api_device_default_rmac_handle_get(
-    switch_device_t device, switch_handle_t *rmac_handle) {
-  switch_device_context_t *device_ctx = NULL;
+    switch_device_t device, switch_handle_t* rmac_handle) {
+  switch_device_context_t* device_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("device context get failed on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("device context get failed on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -617,23 +587,21 @@ switch_status_t switch_api_device_default_rmac_handle_get(
   return status;
 }
 
-switch_status_t switch_api_device_tunnel_dmac_get(
-    switch_device_t device, switch_mac_addr_t *mac_addr) {
+switch_status_t switch_api_device_tunnel_dmac_get(switch_device_t device,
+                                                  switch_mac_addr_t* mac_addr) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
-  switch_device_context_t *device_ctx = NULL;
+  switch_device_context_t* device_ctx = NULL;
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "device tunnel dmac get failed: "
         "device context get failed on device %d: %s",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
-  SWITCH_MEMCPY(mac_addr,
-                &device_ctx->device_info.tunnel_dmac,
+  SWITCH_MEMCPY(mac_addr, &device_ctx->device_info.tunnel_dmac,
                 sizeof(switch_mac_addr_t));
 
   return status;
@@ -641,7 +609,6 @@ switch_status_t switch_api_device_tunnel_dmac_get(
 #ifdef __cplusplus
 }
 #endif
-
 
 switch_status_t switch_api_device_remove(switch_device_t device) {
   return switch_api_device_remove_internal(device);

--- a/switchapi/es2k/switch_fdb.c
+++ b/switchapi/es2k/switch_fdb.c
@@ -16,18 +16,17 @@
  */
 
 #include "switchapi/switch_fdb.h"
-#include "switch_pd_fdb.h"
 
+#include "switch_pd_fdb.h"
+#include "switch_pd_utils.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_rif_int.h"
 #include "switchapi/switch_status.h"
-#include "switch_pd_utils.h"
 
-switch_status_t switch_l2_hash_key_init(void *args,
-                                          switch_uint8_t *key,
-                                          switch_uint32_t *len) {
-  switch_mac_addr_t *l2_key = NULL;
+switch_status_t switch_l2_hash_key_init(void* args, switch_uint8_t* key,
+                                        switch_uint32_t* len) {
+  switch_mac_addr_t* l2_key = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!args || !key || !len) {
@@ -35,7 +34,7 @@ switch_status_t switch_l2_hash_key_init(void *args,
     return status;
   }
 
-  l2_key = (switch_mac_addr_t *)args;
+  l2_key = (switch_mac_addr_t*)args;
   *len = 0;
 
   SWITCH_MEMCPY((key + *len), l2_key, sizeof(switch_mac_addr_t));
@@ -46,49 +45,44 @@ switch_status_t switch_l2_hash_key_init(void *args,
   return status;
 }
 
-switch_int32_t switch_l2_hash_compare(const void *key1, const void *key2) {
-
-
-  switch_l2_info_t *l2_info = (switch_l2_info_t *) key2;
+switch_int32_t switch_l2_hash_compare(const void* key1, const void* key2) {
+  switch_l2_info_t* l2_info = (switch_l2_info_t*)key2;
   switch_mac_addr_t l2_mac;
 
   SWITCH_MEMSET(&l2_mac, 0x0, sizeof(switch_mac_addr_t));
 
   if (l2_info) {
-      SWITCH_MEMCPY(&l2_mac, &l2_info->api_l2_info.dst_mac,
-                    sizeof(switch_mac_addr_t));
+    SWITCH_MEMCPY(&l2_mac, &l2_info->api_l2_info.dst_mac,
+                  sizeof(switch_mac_addr_t));
   }
   return SWITCH_MEMCMP(key1, &l2_mac, SWITCH_L2_HASH_KEY_SIZE);
 }
 
-switch_status_t switch_l2_init(switch_device_t device)
-{
-  switch_l2_context_t *l2_ctx = NULL;
+switch_status_t switch_l2_init(switch_device_t device) {
+  switch_l2_context_t* l2_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   switch_status_t tmp_status = SWITCH_STATUS_SUCCESS;
 
   l2_ctx = SWITCH_MALLOC(device, sizeof(switch_l2_context_t), 0x1);
   if (!l2_ctx) {
-      status = SWITCH_STATUS_NO_MEMORY;
-      krnlmon_log_error(
+    status = SWITCH_STATUS_NO_MEMORY;
+    krnlmon_log_error(
         "switch_l2_init: Failed to allocate memory for l2 context on "
         "device: %d, error: %s\n",
-        device,
-        switch_error_to_string(status));
-      return status;
+        device, switch_error_to_string(status));
+    return status;
   }
-   
+
   SWITCH_MEMSET(l2_ctx, 0x0, sizeof(switch_l2_context_t));
 
-  status = switch_device_api_context_set(
-      device, SWITCH_API_TYPE_L2, (void *)l2_ctx);
+  status =
+      switch_device_api_context_set(device, SWITCH_API_TYPE_L2, (void*)l2_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-      krnlmon_log_error(
+    krnlmon_log_error(
         "switch_l2_init: Failed to set device api context on device %d:"
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
-      return status;
+        device, switch_error_to_string(status));
+    return status;
   }
 
   l2_ctx->l2_hashtable.size = L2_FWD_RX_TABLE_SIZE;
@@ -98,65 +92,61 @@ switch_status_t switch_l2_init(switch_device_t device)
 
   status = SWITCH_HASHTABLE_INIT(&l2_ctx->l2_hashtable);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("switch_l2_init: Failed to initialize hashtable for device %d\n",
-                     device);
+    krnlmon_log_error(
+        "switch_l2_init: Failed to initialize hashtable for device %d\n",
+        device);
     return status;
   }
 
-  status = switch_handle_type_init(
-    device, SWITCH_HANDLE_TYPE_L2_FWD_RX, L2_FWD_RX_TABLE_SIZE);
+  status = switch_handle_type_init(device, SWITCH_HANDLE_TYPE_L2_FWD_RX,
+                                   L2_FWD_RX_TABLE_SIZE);
   if (status != SWITCH_STATUS_SUCCESS) {
-      krnlmon_log_error(
+    krnlmon_log_error(
         "switch_l2_init: Failed to initialize switch handle "
         "for type SWITCH_HANDLE_TYPE_L2_FWD_RX"
         "on device %d:, error: %s\n",
-        device,
-        switch_error_to_string(status));
-      goto cleanup;
+        device, switch_error_to_string(status));
+    goto cleanup;
   }
 
-  status = switch_handle_type_init(
-      device, SWITCH_HANDLE_TYPE_L2_FWD_TX, L2_FWD_TX_TABLE_SIZE);
+  status = switch_handle_type_init(device, SWITCH_HANDLE_TYPE_L2_FWD_TX,
+                                   L2_FWD_TX_TABLE_SIZE);
   if (status != SWITCH_STATUS_SUCCESS) {
-      krnlmon_log_error(
+    krnlmon_log_error(
         "switch_l2_init: Failed to initialize switch handle "
         "for type SWITCH_HANDLE_TYPE_L2_FWD_TX"
         "on device %d:, error: %s\n",
-        device,
-        switch_error_to_string(status));
-      goto cleanup;
+        device, switch_error_to_string(status));
+    goto cleanup;
   }
 
-  return status;   
+  return status;
 
 cleanup:
   tmp_status = switch_l2_free(device);
   SWITCH_ASSERT(tmp_status == SWITCH_STATUS_SUCCESS);
   return status;
- 
 }
 
-switch_status_t switch_l2_free(switch_device_t device)
-{
-  switch_l2_context_t *l2_ctx = NULL;
+switch_status_t switch_l2_free(switch_device_t device) {
+  switch_l2_context_t* l2_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_L2, (void **)&l2_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_L2,
+                                         (void**)&l2_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "switch_l2_free: Failed to get device api context on device %d: "
         "error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
-  
+
   status = SWITCH_HASHTABLE_DONE(&l2_ctx->l2_hashtable);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("switch_l2_free: SWITCH_HASHTABLE_DONE failed for device %d: %s\n",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error(
+        "switch_l2_free: SWITCH_HASHTABLE_DONE failed for device %d: %s\n",
+        device, switch_error_to_string(status));
   }
 
   status = switch_handle_type_free(device, SWITCH_HANDLE_TYPE_L2_FWD_TX);
@@ -165,8 +155,7 @@ switch_status_t switch_l2_free(switch_device_t device)
         "switch_l2_free: Failed to free handle type "
         "SWITCH_HANDLE_TYPE_L2_FWD_TX on device %d: "
         "error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
   }
 
   status = switch_handle_type_free(device, SWITCH_HANDLE_TYPE_L2_FWD_RX);
@@ -175,8 +164,7 @@ switch_status_t switch_l2_free(switch_device_t device)
         "switch_l2_free: Failed to free handle type "
         "SWITCH_HANDLE_TYPE_L2_FWD_RX on device %d: "
         "error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
   }
 
   SWITCH_FREE(device, l2_ctx);
@@ -186,33 +174,34 @@ switch_status_t switch_l2_free(switch_device_t device)
   return status;
 }
 
-switch_status_t switch_api_l2_handle_get(
-    const switch_device_t device,
-    const switch_mac_addr_t *l2_key,
-    switch_handle_t *l2_handle) {
-  switch_l2_context_t *l2_ctx = NULL;
-  switch_l2_info_t *l2_info = NULL;
+switch_status_t switch_api_l2_handle_get(const switch_device_t device,
+                                         const switch_mac_addr_t* l2_key,
+                                         switch_handle_t* l2_handle) {
+  switch_l2_context_t* l2_ctx = NULL;
+  switch_l2_info_t* l2_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!l2_key || !l2_handle) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
-    krnlmon_log_error("Failed to find l2 handle due to invalid parameters \n"
-             "error: %s\n",
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "Failed to find l2 handle due to invalid parameters \n"
+        "error: %s\n",
+        switch_error_to_string(status));
     return status;
   }
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_L2, (void **)&l2_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_L2,
+                                         (void**)&l2_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("switch_api_l2_handle_get: Failed to get device api context \n"
-             "error: %s\n",
-              switch_error_to_string(status));
+    krnlmon_log_error(
+        "switch_api_l2_handle_get: Failed to get device api context \n"
+        "error: %s\n",
+        switch_error_to_string(status));
     return status;
   }
 
-  status = SWITCH_HASHTABLE_SEARCH(
-      &l2_ctx->l2_hashtable, (void *)l2_key, (void **)&l2_info);
+  status = SWITCH_HASHTABLE_SEARCH(&l2_ctx->l2_hashtable, (void*)l2_key,
+                                   (void**)&l2_info);
   if (status == SWITCH_STATUS_SUCCESS) {
     *l2_handle = l2_info->api_l2_info.l2_handle;
   }
@@ -220,24 +209,23 @@ switch_status_t switch_api_l2_handle_get(
   return status;
 }
 
-switch_status_t switch_api_l2_forward_create(
-    const switch_device_t device,
-    switch_api_l2_info_t *api_l2_info,
-    switch_handle_t *l2_handle)
-{
+switch_status_t switch_api_l2_forward_create(const switch_device_t device,
+                                             switch_api_l2_info_t* api_l2_info,
+                                             switch_handle_t* l2_handle) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
   switch_handle_t tnl_handle = SWITCH_API_INVALID_HANDLE;
-  switch_l2_info_t *l2_info = NULL;
-  switch_l2_context_t *l2_ctx = NULL;
+  switch_l2_info_t* l2_info = NULL;
+  switch_l2_context_t* l2_ctx = NULL;
   switch_mac_addr_t l2_mac;
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_L2, (void **)&l2_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_L2,
+                                         (void**)&l2_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("switch_api_l2_forward_create: Failed to find the device api "
-             "context, error: %s \n",
-              switch_error_to_string(status));
+    krnlmon_log_error(
+        "switch_api_l2_forward_create: Failed to find the device api "
+        "context, error: %s \n",
+        switch_error_to_string(status));
     return status;
   }
 
@@ -249,8 +237,7 @@ switch_status_t switch_api_l2_forward_create(
     krnlmon_log_error(
         "switch_api_l2_forward_create: Failed to get api l2 handle on "
         "device %d: ,error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -258,59 +245,55 @@ switch_status_t switch_api_l2_forward_create(
     krnlmon_log_info(
         "switch_api_l2_forward_create: FDB handle 0x%lx on device %d "
         "already exists\n",
-        handle,
-        device);
+        handle, device);
     *l2_handle = handle;
     return status;
   }
 
-  if(api_l2_info->type == SWITCH_L2_FWD_TX) {
-
+  if (api_l2_info->type == SWITCH_L2_FWD_TX) {
     handle = switch_l2_tx_handle_create(device);
     if (handle == SWITCH_API_INVALID_HANDLE) {
-        status = SWITCH_STATUS_NO_MEMORY;
-        krnlmon_log_error("switch_api_l2_forward_create: Failed to create l2 tx "
-                 "handle on device %d: ,error: %s\n",
-                 device, switch_error_to_string(status));
-        return status;
+      status = SWITCH_STATUS_NO_MEMORY;
+      krnlmon_log_error(
+          "switch_api_l2_forward_create: Failed to create l2 tx "
+          "handle on device %d: ,error: %s\n",
+          device, switch_error_to_string(status));
+      return status;
     }
 
     status = switch_l2_tx_get(device, handle, &l2_info);
     if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error(
-            "switch_api_l2_forward_create: Failed to get l2 tx info for "
-            "handle 0x%lx on device %d: ,error: %s\n",
-            handle,
-            device,
-            switch_error_to_string(status));
-        return status;
+      krnlmon_log_error(
+          "switch_api_l2_forward_create: Failed to get l2 tx info for "
+          "handle 0x%lx on device %d: ,error: %s\n",
+          handle, device, switch_error_to_string(status));
+      return status;
     }
 
-    switch_api_tunnel_info_t *api_tunnel_info = NULL;
+    switch_api_tunnel_info_t* api_tunnel_info = NULL;
 
     // When the learn is from TUNNEL port we have corresponding RIF handle
     if (api_l2_info->learn_from == SWITCH_L2_FWD_LEARN_TUNNEL_INTERFACE) {
-        switch_tunnel_info_t *tunnel_info = NULL;
-        tnl_handle = api_l2_info->rif_handle;
-        status = switch_tunnel_get(device, tnl_handle, &tunnel_info);
-        CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
+      switch_tunnel_info_t* tunnel_info = NULL;
+      tnl_handle = api_l2_info->rif_handle;
+      status = switch_tunnel_get(device, tnl_handle, &tunnel_info);
+      CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
 
-        api_tunnel_info = &tunnel_info->api_tunnel_info;
+      api_tunnel_info = &tunnel_info->api_tunnel_info;
     }
 
     // When the learn is from physical interafce and we have corresponding
     // RIF handle. Second check is to avoid getting physical port id if it
     // is learnt over LAG interface.
-    if (api_l2_info->learn_from == SWITCH_L2_FWD_LEARN_PHYSICAL_INTERFACE
-        && SWITCH_RIF_HANDLE(api_l2_info->rif_handle)) {
-        switch_rif_info_t *rif_info = NULL;
+    if (api_l2_info->learn_from == SWITCH_L2_FWD_LEARN_PHYSICAL_INTERFACE &&
+        SWITCH_RIF_HANDLE(api_l2_info->rif_handle)) {
+      switch_rif_info_t* rif_info = NULL;
 
-        status = switch_rif_get(device, api_l2_info->rif_handle, &rif_info);
-        CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
-        status = switch_pd_get_physical_port_id(device,
-                                                rif_info->api_rif_info.port_id,
-                                                &api_l2_info->port_id);
-        CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
+      status = switch_rif_get(device, api_l2_info->rif_handle, &rif_info);
+      CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
+      status = switch_pd_get_physical_port_id(
+          device, rif_info->api_rif_info.port_id, &api_l2_info->port_id);
+      CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
     }
 
     // When L2 MAC address is learnt, we will not be aware if that MAC is
@@ -320,84 +303,77 @@ switch_status_t switch_api_l2_forward_create(
     // if the MAC is learnt for IPv4 neighbor or Ipv6 neighbor by a lookup
     // and then program respective table
     status = switch_pd_l2_tx_forward_table_entry(device, api_l2_info,
-                                                  api_tunnel_info,  true);
+                                                 api_tunnel_info, true);
     if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error(
-            "switch_api_l2_forward_create: Failed to create platform dependent"
-            " l2 tx forward table entry on device: %d,error: (%s)\n",
-            device,
-            switch_error_to_string(status));
-        return status;
+      krnlmon_log_error(
+          "switch_api_l2_forward_create: Failed to create platform dependent"
+          " l2 tx forward table entry on device: %d,error: (%s)\n",
+          device, switch_error_to_string(status));
+      return status;
     }
 
     status = switch_pd_l2_tx_ipv6_forward_table_entry(device, api_l2_info,
-                                                      api_tunnel_info,  true);
+                                                      api_tunnel_info, true);
     if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error(
-            "switch_api_l2_ipv6_forward_create: Failed to create platform dependent"
-            " l2 tx forward table entry on device: %d,error: (%s)\n",
-            device,
-            switch_error_to_string(status));
-        return status;
+      krnlmon_log_error(
+          "switch_api_l2_ipv6_forward_create: Failed to create platform "
+          "dependent"
+          " l2 tx forward table entry on device: %d,error: (%s)\n",
+          device, switch_error_to_string(status));
+      return status;
     }
 
     // These FDB entries are learnt from OVS, and same FDB entry rule
     // should be programmed for 2_fwd_rx_with_tunnel_table too.
     if (api_l2_info->learn_from == SWITCH_L2_FWD_LEARN_VLAN_INTERFACE) {
       status = switch_pd_sem_bypass_table_entry(device, api_l2_info,
-                                                api_tunnel_info,  true);
+                                                api_tunnel_info, true);
       if (status != SWITCH_STATUS_SUCCESS) {
-          krnlmon_log_error(
-              "switch_api_l2_forward_create: Failed to create platform "
-              "dependent sem bypass table entry on device %d: ,error :(%s)\n",
-              device,
-              switch_error_to_string(status));
-          return status;
+        krnlmon_log_error(
+            "switch_api_l2_forward_create: Failed to create platform "
+            "dependent sem bypass table entry on device %d: ,error :(%s)\n",
+            device, switch_error_to_string(status));
+        return status;
       }
 
-      status = switch_pd_l2_rx_forward_with_tunnel_table_entry(device,
-                                                               api_l2_info,
-                                                               true);
+      status = switch_pd_l2_rx_forward_with_tunnel_table_entry(
+          device, api_l2_info, true);
       if (status != SWITCH_STATUS_SUCCESS) {
-          krnlmon_log_error(
-              "switch_api_l2_forward_create: Failed to create platform "
-              "dependent l2 rx forward tunnel table entry on device %d: "
-              ",error :%s\n",
-              device,
-              switch_error_to_string(status));
-          return status;
+        krnlmon_log_error(
+            "switch_api_l2_forward_create: Failed to create platform "
+            "dependent l2 rx forward tunnel table entry on device %d: "
+            ",error :%s\n",
+            device, switch_error_to_string(status));
+        return status;
       }
     }
-  } else if(api_l2_info->type == SWITCH_L2_FWD_RX) {
-
+  } else if (api_l2_info->type == SWITCH_L2_FWD_RX) {
     handle = switch_l2_rx_handle_create(device);
     if (handle == SWITCH_API_INVALID_HANDLE) {
-        status = SWITCH_STATUS_NO_MEMORY;
-        krnlmon_log_error("switch_api_l2_forward_create: Failed to create l2 rx "
-                 "handle on device %d: ,error: %s\n",
-                 device, switch_error_to_string(status));
-        return status;
+      status = SWITCH_STATUS_NO_MEMORY;
+      krnlmon_log_error(
+          "switch_api_l2_forward_create: Failed to create l2 rx "
+          "handle on device %d: ,error: %s\n",
+          device, switch_error_to_string(status));
+      return status;
     }
 
     status = switch_l2_rx_get(device, handle, &l2_info);
     if (status != SWITCH_STATUS_SUCCESS) {
-         krnlmon_log_error(
-            "switch_api_l2_forward_create: Failed to get l2 rx info "
-            "for handle 0x%lx on device %d: "
-            ",error: %s\n",
-            handle,
-            device,
-            switch_error_to_string(status));
-        return status;
+      krnlmon_log_error(
+          "switch_api_l2_forward_create: Failed to get l2 rx info "
+          "for handle 0x%lx on device %d: "
+          ",error: %s\n",
+          handle, device, switch_error_to_string(status));
+      return status;
     }
 
     status = switch_pd_l2_rx_forward_table_entry(device, api_l2_info, true);
     if (status != SWITCH_STATUS_SUCCESS) {
       krnlmon_log_error(
-              "switch_api_l2_forward_create: Failed to create platform "
-              "dependent l2 rx forward table entry on device %d: ,error: %s\n",
-              device,
-              switch_error_to_string(status));
+          "switch_api_l2_forward_create: Failed to create platform "
+          "dependent l2 rx forward table entry on device %d: ,error: %s\n",
+          device, switch_error_to_string(status));
       return status;
     }
   } else {
@@ -406,36 +382,33 @@ switch_status_t switch_api_l2_forward_create(
   }
 
   api_l2_info->l2_handle = handle;
-  SWITCH_MEMCPY(&l2_info->api_l2_info,
-              api_l2_info,
-              sizeof(switch_api_l2_info_t));
+  SWITCH_MEMCPY(&l2_info->api_l2_info, api_l2_info,
+                sizeof(switch_api_l2_info_t));
 
-  status = SWITCH_HASHTABLE_INSERT(&l2_ctx->l2_hashtable,
-                                   &(l2_info->node),
-                                   (void *)&l2_mac,
-                                   (void *)l2_info);
+  status = SWITCH_HASHTABLE_INSERT(&l2_ctx->l2_hashtable, &(l2_info->node),
+                                   (void*)&l2_mac, (void*)l2_info);
   SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
 
   *l2_handle = handle;
 
-  return SWITCH_STATUS_SUCCESS; 
+  return SWITCH_STATUS_SUCCESS;
 }
 
-switch_status_t switch_api_l2_forward_delete (
-    const switch_device_t device,
-    const switch_api_l2_info_t *api_l2_info) {
+switch_status_t switch_api_l2_forward_delete(
+    const switch_device_t device, const switch_api_l2_info_t* api_l2_info) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   switch_handle_t l2_handle;
-  switch_l2_context_t *l2_ctx = NULL;
+  switch_l2_context_t* l2_ctx = NULL;
   switch_mac_addr_t l2_mac;
-  switch_l2_info_t *l2_info = NULL;
+  switch_l2_info_t* l2_info = NULL;
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_L2, (void **)&l2_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_L2,
+                                         (void**)&l2_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("switch_api_l2_forward_delete: Failed to get device api "
-             "context, error: %s \n",
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "switch_api_l2_forward_delete: Failed to get device api "
+        "context, error: %s \n",
+        switch_error_to_string(status));
     return status;
   }
 
@@ -445,88 +418,78 @@ switch_status_t switch_api_l2_forward_delete (
     krnlmon_log_error(
         "switch_api_l2_forward_delete: Failed to get api l2 "
         "handle on device: %d, error:%s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
-  status = SWITCH_HASHTABLE_DELETE(&l2_ctx->l2_hashtable, (void *)(&l2_mac),
-                                   (void **)&l2_info);
+  status = SWITCH_HASHTABLE_DELETE(&l2_ctx->l2_hashtable, (void*)(&l2_mac),
+                                   (void**)&l2_info);
   SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
 
-  if(api_l2_info->type == SWITCH_L2_FWD_TX)
-  {
-    status = switch_pd_l2_tx_forward_table_entry (device, api_l2_info, NULL,
-                                                  false);
+  if (api_l2_info->type == SWITCH_L2_FWD_TX) {
+    status =
+        switch_pd_l2_tx_forward_table_entry(device, api_l2_info, NULL, false);
     if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error(
-              "switch_api_l2_forward_delete: Failed to delete platform "
-              "dependent l2 tx forward table entry on device %d: ,error :%s\n",
-              device,
-              switch_error_to_string(status));
-        return status;
+      krnlmon_log_error(
+          "switch_api_l2_forward_delete: Failed to delete platform "
+          "dependent l2 tx forward table entry on device %d: ,error :%s\n",
+          device, switch_error_to_string(status));
+      return status;
     }
 
-    status = switch_pd_l2_tx_ipv6_forward_table_entry(device, api_l2_info,
-                                                      NULL,  false);
+    status = switch_pd_l2_tx_ipv6_forward_table_entry(device, api_l2_info, NULL,
+                                                      false);
     if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error(
-            "switch_api_l2_ipv6_forward_create: Failed to delete platform "
-	    "dependent l2 tx forward table entry on device: %d,error: (%s)",
-            device,
-            switch_error_to_string(status));
-        return status;
+      krnlmon_log_error(
+          "switch_api_l2_ipv6_forward_create: Failed to delete platform "
+          "dependent l2 tx forward table entry on device: %d,error: (%s)",
+          device, switch_error_to_string(status));
+      return status;
     }
 
     /* These FDB entries are learnt from OVS, and same FDB entry rule
      * should be deleted from 2_fwd_rx_with_tunnel_table too.
      */
     if (l2_info->api_l2_info.learn_from == SWITCH_L2_FWD_LEARN_VLAN_INTERFACE) {
-      status = switch_pd_sem_bypass_table_entry (device, api_l2_info, NULL,
-                                                    false);
+      status =
+          switch_pd_sem_bypass_table_entry(device, api_l2_info, NULL, false);
       if (status != SWITCH_STATUS_SUCCESS) {
-          krnlmon_log_error(
-                "switch_api_l2_forward_delete: Failed to delete platform "
-                "dependent sem bypass table entry on device %d: ,error :%s\n",
-                device,
-                switch_error_to_string(status));
-          return status;
+        krnlmon_log_error(
+            "switch_api_l2_forward_delete: Failed to delete platform "
+            "dependent sem bypass table entry on device %d: ,error :%s\n",
+            device, switch_error_to_string(status));
+        return status;
       }
 
-      status = switch_pd_l2_rx_forward_with_tunnel_table_entry(device,
-                                                               api_l2_info,
-                                                               false);
+      status = switch_pd_l2_rx_forward_with_tunnel_table_entry(
+          device, api_l2_info, false);
       if (status != SWITCH_STATUS_SUCCESS) {
-          krnlmon_log_error(
-              "switch_api_l2_forward_delete: Failed to delete platform "
-              "dependent l2 rx forward "
-              "tunnel table entry on device %d: ,error :%s\n",
-              device,
-              switch_error_to_string(status));
-          return status;
+        krnlmon_log_error(
+            "switch_api_l2_forward_delete: Failed to delete platform "
+            "dependent l2 rx forward "
+            "tunnel table entry on device %d: ,error :%s\n",
+            device, switch_error_to_string(status));
+        return status;
       }
     }
 
     status = switch_l2_tx_handle_delete(device, l2_handle, 1);
     SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
-  }
-  else if(api_l2_info->type == SWITCH_L2_FWD_RX)
-  {
-    status = switch_pd_l2_rx_forward_table_entry (device, api_l2_info, false);
+  } else if (api_l2_info->type == SWITCH_L2_FWD_RX) {
+    status = switch_pd_l2_rx_forward_table_entry(device, api_l2_info, false);
     if (status != SWITCH_STATUS_SUCCESS) {
       krnlmon_log_error(
-              "switch_api_l2_forward_delete: Failed to delete platform "
-              "dependent l2 rx forward table entry on device %d: ,error :%s\n",
-              device,
-              switch_error_to_string(status));
+          "switch_api_l2_forward_delete: Failed to delete platform "
+          "dependent l2 rx forward table entry on device %d: ,error :%s\n",
+          device, switch_error_to_string(status));
       return status;
     }
 
     status = switch_l2_rx_handle_delete(device, l2_handle, 1);
     SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
   } else {
-      krnlmon_log_error("Invalid L2 FWD type");
-      return SWITCH_STATUS_NOT_SUPPORTED;
+    krnlmon_log_error("Invalid L2 FWD type");
+    return SWITCH_STATUS_NOT_SUPPORTED;
   }
 
   return status;

--- a/switchapi/es2k/switch_fdb.c
+++ b/switchapi/es2k/switch_fdb.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/es2k/switch_handle.c
+++ b/switchapi/es2k/switch_handle.c
@@ -46,39 +46,42 @@ switch_status_t switch_handle_type_allocator_init(switch_device_t device,
                                                   switch_uint32_t num_handles,
                                                   bool grow_on_demand,
                                                   bool zero_based) {
-  switch_device_context_t *device_ctx = NULL;
-  switch_handle_info_t *handle_info = NULL;
-  switch_id_allocator_t *allocator = NULL;
+  switch_device_context_t* device_ctx = NULL;
+  switch_handle_info_t* handle_info = NULL;
+  switch_id_allocator_t* allocator = NULL;
   switch_size_t size = 0;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (device > SWITCH_MAX_DEVICE) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("handle allocator init failed, error: %s\n",
-                     switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle allocator init: Failed to get device context, error: %s\n",
-                     switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle allocator init: Failed to get device context, error: %s\n",
+        switch_error_to_string(status));
     return status;
   }
 
   if (type >= SWITCH_HANDLE_TYPE_MAX) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
-    krnlmon_log_error("handle allocator init failedto get device context, error: %s\n",
-                     switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle allocator init failedto get device context, error: %s\n",
+        switch_error_to_string(status));
     return status;
   }
 
   handle_info = SWITCH_MALLOC(device, sizeof(switch_handle_info_t), 1);
   if (!handle_info) {
     status = SWITCH_STATUS_NO_MEMORY;
-    krnlmon_log_error("handle allocator init: Failed to allocate memory for "
-             "handle %s, error: %s\n", switch_handle_type_to_string(type),
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle allocator init: Failed to allocate memory for "
+        "handle %s, error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     return status;
   }
 
@@ -89,9 +92,10 @@ switch_status_t switch_handle_type_allocator_init(switch_device_t device,
   if (status != SWITCH_STATUS_SUCCESS) {
     SWITCH_FREE(device, handle_info);
     status = SWITCH_STATUS_FAILURE;
-    krnlmon_log_error("handle allocator init: Faile to allocate new api id "
-             "for handle %s, error: %s\n", switch_handle_type_to_string(type),
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle allocator init: Faile to allocate new api id "
+        "for handle %s, error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     return status;
   }
 
@@ -104,13 +108,13 @@ switch_status_t switch_handle_type_allocator_init(switch_device_t device,
   handle_info->zero_based = zero_based;
   handle_info->new_allocator = bf_id_allocator_new(size, zero_based);
 
-  status = SWITCH_ARRAY_INSERT(
-      &device_ctx->handle_info_array, type, (void *)handle_info);
+  status = SWITCH_ARRAY_INSERT(&device_ctx->handle_info_array, type,
+                               (void*)handle_info);
 
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle allocator init: Failed to insert handle %s, error: %s\n",
-                     switch_handle_type_to_string(type),
-                     switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle allocator init: Failed to insert handle %s, error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     switch_api_id_allocator_destroy(device, handle_info->allocator);
     bf_id_allocator_destroy(handle_info->new_allocator);
     SWITCH_FREE(device, handle_info);
@@ -122,38 +126,39 @@ switch_status_t switch_handle_type_allocator_init(switch_device_t device,
 
 switch_status_t switch_handle_type_free(switch_device_t device,
                                         switch_handle_type_t type) {
-  switch_device_context_t *device_ctx = NULL;
-  switch_handle_info_t *handle_info = NULL;
+  switch_device_context_t* device_ctx = NULL;
+  switch_handle_info_t* handle_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (device > SWITCH_MAX_DEVICE) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("handle free failed: %s\n",
-                     switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle free failed: Failed to get device context, error: %s\n",
-                     switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle free failed: Failed to get device context, error: %s\n",
+        switch_error_to_string(status));
     return status;
   }
 
   if (type >= SWITCH_HANDLE_TYPE_MAX) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("handle free failed, error: %s\n",
-                     switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
-  status = SWITCH_ARRAY_GET(
-      &device_ctx->handle_info_array, type, (void *)&handle_info);
+  status = SWITCH_ARRAY_GET(&device_ctx->handle_info_array, type,
+                            (void*)&handle_info);
 
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error("handle %s free failed: %s\n",
-                     switch_handle_type_to_string(type),
-                     switch_error_to_string(status));
+                      switch_handle_type_to_string(type),
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -161,9 +166,10 @@ switch_status_t switch_handle_type_free(switch_device_t device,
   bf_id_allocator_destroy(handle_info->new_allocator);
   status = SWITCH_ARRAY_DELETE(&device_ctx->handle_info_array, type);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle free: Failed to destroy allocator for "
-             "handle %s, error: %s\n", switch_handle_type_to_string(type),
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle free: Failed to destroy allocator for "
+        "handle %s, error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     return status;
   }
   SWITCH_FREE(device, handle_info);
@@ -171,10 +177,10 @@ switch_status_t switch_handle_type_free(switch_device_t device,
 }
 
 static switch_handle_t __switch_handle_create(switch_device_t device,
-                                       switch_handle_type_t type,
-                                       unsigned int count) {
-  switch_device_context_t *device_ctx = NULL;
-  switch_handle_info_t *handle_info = NULL;
+                                              switch_handle_type_t type,
+                                              unsigned int count) {
+  switch_device_context_t* device_ctx = NULL;
+  switch_handle_info_t* handle_info = NULL;
   switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
   switch_uint32_t id = 0;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
@@ -182,31 +188,32 @@ static switch_handle_t __switch_handle_create(switch_device_t device,
   if (device > SWITCH_MAX_DEVICE) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("handle_create failed, error: %s\n",
-                     switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle_create: Failed to get device context, error: %s\n",
-                     switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle_create: Failed to get device context, error: %s\n",
+        switch_error_to_string(status));
     return status;
   }
 
   if (type >= SWITCH_HANDLE_TYPE_MAX) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("handle_create failed, error: %s\n",
-                     switch_error_to_string(status));
+                      switch_error_to_string(status));
     return SWITCH_API_INVALID_HANDLE;
   }
 
-  status = SWITCH_ARRAY_GET(
-      &device_ctx->handle_info_array, type, (void **)&handle_info);
+  status = SWITCH_ARRAY_GET(&device_ctx->handle_info_array, type,
+                            (void**)&handle_info);
 
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error("handle_create: Failed to get handle %s, error: %s\n",
-                     switch_handle_type_to_string(type),
-                     switch_error_to_string(status));
+                      switch_handle_type_to_string(type),
+                      switch_error_to_string(status));
     return SWITCH_API_INVALID_HANDLE;
   }
 
@@ -219,10 +226,10 @@ static switch_handle_t __switch_handle_create(switch_device_t device,
       status = switch_api_id_allocator_allocate_contiguous(
           device, handle_info->allocator, count, &id);
     if (status != SWITCH_STATUS_SUCCESS) {
-      krnlmon_log_error("handle_create: Failed to allocate contiguous allocator"
-               " for handle %s, error: %s\n",
-               switch_handle_type_to_string(type),
-               switch_error_to_string(status));
+      krnlmon_log_error(
+          "handle_create: Failed to allocate contiguous allocator"
+          " for handle %s, error: %s\n",
+          switch_handle_type_to_string(type), switch_error_to_string(status));
       return SWITCH_API_INVALID_HANDLE;
     }
     handle_info->num_in_use++;
@@ -233,10 +240,10 @@ static switch_handle_t __switch_handle_create(switch_device_t device,
 }
 
 static switch_status_t _switch_handle_delete_contiguous(switch_device_t device,
-                                                 switch_handle_t handle,
-                                                 uint32_t count) {
-  switch_device_context_t *device_ctx = NULL;
-  switch_handle_info_t *handle_info = NULL;
+                                                        switch_handle_t handle,
+                                                        uint32_t count) {
+  switch_device_context_t* device_ctx = NULL;
+  switch_handle_info_t* handle_info = NULL;
   switch_uint32_t id = 0;
   switch_handle_type_t type = SWITCH_HANDLE_TYPE_NONE;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
@@ -244,25 +251,28 @@ static switch_status_t _switch_handle_delete_contiguous(switch_device_t device,
   if (device > SWITCH_MAX_DEVICE) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("handle delete contiguous failed, error: %s\n",
-                     switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle delete contiguous: Failed to get device "
-             "context, error: %s\n", switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle delete contiguous: Failed to get device "
+        "context, error: %s\n",
+        switch_error_to_string(status));
     return status;
   }
 
   type = switch_handle_type_get(handle);
-  status = SWITCH_ARRAY_GET(
-      &device_ctx->handle_info_array, type, (void *)&handle_info);
+  status = SWITCH_ARRAY_GET(&device_ctx->handle_info_array, type,
+                            (void*)&handle_info);
 
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle delete contiguous: Failed to get handle info for type %s, "
-             "error: %s\n", switch_handle_type_to_string(type),
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle delete contiguous: Failed to get handle info for type %s, "
+        "error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     return status;
   }
 
@@ -274,25 +284,26 @@ static switch_status_t _switch_handle_delete_contiguous(switch_device_t device,
 }
 
 static switch_status_t _switch_handle_delete(switch_device_t device,
-                                      switch_handle_t handle) {
+                                             switch_handle_t handle) {
   return _switch_handle_delete_contiguous(device, handle, 1);
 }
 
 static switch_handle_t _switch_handle_create(switch_device_t device,
-                                      switch_handle_type_t type,
-                                      switch_uint32_t size,
-                                      unsigned int count) {
-  switch_device_context_t *device_ctx = NULL;
-  void *i_info = NULL;
-  void *handle_array = NULL;
+                                             switch_handle_type_t type,
+                                             switch_uint32_t size,
+                                             unsigned int count) {
+  switch_device_context_t* device_ctx = NULL;
+  void* i_info = NULL;
+  void* handle_array = NULL;
   switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle create: Failed to get device context for type %s, "
-             "error: %s\n", switch_handle_type_to_string(type),
-              switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle create: Failed to get device context for type %s, "
+        "error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     return SWITCH_API_INVALID_HANDLE;
   }
 
@@ -302,29 +313,30 @@ static switch_handle_t _switch_handle_create(switch_device_t device,
   if (handle == SWITCH_API_INVALID_HANDLE) {
     status = SWITCH_STATUS_FAILURE;
     krnlmon_log_error("handle create: Invalid handle for type %s, error: %s\n",
-              switch_handle_type_to_string(type),
-              switch_error_to_string(status));
+                      switch_handle_type_to_string(type),
+                      switch_error_to_string(status));
     return SWITCH_API_INVALID_HANDLE;
   }
 
   i_info = SWITCH_MALLOC(device, size, 1);
   if (!i_info) {
     status = SWITCH_STATUS_NO_MEMORY;
-    krnlmon_log_error("handle create: Failed to allocate memory for type %s, "
-             "error: %s\n", switch_handle_type_to_string(type),
-              switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle create: Failed to allocate memory for type %s, "
+        "error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     _switch_handle_delete(device, handle);
     return SWITCH_API_INVALID_HANDLE;
   }
 
   SWITCH_MEMSET(i_info, 0, size);
 
-  status = SWITCH_ARRAY_INSERT(handle_array, handle, (void *)i_info);
+  status = SWITCH_ARRAY_INSERT(handle_array, handle, (void*)i_info);
 
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle create: Failed to insert handle for type %s, error: %s\n",
-              switch_handle_type_to_string(type),
-              switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle create: Failed to insert handle for type %s, error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     SWITCH_FREE(device, i_info);
     _switch_handle_delete(device, handle);
     return SWITCH_API_INVALID_HANDLE;
@@ -347,32 +359,31 @@ switch_handle_t switch_handle_create_contiguous(switch_device_t device,
 
 switch_status_t switch_handle_get(switch_device_t device,
                                   switch_handle_type_t type,
-                                  switch_handle_t handle,
-                                  void **i_info) {
-  switch_device_context_t *device_ctx = NULL;
-  void *handle_array = NULL;
+                                  switch_handle_t handle, void** i_info) {
+  switch_device_context_t* device_ctx = NULL;
+  void* handle_array = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!SWITCH_HANDLE_VALID(handle, type)) {
-    krnlmon_log_error("handle get failed due to invalid handle %lx\n",
-              handle);
+    krnlmon_log_error("handle get failed due to invalid handle %lx\n", handle);
     return SWITCH_STATUS_INVALID_HANDLE;
   }
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle get: Failed to get device context for handle "
-             "type %s, error: %s\n", switch_handle_type_to_string(type),
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle get: Failed to get device context for handle "
+        "type %s, error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     return status;
   }
   handle_array = &device_ctx->handle_array[type];
 
-  status = SWITCH_ARRAY_GET(handle_array, handle, (void **)i_info);
+  status = SWITCH_ARRAY_GET(handle_array, handle, (void**)i_info);
 
   type = switch_handle_type_get(handle);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error("handle get: failed to get handle type, error: %s\n",
-              switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
   return SWITCH_STATUS_SUCCESS;
@@ -382,43 +393,46 @@ switch_status_t switch_handle_delete_contiguous(switch_device_t device,
                                                 switch_handle_type_t type,
                                                 switch_handle_t handle,
                                                 uint32_t count) {
-  switch_device_context_t *device_ctx = NULL;
-  void *i_info = NULL;
-  void *handle_array = NULL;
+  switch_device_context_t* device_ctx = NULL;
+  void* i_info = NULL;
+  void* handle_array = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle delete contiguous failed for type %s, error: %s\n",
-              switch_handle_type_to_string(type),
-              switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle delete contiguous failed for type %s, error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     return status;
   }
   handle_array = &device_ctx->handle_array[type];
 
-  status = SWITCH_ARRAY_GET(handle_array, handle, (void **)&i_info);
+  status = SWITCH_ARRAY_GET(handle_array, handle, (void**)&i_info);
 
   type = switch_handle_type_get(handle);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle delete contiguous: failed to get handle "
-             "type %s, error: %s\n", switch_handle_type_to_string(type),
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle delete contiguous: failed to get handle "
+        "type %s, error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     return status;
   }
 
   status = SWITCH_ARRAY_DELETE(handle_array, handle);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle delete contiguous: failed to delete array "
-             "for handle %s, error: %s\n", switch_handle_type_to_string(type),
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle delete contiguous: failed to delete array "
+        "for handle %s, error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     return status;
   }
 
   status = _switch_handle_delete_contiguous(device, handle, count);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle delete contiguous: failed to delete "
-             "handle %s, error: %s\n", switch_handle_type_to_string(type),
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle delete contiguous: failed to delete "
+        "handle %s, error: %s\n",
+        switch_handle_type_to_string(type), switch_error_to_string(status));
     return status;
   }
   SWITCH_FREE(device, i_info);
@@ -433,9 +447,9 @@ switch_status_t switch_handle_delete(switch_device_t device,
 
 switch_status_t switch_api_handle_count_get(switch_device_t device,
                                             switch_handle_type_t type,
-                                            switch_size_t *num_entries) {
-  switch_device_context_t *device_ctx = NULL;
-  switch_handle_info_t *handle_info = NULL;
+                                            switch_size_t* num_entries) {
+  switch_device_context_t* device_ctx = NULL;
+  switch_handle_info_t* handle_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(type < SWITCH_HANDLE_TYPE_MAX);
@@ -445,16 +459,17 @@ switch_status_t switch_api_handle_count_get(switch_device_t device,
   status = switch_device_context_get(device, &device_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error("handle count get failed, error: %s\n",
-              switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
-  status = SWITCH_ARRAY_GET(
-      &device_ctx->handle_info_array, type, (void *)&handle_info);
+  status = SWITCH_ARRAY_GET(&device_ctx->handle_info_array, type,
+                            (void*)&handle_info);
 
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("handle count get: Failed to get handle info, error: %s\n",
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "handle count get: Failed to get handle info, error: %s\n",
+        switch_error_to_string(status));
     return status;
   }
 

--- a/switchapi/es2k/switch_handle.c
+++ b/switchapi/es2k/switch_handle.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/es2k/switch_id.c
+++ b/switchapi/es2k/switch_id.c
@@ -26,17 +26,17 @@ extern "C" {
 #define __FILE_ID__ SWITCH_ID
 
 static switch_status_t switch_api_id_allocator_new_internal(
-    switch_device_t device,
-    switch_uint32_t initial_size,
-    bool zero_based,
-    switch_id_allocator_t **allocator) {
+    switch_device_t device, switch_uint32_t initial_size, bool zero_based,
+    switch_id_allocator_t** allocator) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   *allocator = SWITCH_MALLOC(device, sizeof(switch_id_allocator_t), 1);
   if (*allocator == NULL) {
     status = SWITCH_STATUS_NO_MEMORY;
-    krnlmon_log_error("id alloc: Failed to allocate memory for switch_id_allocator_t, "
-             "error: %s\n", switch_error_to_string(status));
+    krnlmon_log_error(
+        "id alloc: Failed to allocate memory for switch_id_allocator_t, "
+        "error: %s\n",
+        switch_error_to_string(status));
     return status;
   }
 
@@ -45,8 +45,10 @@ static switch_status_t switch_api_id_allocator_new_internal(
   if ((*allocator)->data == NULL) {
     status = SWITCH_STATUS_NO_MEMORY;
     SWITCH_FREE(device, *allocator);
-    krnlmon_log_error("id alloc: Failed to allocate memory for allocator data, "
-             "error: %s\n", switch_error_to_string(status));
+    krnlmon_log_error(
+        "id alloc: Failed to allocate memory for allocator data, "
+        "error: %s\n",
+        switch_error_to_string(status));
     return status;
   }
 
@@ -57,12 +59,13 @@ static switch_status_t switch_api_id_allocator_new_internal(
 }
 
 static switch_status_t switch_api_id_allocator_destroy_internal(
-    switch_device_t device, switch_id_allocator_t *allocator) {
+    switch_device_t device, switch_id_allocator_t* allocator) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!allocator) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
-    krnlmon_log_error("id destroy failed, error: %s", switch_error_to_string(status));
+    krnlmon_log_error("id destroy failed, error: %s",
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -89,10 +92,8 @@ static inline switch_int32_t switch_api_id_fit_width(switch_uint32_t val,
 }
 
 static switch_status_t switch_api_id_allocator_allocate_contiguous_internal(
-    switch_device_t device,
-    switch_id_allocator_t *allocator,
-    switch_uint8_t count,
-    switch_uint32_t *id) {
+    switch_device_t device, switch_id_allocator_t* allocator,
+    switch_uint8_t count, switch_uint32_t* id) {
   switch_uint32_t n_words = 0;
   switch_uint32_t i = 0;
   switch_int32_t pos = -1;
@@ -101,7 +102,7 @@ static switch_status_t switch_api_id_allocator_allocate_contiguous_internal(
   if (!allocator) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("id alloc contiguous failed, error: %s",
-             switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -118,11 +119,11 @@ static switch_status_t switch_api_id_allocator_allocate_contiguous_internal(
   }
 
   n_words = allocator->n_words;
-  allocator->data = SWITCH_REALLOC(
-      device, allocator->data, n_words * 2 * sizeof(switch_uint32_t));
+  allocator->data = SWITCH_REALLOC(device, allocator->data,
+                                   n_words * 2 * sizeof(switch_uint32_t));
 
-  SWITCH_MEMSET(
-      &allocator->data[n_words], 0, n_words * sizeof(switch_uint32_t));
+  SWITCH_MEMSET(&allocator->data[n_words], 0,
+                n_words * sizeof(switch_uint32_t));
   allocator->n_words = n_words * 2;
   allocator->data[n_words] |= (0xFFFFFFFF << (32 - count)) & 0xFFFFFFFF;
   *id = 32 * n_words + (allocator->zero_based ? 0 : 1);
@@ -130,13 +131,13 @@ static switch_status_t switch_api_id_allocator_allocate_contiguous_internal(
 }
 
 static switch_status_t switch_api_id_allocator_allocate_internal(
-    switch_device_t device, switch_id_allocator_t *allocator, switch_id_t *id) {
+    switch_device_t device, switch_id_allocator_t* allocator, switch_id_t* id) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!allocator) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("id alloc internal failed, error: %s",
-             switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -144,12 +145,13 @@ static switch_status_t switch_api_id_allocator_allocate_internal(
 }
 
 static switch_status_t switch_api_id_allocator_release_internal(
-    switch_device_t device, switch_id_allocator_t *allocator, switch_id_t id) {
+    switch_device_t device, switch_id_allocator_t* allocator, switch_id_t id) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!allocator) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
-    krnlmon_log_error("id release failed, error: %s", switch_error_to_string(status));
+    krnlmon_log_error("id release failed, error: %s",
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -161,33 +163,31 @@ static switch_status_t switch_api_id_allocator_release_internal(
 }
 
 switch_status_t switch_api_id_allocator_destroy(
-    switch_device_t device, switch_id_allocator_t *allocator) {
+    switch_device_t device, switch_id_allocator_t* allocator) {
   return switch_api_id_allocator_destroy_internal(device, allocator);
 }
 
 switch_status_t switch_api_id_allocator_new(switch_device_t device,
                                             switch_uint32_t initial_size,
                                             bool zero_based,
-                                            switch_id_allocator_t **allocator) {
+                                            switch_id_allocator_t** allocator) {
   return switch_api_id_allocator_new_internal(device, initial_size, zero_based,
-                                       allocator);
+                                              allocator);
 }
 
 switch_status_t switch_api_id_allocator_allocate(
-    switch_device_t device, switch_id_allocator_t *allocator, switch_id_t *id) {
-    return switch_api_id_allocator_allocate_internal(device, allocator, id);
+    switch_device_t device, switch_id_allocator_t* allocator, switch_id_t* id) {
+  return switch_api_id_allocator_allocate_internal(device, allocator, id);
 }
 
 switch_status_t switch_api_id_allocator_release(
-    switch_device_t device, switch_id_allocator_t *allocator, switch_id_t id) {
-    return switch_api_id_allocator_release_internal(device, allocator, id);
+    switch_device_t device, switch_id_allocator_t* allocator, switch_id_t id) {
+  return switch_api_id_allocator_release_internal(device, allocator, id);
 }
 
 switch_status_t switch_api_id_allocator_allocate_contiguous(
-    switch_device_t device,
-    switch_id_allocator_t *allocator,
-    switch_uint8_t count,
-    switch_id_t *id) {
+    switch_device_t device, switch_id_allocator_t* allocator,
+    switch_uint8_t count, switch_id_t* id) {
   return switch_api_id_allocator_allocate_contiguous_internal(device, allocator,
-                                                       count, id);
+                                                              count, id);
 }

--- a/switchapi/es2k/switch_id.c
+++ b/switchapi/es2k/switch_id.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/es2k/switch_l3.c
+++ b/switchapi/es2k/switch_l3.c
@@ -17,14 +17,14 @@
 
 #include "switchapi/switch_l3.h"
 
+#include "switch_pd_routing.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_nhop_int.h"
-#include "switch_pd_routing.h"
 
-switch_status_t switch_route_table_entry_key_init(void *args,
-                                                  switch_uint8_t *key,
-                                                  switch_uint32_t *len) {
-  switch_route_entry_t *route_entry = NULL;
+switch_status_t switch_route_table_entry_key_init(void* args,
+                                                  switch_uint8_t* key,
+                                                  switch_uint32_t* len) {
+  switch_route_entry_t* route_entry = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!args || !key || !len) {
@@ -33,7 +33,7 @@ switch_status_t switch_route_table_entry_key_init(void *args,
   }
 
   *len = 0;
-  route_entry = (switch_route_entry_t *)args;
+  route_entry = (switch_route_entry_t*)args;
 
   SWITCH_MEMCPY(key, &route_entry->vrf_handle, sizeof(switch_handle_t));
   *len += sizeof(switch_handle_t);
@@ -49,13 +49,13 @@ switch_status_t switch_route_table_entry_key_init(void *args,
   return status;
 }
 
-switch_int32_t switch_route_entry_hash_compare(const void *key1,
-                                               const void *key2) {
+switch_int32_t switch_route_entry_hash_compare(const void* key1,
+                                               const void* key2) {
   return SWITCH_MEMCMP(key1, key2, SWITCH_ROUTE_HASH_KEY_SIZE);
 }
 
 switch_status_t switch_l3_init(switch_device_t device) {
-  switch_l3_context_t *l3_ctx = NULL;
+  switch_l3_context_t* l3_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   l3_ctx = SWITCH_MALLOC(device, sizeof(switch_l3_context_t), 0x1);
@@ -64,62 +64,57 @@ switch_status_t switch_l3_init(switch_device_t device) {
     krnlmon_log_error(
         "l3 init: Failed to allocate memory for switch_l3_context_t "
         "on device %d ,error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
   status =
-      switch_device_api_context_set(device, SWITCH_API_TYPE_L3, (void *)l3_ctx);
+      switch_device_api_context_set(device, SWITCH_API_TYPE_L3, (void*)l3_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "l3 init: Failed to set device context device %d "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
   }
-  
+
   l3_ctx->route_hashtable.size = IPV4_TABLE_SIZE;
   l3_ctx->route_hashtable.compare_func = switch_route_entry_hash_compare;
   l3_ctx->route_hashtable.key_func = switch_route_table_entry_key_init;
   l3_ctx->route_hashtable.hash_seed = SWITCH_ROUTE_HASH_SEED;
-  
+
   status = SWITCH_HASHTABLE_INIT(&l3_ctx->route_hashtable);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "l3 init: Failed to init hashtable on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
-  status = switch_handle_type_init(
-      device, SWITCH_HANDLE_TYPE_ROUTE, IPV4_TABLE_SIZE);
+  status = switch_handle_type_init(device, SWITCH_HANDLE_TYPE_ROUTE,
+                                   IPV4_TABLE_SIZE);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "l3 init: Failed to init SWITCH_HANDLE_TYPE_ROUTE on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
   return status;
-} 
+}
 
 switch_status_t switch_l3_free(switch_device_t device) {
-  switch_l3_context_t *l3_ctx = NULL;
+  switch_l3_context_t* l3_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_L3, (void **)&l3_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_L3,
+                                         (void**)&l3_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "l3 free: Failed to get device context on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
   }
 
   status = SWITCH_HASHTABLE_DONE(&l3_ctx->route_hashtable);
@@ -127,8 +122,7 @@ switch_status_t switch_l3_free(switch_device_t device) {
     krnlmon_log_error(
         "l3 free: SWITCH_HASHTABLE_DONE failed on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
   }
 
   status = switch_handle_type_free(device, SWITCH_HANDLE_TYPE_ROUTE);
@@ -136,8 +130,7 @@ switch_status_t switch_l3_free(switch_device_t device) {
     krnlmon_log_error(
         "l3 free: Failed to free SWITCH_HANDLE_TYPE_ROUTE on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
   }
 
   SWITCH_FREE(device, l3_ctx);
@@ -148,11 +141,10 @@ switch_status_t switch_l3_free(switch_device_t device) {
 }
 
 switch_status_t switch_route_table_hash_lookup(
-    switch_device_t device,
-    switch_route_entry_t *route_entry,
-    switch_handle_t *route_handle) {
-  switch_l3_context_t *l3_ctx = NULL;
-  switch_route_info_t *route_info = NULL;
+    switch_device_t device, switch_route_entry_t* route_entry,
+    switch_handle_t* route_handle) {
+  switch_l3_context_t* l3_ctx = NULL;
+  switch_route_info_t* route_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!route_entry) {
@@ -160,24 +152,22 @@ switch_status_t switch_route_table_hash_lookup(
     krnlmon_log_error(
         "route table lookup failed on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_L3, (void **)&l3_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_L3,
+                                         (void**)&l3_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "route table lookup: Failed to get device context on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
-  status = SWITCH_HASHTABLE_SEARCH(
-      &l3_ctx->route_hashtable, (void *)route_entry, (void **)&route_info);
+  status = SWITCH_HASHTABLE_SEARCH(&l3_ctx->route_hashtable, (void*)route_entry,
+                                   (void**)&route_info);
   if (status == SWITCH_STATUS_SUCCESS) {
     *route_handle = route_info->api_route_info.route_handle;
   }
@@ -187,9 +177,9 @@ switch_status_t switch_route_table_hash_lookup(
 
 switch_status_t switch_route_hashtable_insert(switch_device_t device,
                                               switch_handle_t route_handle) {
-  switch_l3_context_t *l3_ctx = NULL;
-  switch_route_info_t *route_info = NULL;
-  switch_route_entry_t *route_entry = NULL;
+  switch_l3_context_t* l3_ctx = NULL;
+  switch_route_info_t* route_info = NULL;
+  switch_route_entry_t* route_entry = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!SWITCH_ROUTE_HANDLE(route_handle)) {
@@ -197,9 +187,7 @@ switch_status_t switch_route_hashtable_insert(switch_device_t device,
     krnlmon_log_error(
         "route hashtable insert failed on device %d "
         ",route handle 0x%lx, error: %s\n",
-        device,
-        route_handle,
-        switch_error_to_string(status));
+        device, route_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -208,37 +196,30 @@ switch_status_t switch_route_hashtable_insert(switch_device_t device,
     krnlmon_log_error(
         "route hashtable insert: Failed to get route info on device %d "
         ",route handle 0x%lx, error: %s\n",
-        device,
-        route_handle,
-        switch_error_to_string(status));
+        device, route_handle, switch_error_to_string(status));
     return status;
   }
 
   route_entry = &route_info->route_entry;
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_L3, (void **)&l3_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_L3,
+                                         (void**)&l3_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "route hashtable insert failed on device %d "
         "route handle 0x%lx: l3 context get failed(%s)\n",
-        device,
-        route_handle,
-        switch_error_to_string(status));
+        device, route_handle, switch_error_to_string(status));
     return status;
   }
 
-  status = SWITCH_HASHTABLE_INSERT(&l3_ctx->route_hashtable,
-                                   &((route_info)->node),
-                                   (void *)route_entry,
-                                   (void *)(route_info));
+  status =
+      SWITCH_HASHTABLE_INSERT(&l3_ctx->route_hashtable, &((route_info)->node),
+                              (void*)route_entry, (void*)(route_info));
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "route hashtable insert failed on device %d "
         "route handle 0x%lx: hashtable insert failed(%s)\n",
-        device,
-        route_handle,
-        switch_error_to_string(status));
+        device, route_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -247,9 +228,9 @@ switch_status_t switch_route_hashtable_insert(switch_device_t device,
 
 switch_status_t switch_route_hashtable_remove(switch_device_t device,
                                               switch_handle_t route_handle) {
-  switch_l3_context_t *l3_ctx = NULL;
-  switch_route_info_t *route_info = NULL;
-  switch_route_entry_t *route_entry = NULL;
+  switch_l3_context_t* l3_ctx = NULL;
+  switch_route_info_t* route_info = NULL;
+  switch_route_entry_t* route_entry = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!SWITCH_ROUTE_HANDLE(route_handle)) {
@@ -257,9 +238,7 @@ switch_status_t switch_route_hashtable_remove(switch_device_t device,
     krnlmon_log_error(
         "route hashtable delete failed on device %d "
         "route handle 0x%lx: route handle invalid(%s)\n",
-        device,
-        route_handle,
-        switch_error_to_string(status));
+        device, route_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -268,35 +247,29 @@ switch_status_t switch_route_hashtable_remove(switch_device_t device,
     krnlmon_log_error(
         "route hashtable delete failed on device %d "
         "route handle 0x%lx: route get failed(%s)\n",
-        device,
-        route_handle,
-        switch_error_to_string(status));
+        device, route_handle, switch_error_to_string(status));
     return status;
   }
 
   route_entry = &route_info->route_entry;
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_L3, (void **)&l3_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_L3,
+                                         (void**)&l3_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "route hashtable delete failed on device %d "
         "route handle 0x%lx: l3 context get failed(%s)\n",
-        device,
-        route_handle,
-        switch_error_to_string(status));
+        device, route_handle, switch_error_to_string(status));
     return status;
   }
 
-  status = SWITCH_HASHTABLE_DELETE(
-      &l3_ctx->route_hashtable, (void *)route_entry, (void **)&route_info);
+  status = SWITCH_HASHTABLE_DELETE(&l3_ctx->route_hashtable, (void*)route_entry,
+                                   (void**)&route_info);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "route hashtable delete failed on device %d "
         "route handle 0x%lx: l3 hashtable delete failed(%s)\n",
-        device,
-        route_handle,
-        switch_error_to_string(status));
+        device, route_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -304,13 +277,12 @@ switch_status_t switch_route_hashtable_remove(switch_device_t device,
 }
 
 switch_status_t switch_api_l3_route_add(
-    switch_device_t device, switch_api_route_entry_t *api_route_entry) 
-{
+    switch_device_t device, switch_api_route_entry_t* api_route_entry) {
   switch_handle_t nhop_group_handle = SWITCH_API_INVALID_HANDLE;
   switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
-  switch_route_info_t *route_info = NULL;
-  switch_nhop_group_info_t *nhop_group_info = NULL;
+  switch_route_info_t* route_info = NULL;
+  switch_nhop_group_info_t* nhop_group_info = NULL;
   switch_route_entry_t route_entry;
   switch_handle_t route_handle = SWITCH_API_INVALID_HANDLE;
   switch_handle_t vrf_handle = SWITCH_API_INVALID_HANDLE;
@@ -320,11 +292,10 @@ switch_status_t switch_api_l3_route_add(
     krnlmon_log_error(
         "l3 route table add failed on device %d "
         "parameters invalid(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
-  
+
   vrf_handle = api_route_entry->vrf_handle;
   if (!SWITCH_VRF_HANDLE(vrf_handle)) {
     status = SWITCH_STATUS_INVALID_HANDLE;
@@ -332,9 +303,7 @@ switch_status_t switch_api_l3_route_add(
         "l3 route table add failed on device %d "
         "vrf handle 0x%lx "
         "vrf handle invalid(%s)\n",
-        device,
-        vrf_handle,
-        switch_error_to_string(status));
+        device, vrf_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -350,9 +319,7 @@ switch_status_t switch_api_l3_route_add(
         "l3 route table add failed on device %d "
         "vrf handle 0x%lx "
         "route table lookup failed(%s)\n",
-        device,
-        vrf_handle,
-        switch_error_to_string(status));
+        device, vrf_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -361,8 +328,7 @@ switch_status_t switch_api_l3_route_add(
     krnlmon_log_error(
         "l3 route table add failed on device %d "
         "route handle create failed(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -371,69 +337,67 @@ switch_status_t switch_api_l3_route_add(
     krnlmon_log_error(
         "l3 route table add failed on device %d "
         "route get failed(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
   switch_ip_table_action_t ip_table_action = SWITCH_ACTION_NONE;
 
   if (switch_handle_type_get(api_route_entry->nhop_handle) ==
-                             SWITCH_HANDLE_TYPE_NHOP) {
-      ip_table_action = SWITCH_ACTION_NHOP;
+      SWITCH_HANDLE_TYPE_NHOP) {
+    ip_table_action = SWITCH_ACTION_NHOP;
   } else if (switch_handle_type_get(api_route_entry->nhop_handle) ==
-                                    SWITCH_HANDLE_TYPE_NHOP_GROUP) {
-      ip_table_action = SWITCH_ACTION_NHOP_GROUP;
-      nhop_group_handle = api_route_entry->nhop_handle;
+             SWITCH_HANDLE_TYPE_NHOP_GROUP) {
+    ip_table_action = SWITCH_ACTION_NHOP_GROUP;
+    nhop_group_handle = api_route_entry->nhop_handle;
 
-      status = switch_nhop_get_group(device, nhop_group_handle, &nhop_group_info);
-      if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error(
-            "Failed to get ecmp info on device: %d, handle: 0x%lx, error: %s",
-            device,
-            nhop_group_handle,
-            switch_error_to_string(status));
-        return status;
-      }
+    status = switch_nhop_get_group(device, nhop_group_handle, &nhop_group_info);
+    if (status != SWITCH_STATUS_SUCCESS) {
+      krnlmon_log_error(
+          "Failed to get ecmp info on device: %d, handle: 0x%lx, error: %s",
+          device, nhop_group_handle, switch_error_to_string(status));
+      return status;
+    }
 
-      /* As action is ECMP, program ECMP hash table as well */
-      status = switch_pd_ecmp_hash_table_entry(device, nhop_group_info, true);
-      if (status != SWITCH_STATUS_SUCCESS) {
-          krnlmon_log_error("Failed to update ECMP hash table for NHOP group "
-                            "action, error: %s\n", switch_error_to_string(status));
-          return status;
-      }
+    /* As action is ECMP, program ECMP hash table as well */
+    status = switch_pd_ecmp_hash_table_entry(device, nhop_group_info, true);
+    if (status != SWITCH_STATUS_SUCCESS) {
+      krnlmon_log_error(
+          "Failed to update ECMP hash table for NHOP group "
+          "action, error: %s\n",
+          switch_error_to_string(status));
+      return status;
+    }
   }
 
   if (api_route_entry->ip_address.type == SWITCH_API_IP_ADDR_V4) {
-      /* Configure IPv4_table */
-      status = switch_pd_ipv4_table_entry(device, api_route_entry, true,
-                                          ip_table_action);
+    /* Configure IPv4_table */
+    status = switch_pd_ipv4_table_entry(device, api_route_entry, true,
+                                        ip_table_action);
   } else if (api_route_entry->ip_address.type == SWITCH_API_IP_ADDR_V6) {
-      /* Configure IPv6_table */
-      status = switch_pd_ipv6_table_entry(device, api_route_entry, true,
-                                            ip_table_action);
+    /* Configure IPv6_table */
+    status = switch_pd_ipv6_table_entry(device, api_route_entry, true,
+                                        ip_table_action);
   } else {
-      krnlmon_log_error("Invalid IP address type: %d",
-                         api_route_entry->ip_address.type);
-      return SWITCH_STATUS_INVALID_PARAMETER;
+    krnlmon_log_error("Invalid IP address type: %d",
+                      api_route_entry->ip_address.type);
+    return SWITCH_STATUS_INVALID_PARAMETER;
   }
 
   if (status != SWITCH_STATUS_SUCCESS) {
-      krnlmon_log_error("Failed to update IP table for NHOP action: %d,"
-                        "error: %s\n", ip_table_action,
-                        switch_error_to_string(status));
-      return status;
+    krnlmon_log_error(
+        "Failed to update IP table for NHOP action: %d,"
+        "error: %s\n",
+        ip_table_action, switch_error_to_string(status));
+    return status;
   }
 
   api_route_entry->route_handle = handle;
-  SWITCH_MEMCPY(&route_info->api_route_info,
-                api_route_entry,
+  SWITCH_MEMCPY(&route_info->api_route_info, api_route_entry,
                 sizeof(switch_api_route_entry_t));
   route_info->route_entry.vrf_handle = vrf_handle;
   route_info->nhop_handle = api_route_entry->nhop_handle;
-  SWITCH_MEMCPY(&route_info->route_entry.ip,
-                &api_route_entry->ip_address,
+  SWITCH_MEMCPY(&route_info->route_entry.ip, &api_route_entry->ip_address,
                 sizeof(switch_ip_addr_t));
 
   status = switch_route_hashtable_insert(device, handle);
@@ -442,21 +406,18 @@ switch_status_t switch_api_l3_route_add(
         "l3 route table add failed on device %d "
         "vrf handle 0x%lx "
         "route table insert failed(%s)\n",
-        device,
-        vrf_handle,
-        switch_error_to_string(status));
+        device, vrf_handle, switch_error_to_string(status));
     return status;
   }
 
   return status;
 }
 
-switch_status_t switch_api_l3_delete_route(switch_device_t device,
-    switch_api_route_entry_t *api_route_entry) {
-
+switch_status_t switch_api_l3_delete_route(
+    switch_device_t device, switch_api_route_entry_t* api_route_entry) {
   switch_route_entry_t route_entry;
-  switch_nhop_group_info_t *nhop_group_info = NULL;
-  switch_route_info_t *route_info = NULL;
+  switch_nhop_group_info_t* nhop_group_info = NULL;
+  switch_route_info_t* route_info = NULL;
   switch_api_route_entry_t api_route_info;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   switch_handle_t nhop_group_handle = SWITCH_API_INVALID_HANDLE;
@@ -467,8 +428,7 @@ switch_status_t switch_api_l3_delete_route(switch_device_t device,
     krnlmon_log_error(
         "l3 route table delete failed on device %d "
         "parameters invalid(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -482,8 +442,7 @@ switch_status_t switch_api_l3_delete_route(switch_device_t device,
     krnlmon_log_error(
         "l3 route table delete failed on device %d "
         "route entry hash find failed(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -492,50 +451,49 @@ switch_status_t switch_api_l3_delete_route(switch_device_t device,
     krnlmon_log_error(
         "l3 route table delete failed on device %d "
         "route get failed(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
   api_route_info = route_info->api_route_info;
   if (route_info->nhop_handle) {
     if (switch_handle_type_get(api_route_info.nhop_handle) ==
-                               SWITCH_HANDLE_TYPE_NHOP_GROUP) {
+        SWITCH_HANDLE_TYPE_NHOP_GROUP) {
       nhop_group_handle = api_route_info.nhop_handle;
-      status = switch_nhop_get_group(device, nhop_group_handle, &nhop_group_info);
+      status =
+          switch_nhop_get_group(device, nhop_group_handle, &nhop_group_info);
       if (status != SWITCH_STATUS_SUCCESS) {
         krnlmon_log_error(
             "nhop_group info get failed on device: %d, nhop_group handle: "
-	    "0x%lx, nhop_group get Failed:(%s)\n",
-            device,
-            nhop_group_handle,
-            switch_error_to_string(status));
+            "0x%lx, nhop_group get Failed:(%s)\n",
+            device, nhop_group_handle, switch_error_to_string(status));
         return status;
       }
 
       status = switch_pd_ecmp_hash_table_entry(device, nhop_group_info, false);
       if (status != SWITCH_STATUS_SUCCESS) {
-          krnlmon_log_error("Failed to delete ECMP hash table for NHOP group"
-                            " action");
-          return status;
+        krnlmon_log_error(
+            "Failed to delete ECMP hash table for NHOP group"
+            " action");
+        return status;
       }
     }
 
     if (api_route_info.ip_address.type == SWITCH_API_IP_ADDR_V4) {
       /* Delete IPv4_table entry */
-      status = switch_pd_ipv4_table_entry(device, &api_route_info,
-                                          false, SWITCH_ACTION_NONE);
+      status = switch_pd_ipv4_table_entry(device, &api_route_info, false,
+                                          SWITCH_ACTION_NONE);
     } else if (api_route_info.ip_address.type == SWITCH_API_IP_ADDR_V6) {
       /* Delete IPv6_table entry */
-      status = switch_pd_ipv6_table_entry(device, api_route_entry,
-                                          false, SWITCH_ACTION_NONE);
+      status = switch_pd_ipv6_table_entry(device, api_route_entry, false,
+                                          SWITCH_ACTION_NONE);
     } else {
-        krnlmon_log_error("Invalid IP address type: %d",
-                           api_route_info.ip_address.type);
-        return SWITCH_STATUS_INVALID_PARAMETER;
+      krnlmon_log_error("Invalid IP address type: %d",
+                        api_route_info.ip_address.type);
+      return SWITCH_STATUS_INVALID_PARAMETER;
     }
 
-    if(status != SWITCH_STATUS_SUCCESS) {
+    if (status != SWITCH_STATUS_SUCCESS) {
       krnlmon_log_error("Failed to Delete IP table entry, error: %s",
                         switch_error_to_string(status));
       return status;
@@ -547,8 +505,7 @@ switch_status_t switch_api_l3_delete_route(switch_device_t device,
     krnlmon_log_error(
         "l3 route table delete failed on device %d "
         "route table delete failed(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 

--- a/switchapi/es2k/switch_l3.c
+++ b/switchapi/es2k/switch_l3.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/es2k/switch_lag.c
+++ b/switchapi/es2k/switch_lag.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Intel Corporation.
+ * Copyright 2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/es2k/switch_neighbor.c
+++ b/switchapi/es2k/switch_neighbor.c
@@ -16,47 +16,44 @@
  */
 
 #include "switchapi/switch_neighbor.h"
-#include "switchapi/switch_neighbor_int.h"
-#include "switch_pd_fdb.h"
 
+#include "switch_pd_fdb.h"
+#include "switch_pd_utils.h"
 #include "switchapi/switch_fdb.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_lag.h"
+#include "switchapi/switch_neighbor_int.h"
 #include "switchapi/switch_nhop.h"
 #include "switchapi/switch_nhop_int.h"
 #include "switchapi/switch_rif_int.h"
 #include "switchapi/switch_rmac_int.h"
-#include "switch_pd_utils.h"
 
 switch_status_t switch_neighbor_init(switch_device_t device) {
-  switch_neighbor_context_t *neighbor_ctx = NULL;
+  switch_neighbor_context_t* neighbor_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   neighbor_ctx = SWITCH_MALLOC(device, sizeof(switch_neighbor_context_t), 0x1);
   if (!neighbor_ctx) {
     status = SWITCH_STATUS_NO_MEMORY;
-    krnlmon_log_error("neighbor init failed for device %d: %s\n",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("neighbor init failed for device %d: %s\n", device,
+                      switch_error_to_string(status));
     return status;
   }
 
-  status = switch_device_api_context_set(
-      device, SWITCH_API_TYPE_NEIGHBOR, (void *)neighbor_ctx);
+  status = switch_device_api_context_set(device, SWITCH_API_TYPE_NEIGHBOR,
+                                         (void*)neighbor_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("neighbor init failed for device %d: %s\n",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("neighbor init failed for device %d: %s\n", device,
+                      switch_error_to_string(status));
     return status;
   }
 
-  status = switch_handle_type_init(
-      device, SWITCH_HANDLE_TYPE_NEIGHBOR, NEIGHBOR_MOD_TABLE_SIZE);
+  status = switch_handle_type_init(device, SWITCH_HANDLE_TYPE_NEIGHBOR,
+                                   NEIGHBOR_MOD_TABLE_SIZE);
 
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("neighbor init failed for device %d: %s\n",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("neighbor init failed for device %d: %s\n", device,
+                      switch_error_to_string(status));
     goto cleanup;
   }
 
@@ -69,25 +66,23 @@ cleanup:
 }
 
 switch_status_t switch_neighbor_free(switch_device_t device) {
-  switch_neighbor_context_t *neighbor_ctx = NULL;
+  switch_neighbor_context_t* neighbor_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_NEIGHBOR, (void **)&neighbor_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_NEIGHBOR,
+                                         (void**)&neighbor_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("neighbor free failed for device %d: %s\n",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("neighbor free failed for device %d: %s\n", device,
+                      switch_error_to_string(status));
     return status;
   }
-  
+
   status = switch_handle_type_free(device, SWITCH_HANDLE_TYPE_NEIGHBOR);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("neighbor free failed for device %d: %s\n",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("neighbor free failed for device %d: %s\n", device,
+                      switch_error_to_string(status));
   }
-  
+
   SWITCH_FREE(device, neighbor_ctx);
   status =
       switch_device_api_context_set(device, SWITCH_API_TYPE_NEIGHBOR, NULL);
@@ -97,21 +92,20 @@ switch_status_t switch_neighbor_free(switch_device_t device) {
 }
 
 switch_status_t switch_api_neighbor_create(
-    switch_device_t device,
-    switch_api_neighbor_info_t *api_neighbor_info,
-    switch_handle_t *neighbor_handle) {
-  switch_neighbor_info_t *neighbor_info = NULL;
+    switch_device_t device, switch_api_neighbor_info_t* api_neighbor_info,
+    switch_handle_t* neighbor_handle) {
+  switch_neighbor_info_t* neighbor_info = NULL;
   switch_handle_t nhop_handle = SWITCH_API_INVALID_HANDLE;
-  switch_nhop_info_t *nhop_info = NULL;
+  switch_nhop_info_t* nhop_info = NULL;
   switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   switch_pd_routing_info_t pd_neighbor_info;
-  switch_rif_info_t *rif_info = NULL;
-  switch_lag_info_t *lag_info = NULL;
+  switch_rif_info_t* rif_info = NULL;
+  switch_lag_info_t* lag_info = NULL;
   switch_handle_t rmac_handle = SWITCH_API_INVALID_HANDLE;
-  switch_rmac_info_t *rmac_info = NULL;
-  switch_rmac_entry_t *rmac_entry = NULL;
-  switch_node_t *node = NULL;
+  switch_rmac_info_t* rmac_info = NULL;
+  switch_rmac_entry_t* rmac_entry = NULL;
+  switch_node_t* node = NULL;
 
   memset(&pd_neighbor_info, 0, sizeof(switch_pd_routing_info_t));
 
@@ -120,8 +114,7 @@ switch_status_t switch_api_neighbor_create(
     krnlmon_log_error(
         "neighbor create failed on device %d: "
         "neighbor info invalid:(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -130,9 +123,7 @@ switch_status_t switch_api_neighbor_create(
     krnlmon_log_error(
         "neighbor create failed on device %d nhop handle 0x%lx: "
         "nhop handle invalid:(%s)\n",
-        device,
-        api_neighbor_info->nhop_handle,
-        switch_error_to_string(status));
+        device, api_neighbor_info->nhop_handle, switch_error_to_string(status));
     return status;
   }
   nhop_handle = api_neighbor_info->nhop_handle;
@@ -143,8 +134,7 @@ switch_status_t switch_api_neighbor_create(
     krnlmon_log_error(
         "neighbor create failed on device %d: "
         "handle create failed:(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -153,8 +143,7 @@ switch_status_t switch_api_neighbor_create(
     krnlmon_log_error(
         "neighbor create failed on device %d: "
         "neighbor get failed:(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -164,88 +153,82 @@ switch_status_t switch_api_neighbor_create(
 
   neighbor_info->neighbor_handle = handle;
   neighbor_info->nhop_handle = nhop_handle;
-  SWITCH_MEMCPY(&neighbor_info->api_neighbor_info,
-                api_neighbor_info,
+  SWITCH_MEMCPY(&neighbor_info->api_neighbor_info, api_neighbor_info,
                 sizeof(switch_api_neighbor_info_t));
 
   *neighbor_handle = handle;
 
-  if((nhop_handle && handle))
-  {
-      pd_neighbor_info.neighbor_handle = handle;
-      pd_neighbor_info.nexthop_handle = nhop_handle;
+  if ((nhop_handle && handle)) {
+    pd_neighbor_info.neighbor_handle = handle;
+    pd_neighbor_info.nexthop_handle = nhop_handle;
 
-      /*get rif_info to access port_id */
-      pd_neighbor_info.rif_handle = api_neighbor_info->rif_handle;
-      if(SWITCH_RIF_HANDLE(api_neighbor_info->rif_handle)) {
+    /*get rif_info to access port_id */
+    pd_neighbor_info.rif_handle = api_neighbor_info->rif_handle;
+    if (SWITCH_RIF_HANDLE(api_neighbor_info->rif_handle)) {
+      status = switch_rif_get(device, pd_neighbor_info.rif_handle, &rif_info);
+      CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
+      status = switch_pd_get_physical_port_id(
+          device, rif_info->api_rif_info.port_id, &pd_neighbor_info.port_id);
+      CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
+      rmac_handle = rif_info->api_rif_info.rmac_handle;
 
-        status = switch_rif_get(device, pd_neighbor_info.rif_handle, &rif_info);
-        CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
-        status = switch_pd_get_physical_port_id(device,
-                                                rif_info->api_rif_info.port_id,
-                                                &pd_neighbor_info.port_id);
-        CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
-        rmac_handle = rif_info->api_rif_info.rmac_handle;
+    } else if (SWITCH_LAG_HANDLE(api_neighbor_info->rif_handle)) {
+      status = switch_lag_get(device, pd_neighbor_info.rif_handle, &lag_info);
+      CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
+      rmac_handle = lag_info->api_lag_info.rmac_handle;
+    }
 
-      } else if (SWITCH_LAG_HANDLE(api_neighbor_info->rif_handle)) {
+    SWITCH_MEMCPY(&pd_neighbor_info.dst_mac_addr, &api_neighbor_info->mac_addr,
+                  sizeof(switch_mac_addr_t));
 
-        status = switch_lag_get(device, pd_neighbor_info.rif_handle, &lag_info);
-        CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
-        rmac_handle = lag_info->api_lag_info.rmac_handle;
+    status = switch_routing_table_entry(device, &pd_neighbor_info, true);
+    if (status != SWITCH_STATUS_SUCCESS) {
+      krnlmon_log_error("routing tables update failed \n");
+      return status;
+    }
+    /*rmac_handle will have source mac info. get rmac_info from rmac_handle */
+    status = switch_rmac_get(device, rmac_handle, &rmac_info);
+    CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
+    SWITCH_LIST_GET_HEAD(rmac_info->rmac_list, node);
+    rmac_entry = (switch_rmac_entry_t*)node->data;
+
+    /* SRC MAC is picked from RMAC of RIF entry. This needs to be programmed
+     * only once, even though many neighbors learnt on same RIF. */
+    if (rmac_entry && !rmac_entry->is_rmac_pd_programmed) {
+      switch_api_l2_info_t api_l2_rx_info;
+      api_l2_rx_info.rif_handle = api_neighbor_info->rif_handle;
+      SWITCH_MEMCPY(&api_l2_rx_info.dst_mac, &(rmac_entry->mac),
+                    sizeof(switch_mac_addr_t));
+
+      status =
+          switch_pd_l2_rx_forward_table_entry(device, &api_l2_rx_info, true);
+      if (status != SWITCH_STATUS_SUCCESS) {
+        return status;
       }
 
-      SWITCH_MEMCPY(&pd_neighbor_info.dst_mac_addr,
-                    &api_neighbor_info->mac_addr, sizeof(switch_mac_addr_t));
-
-      status = switch_routing_table_entry(device, &pd_neighbor_info, true);
+      status = switch_pd_rmac_table_entry(device, rmac_entry,
+                                          api_neighbor_info->rif_handle, true);
       if (status != SWITCH_STATUS_SUCCESS) {
         krnlmon_log_error("routing tables update failed \n");
         return status;
       }
-      /*rmac_handle will have source mac info. get rmac_info from rmac_handle */
-      status = switch_rmac_get(device, rmac_handle, &rmac_info);
-      CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
-      SWITCH_LIST_GET_HEAD(rmac_info->rmac_list, node);
-      rmac_entry = (switch_rmac_entry_t *)node->data;
 
-      /* SRC MAC is picked from RMAC of RIF entry. This needs to be programmed
-       * only once, even though many neighbors learnt on same RIF. */
-      if (rmac_entry && !rmac_entry->is_rmac_pd_programmed) {
-          switch_api_l2_info_t api_l2_rx_info;
-          api_l2_rx_info.rif_handle = api_neighbor_info->rif_handle;
-          SWITCH_MEMCPY(&api_l2_rx_info.dst_mac, &(rmac_entry->mac),
-                        sizeof(switch_mac_addr_t));
-
-          status = switch_pd_l2_rx_forward_table_entry(device, &api_l2_rx_info,
-                                                       true);
-          if (status != SWITCH_STATUS_SUCCESS) {
-            return status;
-          }
-
-          status = switch_pd_rmac_table_entry(device, rmac_entry,
-                                           api_neighbor_info->rif_handle, true);
-          if (status != SWITCH_STATUS_SUCCESS) {
-              krnlmon_log_error("routing tables update failed \n");
-              return status;
-          }
-
-          rmac_entry->is_rmac_pd_programmed = true;
-      }
+      rmac_entry->is_rmac_pd_programmed = true;
+    }
   }
 
-  SWITCH_MEMCPY(&neighbor_info->switch_pd_routing_info,
-                &pd_neighbor_info,
+  SWITCH_MEMCPY(&neighbor_info->switch_pd_routing_info, &pd_neighbor_info,
                 sizeof(switch_pd_routing_info_t));
-  krnlmon_log_info(
-      "neighbor created on device %d neighbor handle 0x%lx\n", device, handle);
+  krnlmon_log_info("neighbor created on device %d neighbor handle 0x%lx\n",
+                   device, handle);
 
   return status;
 }
 
-switch_status_t switch_api_neighbor_delete(
-    switch_device_t device, switch_handle_t neighbor_handle) {
-  switch_neighbor_info_t *neighbor_info = NULL;
-  switch_api_neighbor_info_t *api_neighbor_info = NULL;
+switch_status_t switch_api_neighbor_delete(switch_device_t device,
+                                           switch_handle_t neighbor_handle) {
+  switch_neighbor_info_t* neighbor_info = NULL;
+  switch_api_neighbor_info_t* api_neighbor_info = NULL;
   switch_handle_t nhop_handle = SWITCH_API_INVALID_HANDLE;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
@@ -254,9 +237,7 @@ switch_status_t switch_api_neighbor_delete(
     krnlmon_log_error(
         "neighbor delete failed on device %d neighbor handle 0x%lx: "
         "neighbor handle invalid(%s)\n",
-        device,
-        neighbor_handle,
-        switch_error_to_string(status));
+        device, neighbor_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -265,9 +246,7 @@ switch_status_t switch_api_neighbor_delete(
     krnlmon_log_error(
         "neighbor delete failed on device %d neighbor handle 0x%lx: "
         "neighbor get failed(%s)\n",
-        device,
-        neighbor_handle,
-        switch_error_to_string(status));
+        device, neighbor_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -275,10 +254,9 @@ switch_status_t switch_api_neighbor_delete(
   api_neighbor_info = &neighbor_info->api_neighbor_info;
 
   if (SWITCH_NHOP_HANDLE(nhop_handle)) {
-    status = switch_routing_table_entry(device,
-                                        &neighbor_info->switch_pd_routing_info,
-                                        false);
-    if(status != SWITCH_STATUS_SUCCESS)
+    status = switch_routing_table_entry(
+        device, &neighbor_info->switch_pd_routing_info, false);
+    if (status != SWITCH_STATUS_SUCCESS)
       krnlmon_log_error("routing tables update failed \n");
   }
 
@@ -286,8 +264,7 @@ switch_status_t switch_api_neighbor_delete(
   SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
 
   krnlmon_log_info("neighbor deleted on device %d neighbor handle 0x%lx\n",
-             device,
-             neighbor_handle);
+                   device, neighbor_handle);
 
   return status;
 }

--- a/switchapi/es2k/switch_neighbor.c
+++ b/switchapi/es2k/switch_neighbor.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/es2k/switch_nhop.c
+++ b/switchapi/es2k/switch_nhop.c
@@ -16,20 +16,19 @@
  */
 
 #include "switchapi/switch_nhop.h"
-#include "switchapi/switch_nhop_int.h"
 
+#include "switch_pd_routing.h"
 #include "switchapi/switch_handle_int.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_neighbor_int.h"
-#include "switchapi/switch_rif_int.h"
+#include "switchapi/switch_nhop_int.h"
 #include "switchapi/switch_rif.h"
-#include "switch_pd_routing.h"
+#include "switchapi/switch_rif_int.h"
 
-//add corresponding delete functions
+// add corresponding delete functions
 
 switch_status_t switch_nhop_add_to_group_member_list(
-    switch_device_t device,
-    switch_nhop_info_t *nhop_info,
+    switch_device_t device, switch_nhop_info_t* nhop_info,
     switch_handle_t nhop_mem_handle) {
   PWord_t PValue;
 
@@ -38,9 +37,7 @@ switch_status_t switch_nhop_add_to_group_member_list(
     krnlmon_log_error(
         "nhop add nhop member Failed on device %d, "
         "nhop handle 0x%lx: , nhop mem handle 0x%lx\n",
-        device,
-        nhop_info->nhop_handle,
-        nhop_mem_handle);
+        device, nhop_info->nhop_handle, nhop_mem_handle);
     return SWITCH_STATUS_FAILURE;
   }
 
@@ -48,9 +45,7 @@ switch_status_t switch_nhop_add_to_group_member_list(
   krnlmon_log_info(
       "nhop add nhop member success on device %d, "
       "nhop handle 0x%lx: , nhop mem handle 0x%lx: ref_cnt: %d\n",
-      device,
-      nhop_info->nhop_handle,
-      nhop_mem_handle,
+      device, nhop_info->nhop_handle, nhop_mem_handle,
       SWITCH_NHOP_NUM_NHOP_MEMBER_REF(nhop_info));
 
   return SWITCH_STATUS_SUCCESS;
@@ -59,23 +54,21 @@ switch_status_t switch_nhop_add_to_group_member_list(
 switch_status_t switch_nhop_member_handle_init(switch_device_t device) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
-  status = switch_handle_type_init(
-      device, SWITCH_HANDLE_TYPE_NHOP_MEMBER, NHOP_MEMBER_HASH_TABLE_SIZE);
+  status = switch_handle_type_init(device, SWITCH_HANDLE_TYPE_NHOP_MEMBER,
+                                   NHOP_MEMBER_HASH_TABLE_SIZE);
 
   if (status != SWITCH_STATUS_SUCCESS) {
-     krnlmon_log_error("nhop member handle init Failed for device %d: %s\n",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("nhop member handle init Failed for device %d: %s\n",
+                      device, switch_error_to_string(status));
     return status;
   }
 
   return SWITCH_STATUS_SUCCESS;
 }
 
-switch_status_t switch_nhop_hash_key_init(void *args,
-                                          switch_uint8_t *key,
-                                          switch_uint32_t *len) {
-  switch_nhop_key_t *nhop_key = NULL;
+switch_status_t switch_nhop_hash_key_init(void* args, switch_uint8_t* key,
+                                          switch_uint32_t* len) {
+  switch_nhop_key_t* nhop_key = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!args || !key || !len) {
@@ -83,7 +76,7 @@ switch_status_t switch_nhop_hash_key_init(void *args,
     return status;
   }
 
-  nhop_key = (switch_nhop_key_t *)args;
+  nhop_key = (switch_nhop_key_t*)args;
   *len = 0;
 
   SWITCH_MEMCPY((key + *len), &nhop_key->handle, sizeof(switch_handle_t));
@@ -100,53 +93,52 @@ switch_status_t switch_nhop_hash_key_init(void *args,
   return status;
 }
 
-switch_int32_t switch_nhop_hash_compare(const void *key1, const void *key2) {
-  switch_nhop_info_t *nhop_info = (switch_nhop_info_t *) key2;
+switch_int32_t switch_nhop_hash_compare(const void* key1, const void* key2) {
+  switch_nhop_info_t* nhop_info = (switch_nhop_info_t*)key2;
   switch_nhop_key_t nhop_key;
 
   SWITCH_MEMSET(&nhop_key, 0x0, sizeof(switch_nhop_key_t));
 
   if (nhop_info) {
-      SWITCH_MEMCPY(&nhop_key, &nhop_info->spath.nhop_key,
-                    sizeof(switch_nhop_key_t));
+    SWITCH_MEMCPY(&nhop_key, &nhop_info->spath.nhop_key,
+                  sizeof(switch_nhop_key_t));
   }
 
   return SWITCH_MEMCMP(key1, &nhop_key, SWITCH_NHOP_HASH_KEY_SIZE);
 }
 
 switch_status_t switch_nhop_init(switch_device_t device) {
-  switch_nhop_context_t *nhop_ctx = NULL;
+  switch_nhop_context_t* nhop_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   nhop_ctx = SWITCH_MALLOC(device, sizeof(switch_nhop_context_t), 0x1);
   if (!nhop_ctx) {
     status = SWITCH_STATUS_NO_MEMORY;
-    krnlmon_log_error("nhop init: Failed to allocate memory for switch_nhop_context_t"
-             " for device %d, error: %s\n",
-             device,
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "nhop init: Failed to allocate memory for switch_nhop_context_t"
+        " for device %d, error: %s\n",
+        device, switch_error_to_string(status));
     return status;
   }
 
-  status = switch_device_api_context_set(
-      device, SWITCH_API_TYPE_NHOP, (void *)nhop_ctx);
+  status = switch_device_api_context_set(device, SWITCH_API_TYPE_NHOP,
+                                         (void*)nhop_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("nhop init: Failed to set device api context for device %d,"
-             " error: %s\n",
-             device,
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "nhop init: Failed to set device api context for device %d,"
+        " error: %s\n",
+        device, switch_error_to_string(status));
     return status;
   }
-  
+
   nhop_ctx->nhop_hashtable.size = NEXTHOP_TABLE_SIZE;
   nhop_ctx->nhop_hashtable.compare_func = switch_nhop_hash_compare;
   nhop_ctx->nhop_hashtable.key_func = switch_nhop_hash_key_init;
   nhop_ctx->nhop_hashtable.hash_seed = SWITCH_NHOP_HASH_SEED;
-  
+
   status = SWITCH_HASHTABLE_INIT(&nhop_ctx->nhop_hashtable);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("nhop init Failed for device %d\n",
-                     device);
+    krnlmon_log_error("nhop init Failed for device %d\n", device);
     return status;
   }
 
@@ -154,8 +146,7 @@ switch_status_t switch_nhop_init(switch_device_t device) {
                                    NEXTHOP_TABLE_SIZE);
 
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("nhop init Failed for device %d\n",
-                     device);
+    krnlmon_log_error("nhop init Failed for device %d\n", device);
     return status;
   }
 
@@ -163,73 +154,65 @@ switch_status_t switch_nhop_init(switch_device_t device) {
                                    NHOP_GROUP_HASH_TABLE_SIZE);
 
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("NHOP group init Failed for device %d\n",
-                     device);
+    krnlmon_log_error("NHOP group init Failed for device %d\n", device);
     return status;
   }
 
   status = switch_nhop_member_handle_init(device);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("nhop member init Failed for device %d: %s\n",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("nhop member init Failed for device %d: %s\n", device,
+                      switch_error_to_string(status));
     return status;
   }
-  
+
   return SWITCH_STATUS_SUCCESS;
 }
 
 switch_status_t switch_nhop_free(switch_device_t device) {
-  switch_nhop_context_t *nhop_ctx = NULL;
+  switch_nhop_context_t* nhop_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_NHOP, (void **)&nhop_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_NHOP,
+                                         (void**)&nhop_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("nhop free Failed for device %d\n",
-                     device);
+    krnlmon_log_error("nhop free Failed for device %d\n", device);
     return status;
   }
 
   status = SWITCH_HASHTABLE_DONE(&nhop_ctx->nhop_hashtable);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("nhop free Failed for device %d: , error: %s\n",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("nhop free Failed for device %d: , error: %s\n", device,
+                      switch_error_to_string(status));
   }
 
   status = switch_handle_type_free(device, SWITCH_HANDLE_TYPE_NHOP);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("nhop free Failed for device %d\n",
-                     device);
+    krnlmon_log_error("nhop free Failed for device %d\n", device);
   }
 
   status = switch_handle_type_free(device, SWITCH_HANDLE_TYPE_NHOP_GROUP);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("NHOP group free Failed for device %d\n",
-                     device);
+    krnlmon_log_error("NHOP group free Failed for device %d\n", device);
   }
 
   status = switch_handle_type_free(device, SWITCH_HANDLE_TYPE_NHOP_MEMBER);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("nhop free Failed for device %d: %s\n",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("nhop free Failed for device %d: %s\n", device,
+                      switch_error_to_string(status));
     return status;
   }
-  
+
   SWITCH_FREE(device, nhop_ctx);
   status = switch_device_api_context_set(device, SWITCH_API_TYPE_NHOP, NULL);
   SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
   return status;
 }
 
-switch_status_t switch_api_nhop_handle_get(
-    const switch_device_t device,
-    const switch_nhop_key_t *nhop_key,
-    switch_handle_t *nhop_handle) {
-  switch_nhop_context_t *nhop_ctx = NULL;
-  switch_nhop_info_t *nhop_info = NULL;
+switch_status_t switch_api_nhop_handle_get(const switch_device_t device,
+                                           const switch_nhop_key_t* nhop_key,
+                                           switch_handle_t* nhop_handle) {
+  switch_nhop_context_t* nhop_ctx = NULL;
+  switch_nhop_info_t* nhop_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!nhop_key || !nhop_handle) {
@@ -238,15 +221,15 @@ switch_status_t switch_api_nhop_handle_get(
     return status;
   }
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_NHOP, (void **)&nhop_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_NHOP,
+                                         (void**)&nhop_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error("nhop_key find Failed \n");
     return status;
   }
 
-  status = SWITCH_HASHTABLE_SEARCH(
-      &nhop_ctx->nhop_hashtable, (void *)nhop_key, (void **)&nhop_info);
+  status = SWITCH_HASHTABLE_SEARCH(&nhop_ctx->nhop_hashtable, (void*)nhop_key,
+                                   (void**)&nhop_info);
   if (status == SWITCH_STATUS_SUCCESS) {
     *nhop_handle = nhop_info->nhop_handle;
   } else {
@@ -256,22 +239,19 @@ switch_status_t switch_api_nhop_handle_get(
   return status;
 }
 
-switch_status_t switch_api_neighbor_handle_get (
-    const switch_device_t device,
-    const switch_handle_t nhop_handle,
-    switch_handle_t *neighbor_handle) {
-  switch_nhop_info_t *nhop_info = NULL;
-  switch_spath_info_t *spath_info = NULL;
+switch_status_t switch_api_neighbor_handle_get(
+    const switch_device_t device, const switch_handle_t nhop_handle,
+    switch_handle_t* neighbor_handle) {
+  switch_nhop_info_t* nhop_info = NULL;
+  switch_spath_info_t* spath_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
-  
+
   if (!SWITCH_NHOP_HANDLE(nhop_handle)) {
     status = SWITCH_STATUS_INVALID_HANDLE;
     krnlmon_log_error(
         "neighbor handle get Failed for "
         "device %d handle 0x%lx: %s\n",
-        device,
-        nhop_handle,
-        switch_error_to_string(status));
+        device, nhop_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -281,9 +261,7 @@ switch_status_t switch_api_neighbor_handle_get (
     krnlmon_log_error(
         "neighbor handle get Failed for "
         "device %d handle 0x%lx: %s\n",
-        device,
-        nhop_handle,
-        switch_error_to_string(status));
+        device, nhop_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -293,9 +271,9 @@ switch_status_t switch_api_neighbor_handle_get (
   return status;
 }
 
-switch_status_t switch_api_create_nhop_group(const switch_device_t device,
-                                         switch_handle_t *nhop_group_handle) {
-  switch_nhop_group_info_t *nhop_group_info = NULL;
+switch_status_t switch_api_create_nhop_group(
+    const switch_device_t device, switch_handle_t* nhop_group_handle) {
+  switch_nhop_group_info_t* nhop_group_info = NULL;
   switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
@@ -305,8 +283,7 @@ switch_status_t switch_api_create_nhop_group(const switch_device_t device,
     krnlmon_log_error(
         "nhop create Failed on device %d "
         "handle create Failed:(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -315,8 +292,7 @@ switch_status_t switch_api_create_nhop_group(const switch_device_t device,
     krnlmon_log_error(
         "nhop group create Failed on device %d "
         "nhop group get Failed:(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -327,24 +303,22 @@ switch_status_t switch_api_create_nhop_group(const switch_device_t device,
 
   *nhop_group_handle = handle;
 
-  krnlmon_log_info("nhop group handle created on device %d nhop group handle 0x%lx\n",
-                   device,
-                   *nhop_group_handle);
+  krnlmon_log_info(
+      "nhop group handle created on device %d nhop group handle 0x%lx\n",
+      device, *nhop_group_handle);
 
   return status;
 }
 
-switch_status_t switch_api_add_nhop_member (
-    const switch_device_t device,
-    const switch_handle_t nhop_group_handle,
-    const switch_uint32_t num_nhops,
-    const switch_handle_t *nhop_handles,
-    switch_handle_t *member_handle) {
+switch_status_t switch_api_add_nhop_member(
+    const switch_device_t device, const switch_handle_t nhop_group_handle,
+    const switch_uint32_t num_nhops, const switch_handle_t* nhop_handles,
+    switch_handle_t* member_handle) {
   switch_uint32_t index = 0;
   switch_handle_t nhop_handle = 0;
-  switch_nhop_group_info_t *nhop_group_info = NULL;
-  switch_nhop_info_t *nhop_info = NULL;
-  switch_nhop_member_t *nhop_member = NULL;
+  switch_nhop_group_info_t* nhop_group_info = NULL;
+  switch_nhop_info_t* nhop_info = NULL;
+  switch_nhop_member_t* nhop_member = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   switch_handle_t nhop_member_handle = SWITCH_API_INVALID_HANDLE;
 
@@ -353,9 +327,7 @@ switch_status_t switch_api_add_nhop_member (
     krnlmon_log_error(
         "nhop member add Failed on device %d nhop group handle 0x%lx: "
         "parameters invalid:(%s)\n",
-        device,
-        nhop_group_handle,
-        switch_error_to_string(status));
+        device, nhop_group_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -365,9 +337,7 @@ switch_status_t switch_api_add_nhop_member (
     krnlmon_log_error(
         "nhop member add Failed on device %d nhop group handle 0x%lx: "
         "nhop group get Failed:(%s)\n",
-        device,
-        nhop_group_handle,
-        switch_error_to_string(status));
+        device, nhop_group_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -382,9 +352,7 @@ switch_status_t switch_api_add_nhop_member (
           "nhop member add Failed on device %d nhop group handle 0x%lx "
           "nhop handle 0x%lx: "
           "nhop get Failed:(%s)\n",
-          device,
-          nhop_group_handle,
-          nhop_handle,
+          device, nhop_group_handle, nhop_handle,
           switch_error_to_string(status));
       return status;
     }
@@ -396,9 +364,7 @@ switch_status_t switch_api_add_nhop_member (
           "nhop member add Failed on device %d nhop group handle 0x%lx "
           "nhop handle 0x%lx: "
           "nhop member create Failed:(%s)\n",
-          device,
-          nhop_group_handle,
-          nhop_handle,
+          device, nhop_group_handle, nhop_handle,
           switch_error_to_string(status));
       return status;
     }
@@ -409,9 +375,7 @@ switch_status_t switch_api_add_nhop_member (
           "nhop member add Failed on device %d nhop group handle 0x%lx "
           "nhop handle 0x%lx: "
           "nhop member get Failed:(%s)\n",
-          device,
-          nhop_group_handle,
-          nhop_handle,
+          device, nhop_group_handle, nhop_handle,
           switch_error_to_string(status));
       return status;
     }
@@ -422,22 +386,19 @@ switch_status_t switch_api_add_nhop_member (
     nhop_member->nhop_handle = nhop_handle;
     nhop_member->active = true;
 
-    status = SWITCH_LIST_INSERT(
-        &(nhop_group_info->members), &(nhop_member->node), nhop_member);
+    status = SWITCH_LIST_INSERT(&(nhop_group_info->members),
+                                &(nhop_member->node), nhop_member);
     SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
 
-    status =
-        switch_nhop_add_to_group_member_list(device, nhop_info,
-                                             nhop_member_handle);
+    status = switch_nhop_add_to_group_member_list(device, nhop_info,
+                                                  nhop_member_handle);
     if (status != SWITCH_STATUS_SUCCESS) {
       krnlmon_log_error(
           "Failed to add nhop member_handle to nhop , device %d"
           " nhop handle 0x%lx: "
           " nhop_member_handle: 0x%lx"
           " with status (%s)\n",
-          device,
-          nhop_info->nhop_handle,
-          nhop_member_handle,
+          device, nhop_info->nhop_handle, nhop_member_handle,
           switch_error_to_string(status));
       return status;
     }
@@ -447,21 +408,19 @@ switch_status_t switch_api_add_nhop_member (
    * based on number of nhops here update the table for each hash-nhop entry */
   krnlmon_log_info(
       "nhop member add on device %d nhop_group handle 0x%lx num nhops %d\n",
-      device,
-      nhop_group_handle,
-      num_nhops);
+      device, nhop_group_handle, num_nhops);
 
   return status;
 }
 
-switch_status_t switch_api_delete_nhop_group(const switch_device_t device,
-                                       const switch_handle_t nhop_group_handle) {
+switch_status_t switch_api_delete_nhop_group(
+    const switch_device_t device, const switch_handle_t nhop_group_handle) {
   switch_uint32_t index = 0;
-  switch_node_t *node = NULL;
+  switch_node_t* node = NULL;
   switch_uint32_t num_nhops = 0;
-  switch_handle_t *nhop_handles = NULL;
-  switch_nhop_group_info_t *nhop_group_info = NULL;
-  switch_nhop_member_t *nhop_member = NULL;
+  switch_handle_t* nhop_handles = NULL;
+  switch_nhop_group_info_t* nhop_group_info = NULL;
+  switch_nhop_member_t* nhop_member = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(SWITCH_NHOP_GROUP_HANDLE(nhop_group_handle));
@@ -470,9 +429,7 @@ switch_status_t switch_api_delete_nhop_group(const switch_device_t device,
     krnlmon_log_error(
         "nhop_group delete failed on device %d nhop_group handle 0x%lx: "
         "nhop_group handle invalid:(%s)\n",
-        device,
-        nhop_group_handle,
-        switch_error_to_string(status));
+        device, nhop_group_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -481,9 +438,7 @@ switch_status_t switch_api_delete_nhop_group(const switch_device_t device,
     krnlmon_log_error(
         "nhop_group delete failed on device %d nhop_group handle 0x%lx: "
         "nhop_group get failed:(%s)\n",
-        device,
-        nhop_group_handle,
-        switch_error_to_string(status));
+        device, nhop_group_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -496,27 +451,23 @@ switch_status_t switch_api_delete_nhop_group(const switch_device_t device,
       krnlmon_log_error(
           "nhop_group delete failed on device %d nhop_group handle 0x%lx: "
           "memory allocation failed:(%s)\n",
-          device,
-          nhop_group_handle,
-          switch_error_to_string(status));
+          device, nhop_group_handle, switch_error_to_string(status));
       return status;
     }
 
     FOR_EACH_IN_LIST(nhop_group_info->members, node) {
-      nhop_member = (switch_nhop_member_t *)node->data;
+      nhop_member = (switch_nhop_member_t*)node->data;
       nhop_handles[index++] = nhop_member->nhop_handle;
     }
     FOR_EACH_IN_LIST_END();
 
-    status = switch_api_delete_nhop_member(
-        device, nhop_group_handle, num_nhops, nhop_handles);
+    status = switch_api_delete_nhop_member(device, nhop_group_handle, num_nhops,
+                                           nhop_handles);
     if (status != SWITCH_STATUS_SUCCESS) {
       krnlmon_log_error(
           "nhop_group delete failed on device %d nhop_group handle 0x%lx: "
           "nhop_group member delete failed:(%s)\n",
-          device,
-          nhop_group_handle,
-          switch_error_to_string(status));
+          device, nhop_group_handle, switch_error_to_string(status));
       SWITCH_FREE(device, nhop_handles);
       return status;
     }
@@ -527,18 +478,18 @@ switch_status_t switch_api_delete_nhop_group(const switch_device_t device,
   status = switch_nhop_group_delete_handle(device, nhop_group_handle);
   SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
 
-  krnlmon_log_debug("nhop_group handle deleted on device %d nhop_group handle "
-		    "0x%lx\n", device, nhop_group_handle);
+  krnlmon_log_debug(
+      "nhop_group handle deleted on device %d nhop_group handle "
+      "0x%lx\n",
+      device, nhop_group_handle);
 
   return status;
 }
 
 switch_status_t switch_api_nhop_group_get_by_nhop_member(
-    const switch_device_t device,
-    const switch_handle_t nhop_member_handle,
-    switch_handle_t *nhop_group_handle,
-    switch_handle_t *nhop_handle) {
-  switch_nhop_member_t *nhop_member = NULL;
+    const switch_device_t device, const switch_handle_t nhop_member_handle,
+    switch_handle_t* nhop_group_handle, switch_handle_t* nhop_handle) {
+  switch_nhop_member_t* nhop_member = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(SWITCH_NHOP_MEMBER_HANDLE(nhop_member_handle));
@@ -547,9 +498,7 @@ switch_status_t switch_api_nhop_group_get_by_nhop_member(
     krnlmon_log_error(
         "nhop member get failed on device %d "
         "nhop_group handle 0x%lx: invalid nhop_group handle(%s)",
-        device,
-        nhop_member_handle,
-        switch_error_to_string(status));
+        device, nhop_member_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -560,51 +509,45 @@ switch_status_t switch_api_nhop_group_get_by_nhop_member(
 }
 
 switch_status_t switch_nhop_member_get_from_nhop(
-    const switch_device_t device,
-    const switch_handle_t nhop_group_handle,
-    const switch_handle_t nhop_handle,
-    switch_nhop_member_t **nhop_member) {
-  switch_nhop_group_info_t *nhop_group_info = NULL;
-  switch_nhop_member_t *tmp_nhop_member = NULL;
-  switch_node_t *node = NULL;
+    const switch_device_t device, const switch_handle_t nhop_group_handle,
+    const switch_handle_t nhop_handle, switch_nhop_member_t** nhop_member) {
+  switch_nhop_group_info_t* nhop_group_info = NULL;
+  switch_nhop_member_t* tmp_nhop_member = NULL;
+  switch_node_t* node = NULL;
   bool member_found = FALSE;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!nhop_member) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
-    krnlmon_log_error("Failed to get nhop member on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("Failed to get nhop member on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
   if (!SWITCH_NHOP_GROUP_HANDLE(nhop_group_handle)) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("Failed to get nhop_group member on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+                      device, switch_error_to_string(status));
     return status;
   }
 
   SWITCH_ASSERT(SWITCH_NHOP_HANDLE(nhop_handle));
   if (!SWITCH_NHOP_HANDLE(nhop_handle)) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
-    krnlmon_log_error("Failed to get nhop member on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("Failed to get nhop member on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
   status = switch_nhop_get_group(device, nhop_group_handle, &nhop_group_info);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("Failed to get nhop member on device %d: %s",
-                     device,
-                     switch_error_to_string(status));
+    krnlmon_log_error("Failed to get nhop member on device %d: %s", device,
+                      switch_error_to_string(status));
     return status;
   }
 
   FOR_EACH_IN_LIST(nhop_group_info->members, node) {
-    tmp_nhop_member = (switch_nhop_member_t *)node->data;
+    tmp_nhop_member = (switch_nhop_member_t*)node->data;
     if (tmp_nhop_member->nhop_handle == nhop_handle) {
       member_found = TRUE;
       *nhop_member = tmp_nhop_member;
@@ -622,8 +565,7 @@ switch_status_t switch_nhop_member_get_from_nhop(
 }
 
 switch_status_t switch_nhop_remove_from_group_member_list(
-    switch_device_t device,
-    switch_nhop_info_t *nhop_info,
+    switch_device_t device, switch_nhop_info_t* nhop_info,
     switch_handle_t nhop_mem_handle) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
@@ -633,9 +575,7 @@ switch_status_t switch_nhop_remove_from_group_member_list(
     krnlmon_log_error(
         "nhop remove nhop mem Failed on device %d, "
         "nhop handle 0x%lx: , nhop mem handle 0x%lx\n",
-        device,
-        nhop_info->nhop_handle,
-        nhop_mem_handle);
+        device, nhop_info->nhop_handle, nhop_mem_handle);
     return SWITCH_STATUS_FAILURE;
   }
 
@@ -643,22 +583,18 @@ switch_status_t switch_nhop_remove_from_group_member_list(
   krnlmon_log_info(
       "nhop remove nhop mem success on device %d, "
       "nhop handle 0x%lx: , nhop mem handle 0x%lx: ref_cnt: %d\n",
-      device,
-      nhop_info->nhop_handle,
-      nhop_mem_handle,
+      device, nhop_info->nhop_handle, nhop_mem_handle,
       SWITCH_NHOP_NUM_NHOP_MEMBER_REF(nhop_info));
 
   return status;
 }
 
 switch_status_t switch_api_delete_nhop_member(
-    const switch_device_t device,
-    const switch_handle_t nhop_group_handle,
-    const switch_uint32_t num_nhops,
-    const switch_handle_t *nhop_handles) {
-  switch_nhop_info_t *nhop_info = NULL;
-  switch_nhop_group_info_t *nhop_group_info = NULL;
-  switch_nhop_member_t *nhop_member = NULL;
+    const switch_device_t device, const switch_handle_t nhop_group_handle,
+    const switch_uint32_t num_nhops, const switch_handle_t* nhop_handles) {
+  switch_nhop_info_t* nhop_info = NULL;
+  switch_nhop_group_info_t* nhop_group_info = NULL;
+  switch_nhop_member_t* nhop_member = NULL;
   switch_handle_t nhop_handle = 0;
   switch_handle_t member_handle = SWITCH_API_INVALID_HANDLE;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
@@ -669,9 +605,7 @@ switch_status_t switch_api_delete_nhop_member(
     krnlmon_log_error(
         "nhop member delete Failed on device %d nhop_group handle 0x%lx: "
         "parameters invalid:(%s)\n",
-        device,
-        nhop_group_handle,
-        switch_error_to_string(status));
+        device, nhop_group_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -680,9 +614,7 @@ switch_status_t switch_api_delete_nhop_member(
     krnlmon_log_error(
         "nhop member delete Failed on device %d nhop_group handle 0x%lx: "
         "nhop_group handle invalid:(%s)\n",
-        device,
-        nhop_group_handle,
-        switch_error_to_string(status));
+        device, nhop_group_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -691,9 +623,7 @@ switch_status_t switch_api_delete_nhop_member(
     krnlmon_log_error(
         "nhop member delete Failed on device %d nhop_group handle 0x%lx: "
         "nhop_group get Failed:(%s)\n",
-        device,
-        nhop_group_handle,
-        switch_error_to_string(status));
+        device, nhop_group_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -706,9 +636,7 @@ switch_status_t switch_api_delete_nhop_member(
           "nhop member delete Failed on device %d nhop_group handle 0x%lx "
           "nhop handle 0x%lx: "
           "nhop handle invalid:(%s)\n",
-          device,
-          nhop_group_handle,
-          nhop_handle,
+          device, nhop_group_handle, nhop_handle,
           switch_error_to_string(status));
       return status;
     }
@@ -719,43 +647,38 @@ switch_status_t switch_api_delete_nhop_member(
           "nhop member delete Failed on device %d nhop_group handle 0x%lx "
           "nhop handle 0x%lx: "
           "nhop get Failed:(%s)\n",
-          device,
-          nhop_group_handle,
-          nhop_handle,
+          device, nhop_group_handle, nhop_handle,
           switch_error_to_string(status));
       return status;
     }
 
-    status = switch_nhop_member_get_from_nhop(
-        device, nhop_group_handle, nhop_handle, &nhop_member);
+    status = switch_nhop_member_get_from_nhop(device, nhop_group_handle,
+                                              nhop_handle, &nhop_member);
     if (status != SWITCH_STATUS_SUCCESS) {
       krnlmon_log_error(
           "nhop member delete Failed on device %d nhop_group handle 0x%lx "
           "nhop handle 0x%lx: "
           "nhop_group member from nhop Failed:(%s)\n",
-          device,
-          nhop_group_handle,
-          nhop_handle,
+          device, nhop_group_handle, nhop_handle,
           switch_error_to_string(status));
       return status;
     }
 
     member_handle = nhop_member->member_handle;
-    status =
-        switch_nhop_remove_from_group_member_list(device, nhop_info, member_handle);
+    status = switch_nhop_remove_from_group_member_list(device, nhop_info,
+                                                       member_handle);
     if (status != SWITCH_STATUS_SUCCESS) {
       krnlmon_log_error(
           "nhop member delete Failed on device %d nhop_group handle 0x%lx "
           "nhop handle 0x%lx: "
           "nhop_group member list remove Failed:(%s)\n",
-          device,
-          nhop_group_handle,
-          nhop_handle,
+          device, nhop_group_handle, nhop_handle,
           switch_error_to_string(status));
       return status;
     }
 
-    status = SWITCH_LIST_DELETE(&(nhop_group_info->members), &(nhop_member->node));
+    status =
+        SWITCH_LIST_DELETE(&(nhop_group_info->members), &(nhop_member->node));
     SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
 
     status = switch_nhop_delete_member_handle(device, member_handle);
@@ -764,21 +687,19 @@ switch_status_t switch_api_delete_nhop_member(
 
   krnlmon_log_info(
       "nhop member deleted on device %d nhop_group handle 0x%lx num nhops %d\n",
-      device,
-      nhop_group_handle,
-      num_nhops);
+      device, nhop_group_handle, num_nhops);
 
   return status;
 }
 
-switch_status_t switch_api_delete_nhop_members (
+switch_status_t switch_api_delete_nhop_members(
     switch_device_t device, switch_handle_t nhop_group_handle) {
   switch_uint32_t index = 0;
   switch_uint32_t num_nhops = 0;
-  switch_node_t *node = NULL;
-  switch_nhop_group_info_t *nhop_group_info = NULL;
-  switch_handle_t *nhop_handles = NULL;
-  switch_nhop_member_t *nhop_member = NULL;
+  switch_node_t* node = NULL;
+  switch_nhop_group_info_t* nhop_group_info = NULL;
+  switch_handle_t* nhop_handles = NULL;
+  switch_nhop_member_t* nhop_member = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!SWITCH_NHOP_GROUP_HANDLE(nhop_group_handle)) {
@@ -786,9 +707,7 @@ switch_status_t switch_api_delete_nhop_members (
     krnlmon_log_error(
         "nhop members delete Failed on device %d nhop_group handle 0x%lx: "
         "nhop_group handle invalid:(%s)\n",
-        device,
-        nhop_group_handle,
-        switch_error_to_string(status));
+        device, nhop_group_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -797,9 +716,7 @@ switch_status_t switch_api_delete_nhop_members (
     krnlmon_log_error(
         "nhop members delete Failed on device %d nhop_group handle 0x%lx: "
         "nhop_group get Failed:(%s)\n",
-        device,
-        nhop_group_handle,
-        switch_error_to_string(status));
+        device, nhop_group_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -808,9 +725,7 @@ switch_status_t switch_api_delete_nhop_members (
     krnlmon_log_error(
         "nhop members delete Failed on device %d nhop_group handle 0x%lx: "
         "handle type not nhop_group:(%s)\n",
-        device,
-        nhop_group_handle,
-        switch_error_to_string(status));
+        device, nhop_group_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -823,62 +738,56 @@ switch_status_t switch_api_delete_nhop_members (
       krnlmon_log_error(
           "nhop members delete Failed on device %d nhop_group handle 0x%lx: "
           "nhop handles malloc Failed:(%s)\n",
-          device,
-          nhop_group_handle,
-          switch_error_to_string(status));
+          device, nhop_group_handle, switch_error_to_string(status));
       return status;
     }
 
     FOR_EACH_IN_LIST(nhop_group_info->members, node) {
-      nhop_member = (switch_nhop_member_t *)node->data;
+      nhop_member = (switch_nhop_member_t*)node->data;
       nhop_handles[index++] = nhop_member->nhop_handle;
     }
     FOR_EACH_IN_LIST_END();
 
-    status = switch_api_delete_nhop_member(
-        device, nhop_group_handle, num_nhops, nhop_handles);
+    status = switch_api_delete_nhop_member(device, nhop_group_handle, num_nhops,
+                                           nhop_handles);
     if (status != SWITCH_STATUS_SUCCESS) {
       krnlmon_log_error(
           "nhop members delete Failed on device %d nhop_group handle 0x%lx: "
           "nhop member delete Failed:(%s)\n",
-          device,
-          nhop_group_handle,
-          switch_error_to_string(status));
+          device, nhop_group_handle, switch_error_to_string(status));
       SWITCH_FREE(device, nhop_handles);
       return status;
     }
     SWITCH_FREE(device, nhop_handles);
   }
 
-  krnlmon_log_info("nhop members deleted on device %d nhop_group handle 0x%lx\n",
-                   device,
-                   nhop_group_handle);
+  krnlmon_log_info(
+      "nhop members deleted on device %d nhop_group handle 0x%lx\n", device,
+      nhop_group_handle);
 
   return status;
 }
 
 switch_status_t switch_api_nhop_create(
-    const switch_device_t device,
-    const switch_api_nhop_info_t *api_nhop_info,
-    switch_handle_t *nhop_handle) {
-  switch_nhop_context_t *nhop_ctx = NULL;
-  switch_nhop_info_t *nhop_info = NULL;
-  switch_spath_info_t *spath_info = NULL;
+    const switch_device_t device, const switch_api_nhop_info_t* api_nhop_info,
+    switch_handle_t* nhop_handle) {
+  switch_nhop_context_t* nhop_ctx = NULL;
+  switch_nhop_info_t* nhop_info = NULL;
+  switch_spath_info_t* spath_info = NULL;
   switch_nhop_key_t nhop_key = {0};
   switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
-  switch_pd_routing_info_t pd_routing_info; //TODO
+  switch_pd_routing_info_t pd_routing_info;  // TODO
 
   memset(&pd_routing_info, 0, sizeof(switch_pd_routing_info_t));
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_NHOP, (void **)&nhop_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_NHOP,
+                                         (void**)&nhop_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "nhop create Failed on device %d: "
         "nhop context get Failed:(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -894,8 +803,7 @@ switch_status_t switch_api_nhop_create(
     krnlmon_log_error(
         "nhop create Failed on device %d: "
         "nhop get Failed:(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -903,8 +811,7 @@ switch_status_t switch_api_nhop_create(
     krnlmon_log_info(
         "nhop create Failed on device %d nhop handle 0x%lx: "
         "nhop already exists\n",
-        device,
-        handle);
+        device, handle);
     status = switch_nhop_get(device, handle, &nhop_info);
     SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
     nhop_info->nhop_ref_count++;
@@ -918,8 +825,7 @@ switch_status_t switch_api_nhop_create(
     krnlmon_log_error(
         "nhop create Failed on device %d "
         "nhop handle create Failed:(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -928,8 +834,7 @@ switch_status_t switch_api_nhop_create(
     krnlmon_log_error(
         "nhop create Failed on device %d "
         "nhop get Failed:(%s)\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -947,54 +852,47 @@ switch_status_t switch_api_nhop_create(
   spath_info->nhop_handle = handle;
   spath_info->tunnel = FALSE;
 
-  SWITCH_MEMCPY(&spath_info->api_nhop_info,
-                api_nhop_info,
+  SWITCH_MEMCPY(&spath_info->api_nhop_info, api_nhop_info,
                 sizeof(switch_api_nhop_info_t));
   SWITCH_MEMCPY(&spath_info->nhop_key, &nhop_key, sizeof(nhop_key));
 
- /* Backend programming for nhop create is not needed because Neighbor
-  * create will call a nexthop create always before creating neighbor.
-  * So, backend programming should happen with Neighbor create only,
-  * by the time neighbor create happens already nexthop would have been created. 
-  * Vice-versa will not happen */
-  SWITCH_MEMCPY(&nhop_info->switch_pd_routing_info,
-                &pd_routing_info,
+  /* Backend programming for nhop create is not needed because Neighbor
+   * create will call a nexthop create always before creating neighbor.
+   * So, backend programming should happen with Neighbor create only,
+   * by the time neighbor create happens already nexthop would have been
+   * created. Vice-versa will not happen */
+  SWITCH_MEMCPY(&nhop_info->switch_pd_routing_info, &pd_routing_info,
                 sizeof(switch_pd_routing_info_t));
 
-  status = SWITCH_HASHTABLE_INSERT(&nhop_ctx->nhop_hashtable,
-                                   &(nhop_info->node),
-                                   (void *)&nhop_key,
-                                   (void *)nhop_info);
+  status =
+      SWITCH_HASHTABLE_INSERT(&nhop_ctx->nhop_hashtable, &(nhop_info->node),
+                              (void*)&nhop_key, (void*)nhop_info);
   SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
 
   *nhop_handle = handle;
 
-  krnlmon_log_info(
-      "nhop created on device %d nhop handle 0x%lx\n", device, handle);
+  krnlmon_log_info("nhop created on device %d nhop handle 0x%lx\n", device,
+                   handle);
 
   return status;
 }
 
-switch_status_t switch_api_nhop_delete(
-    const switch_device_t device, const switch_handle_t nhop_handle) {
-  switch_nhop_context_t *nhop_ctx = NULL;
-  switch_nhop_info_t *nhop_info = NULL;
-  switch_api_nhop_info_t *api_nhop_info = NULL;
-  switch_spath_info_t *spath_info = NULL;
+switch_status_t switch_api_nhop_delete(const switch_device_t device,
+                                       const switch_handle_t nhop_handle) {
+  switch_nhop_context_t* nhop_ctx = NULL;
+  switch_nhop_info_t* nhop_info = NULL;
+  switch_api_nhop_info_t* api_nhop_info = NULL;
+  switch_spath_info_t* spath_info = NULL;
   switch_nhop_key_t nhop_key = {0};
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
-
-
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_NHOP, (void **)&nhop_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_NHOP,
+                                         (void**)&nhop_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "nhop delete Failed on device %d nhop handle 0x%lx: "
         "nhop device context get Failed:(%s)\n",
-        device,
-        nhop_handle,
-        switch_error_to_string(status));
+        device, nhop_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -1003,9 +901,7 @@ switch_status_t switch_api_nhop_delete(
     krnlmon_log_error(
         "nhop delete Failed on device %d nhop handle 0x%lx: "
         "nhop handle invalid:(%s)\n",
-        device,
-        nhop_handle,
-        switch_error_to_string(status));
+        device, nhop_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -1014,9 +910,7 @@ switch_status_t switch_api_nhop_delete(
     krnlmon_log_error(
         "nhop delete Failed on device %d nhop handle 0x%lx: "
         "nhop get Failed:(%s)\n",
-        device,
-        nhop_handle,
-        switch_error_to_string(status));
+        device, nhop_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -1025,9 +919,7 @@ switch_status_t switch_api_nhop_delete(
     krnlmon_log_error(
         "nhop delete Failed on device %d nhop handle 0x%lx: "
         "nhop id type invalid:(%s)\n",
-        device,
-        nhop_handle,
-        switch_error_to_string(status));
+        device, nhop_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -1046,30 +938,27 @@ switch_status_t switch_api_nhop_delete(
     krnlmon_log_error(
         "nhop delete Failed on device %d nhop handle 0x%lx: "
         "nhop is still in use, mark to free: %s\n",
-        device,
-        nhop_handle,
-        switch_error_to_string(status));
+        device, nhop_handle, switch_error_to_string(status));
     return status;
   }
 
-  status = SWITCH_HASHTABLE_DELETE(
-      &nhop_ctx->nhop_hashtable, (void *)(&nhop_key), (void **)&nhop_info);
+  status = SWITCH_HASHTABLE_DELETE(&nhop_ctx->nhop_hashtable,
+                                   (void*)(&nhop_key), (void**)&nhop_info);
   SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
 
   status = switch_nhop_handle_delete(device, nhop_handle, 1);
   SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
 
-  krnlmon_log_info(
-      "nhop deleted on device %d nhop handle 0x%lx\n", device, nhop_handle);
+  krnlmon_log_info("nhop deleted on device %d nhop handle 0x%lx\n", device,
+                   nhop_handle);
 
   return status;
 }
 
-switch_status_t switch_api_nhop_id_type_get(
-    const switch_device_t device,
-    const switch_handle_t nhop_handle,
-    switch_nhop_id_type_t *nhop_type) {
-  switch_nhop_info_t *nhop_info = NULL;
+switch_status_t switch_api_nhop_id_type_get(const switch_device_t device,
+                                            const switch_handle_t nhop_handle,
+                                            switch_nhop_id_type_t* nhop_type) {
+  switch_nhop_info_t* nhop_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!nhop_type || !nhop_handle) {
@@ -1085,24 +974,21 @@ switch_status_t switch_api_nhop_id_type_get(
     krnlmon_log_error(
         "nhop id type get Failed for "
         "device %d handle 0x%lx: %s\n",
-        device,
-        nhop_handle,
-        switch_error_to_string(status));
+        device, nhop_handle, switch_error_to_string(status));
     return status;
   }
 
   status = switch_nhop_get(device, nhop_handle, &nhop_info);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error("Failed to get nhop info on handle 0x%lx, error: %s\n",
-             nhop_handle,
-             switch_error_to_string(status));
+                      nhop_handle, switch_error_to_string(status));
     return status;
   }
 
-  if(nhop_info) {
-     *nhop_type = nhop_info->id_type;
+  if (nhop_info) {
+    *nhop_type = nhop_info->id_type;
   } else {
-     krnlmon_log_error("nhop info was null, status = %d", status);
+    krnlmon_log_error("nhop info was null, status = %d", status);
   }
 
   return status;

--- a/switchapi/es2k/switch_nhop.c
+++ b/switchapi/es2k/switch_nhop.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/es2k/switch_pd_fdb.c
+++ b/switchapi/es2k/switch_pd_fdb.c
@@ -15,1155 +15,1114 @@
  * limitations under the License.
  */
 
-#include "switchapi/switch_fdb.h"
 #include "switch_pd_fdb.h"
-
-#include "switchapi/switch_base_types.h"
-#include "switchapi/switch_internal.h"
-#include "switchapi/switch_rif_int.h"
-#include "switch_pd_p4_name_mapping.h"
-#include "switch_pd_utils.h"
 
 #include "bf_types.h"
 #include "port_mgr/dpdk/bf_dpdk_port_if.h"
+#include "switch_pd_p4_name_mapping.h"
+#include "switch_pd_utils.h"
+#include "switchapi/switch_base_types.h"
+#include "switchapi/switch_fdb.h"
+#include "switchapi/switch_internal.h"
+#include "switchapi/switch_rif_int.h"
 
 switch_status_t switch_pd_l2_tx_forward_table_entry(
-    switch_device_t device,
-    const switch_api_l2_info_t *api_l2_tx_info,
-    const switch_api_tunnel_info_t *api_tunnel_info,
-    bool entry_add) {
+    switch_device_t device, const switch_api_l2_info_t* api_l2_tx_info,
+    const switch_api_tunnel_info_t* api_tunnel_info, bool entry_add) {
+  tdi_status_t status;
 
-    tdi_status_t status;
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
 
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
+  tdi_dev_id_t dev_id = device;
 
-    tdi_dev_id_t dev_id = device;
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
+  uint32_t network_byte_order = 0;
 
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
-    uint32_t network_byte_order = 0;
+  krnlmon_log_debug("%s", __func__);
 
-    krnlmon_log_debug("%s", __func__);
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
-    }
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_flags_create(0, &flags_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
-    }
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_device_get(dev_id, &dev_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
-    }
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_target_create(dev_hdl, &target_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
-    }
-    
-    status = tdi_session_create(dev_hdl, &session);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
-    }
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_L2_FWD_TX_TABLE,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                 LNW_L2_FWD_TX_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_L2_FWD_TX_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_L2_FWD_TX_TABLE_KEY_DST_MAC,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-                LNW_L2_FWD_TX_TABLE_KEY_DST_MAC, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_set_value_ptr(key_hdl, field_id, 
-                                         (const uint8_t *)
-                                         &api_l2_tx_info->dst_mac.mac_addr,
-                                         SWITCH_MAC_LENGTH);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d, error: %d",
-                 field_id, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_L2_FWD_TX_TABLE_KEY_TUN_FLAG,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-                LNW_L2_FWD_TX_TABLE_KEY_TUN_FLAG, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_set_value(key_hdl, field_id, 0);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d"
-                 ", error: %d", field_id, status);
-        goto dealloc_resources;
-    }
-
-    if (entry_add &&
-        api_l2_tx_info->learn_from == SWITCH_L2_FWD_LEARN_TUNNEL_INTERFACE) {
-
-        krnlmon_log_info("Populate set_tunnel action in %s for tunnel "
-                  "interface %x", LNW_L2_FWD_TX_TABLE,
-                  (unsigned int)api_l2_tx_info->rif_handle);
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_L2_FWD_TX_TABLE_ACTION_SET_TUNNEL,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_L2_FWD_TX_TABLE_ACTION_SET_TUNNEL, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id,
-                                                &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_SET_TUNNEL_PARAM_TUNNEL_ID,
-                                                   action_id,
-                                                   &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                    LNW_ACTION_SET_TUNNEL_PARAM_TUNNEL_ID, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value_ptr(data_hdl,
-                                              data_field_id,
-                                              0,
-                                              sizeof(uint32_t));
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_SET_TUNNEL_PARAM_DST_ADDR,
-                                                   action_id,
-                                                   &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_SET_TUNNEL_PARAM_DST_ADDR, status);
-            goto dealloc_resources;
-        }
-
-        network_byte_order = ntohl(api_tunnel_info->dst_ip.ip.v4addr);
-        status = tdi_data_field_set_value_ptr(data_hdl, data_field_id,
-                                              (const uint8_t *)
-                                              &network_byte_order,
-                                              sizeof(uint32_t));
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add %s table entry, error: %d", 
-                   LNW_L2_FWD_TX_TABLE, status);
-            goto dealloc_resources;
-        }
-
-    } else if (entry_add &&
-               api_l2_tx_info->learn_from ==
-               SWITCH_L2_FWD_LEARN_VLAN_INTERFACE) {
-
-        krnlmon_log_info("Populate l2_fwd action in %s "
-                  "for VLAN netdev: vlan%d",
-                  LNW_L2_FWD_TX_TABLE,
-                  api_l2_tx_info->port_id+1);
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl,
-                                                action_id,
-                                                &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_L2_FWD_PARAM_PORT,
-                                                   action_id,
-                                                   &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_L2_FWD_PARAM_PORT, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                          api_l2_tx_info->port_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add %s table entry, error: %d", 
-                    LNW_L2_FWD_TX_TABLE, status);
-            goto dealloc_resources;
-        }
-
-    } else if (entry_add &&
-               (api_l2_tx_info->learn_from ==
-               SWITCH_L2_FWD_LEARN_PHYSICAL_INTERFACE) &&
-	       SWITCH_RIF_HANDLE(api_l2_tx_info->rif_handle)) {
-
-        krnlmon_log_info("Populate l2_fwd action in %s "
-                  "for physical port: %d",
-                  LNW_L2_FWD_TX_TABLE, api_l2_tx_info->port_id);
-        
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id,
-                                                &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_L2_FWD_PARAM_PORT,
-                                                   action_id,
-                                                   &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_L2_FWD_PARAM_PORT, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                          api_l2_tx_info->port_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to add %s entry, error: %d",
+  status = tdi_table_from_name_get(info_hdl, LNW_L2_FWD_TX_TABLE, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
                       LNW_L2_FWD_TX_TABLE, status);
-            goto dealloc_resources;
-        }
-    } else if (entry_add && SWITCH_LAG_HANDLE(api_l2_tx_info->rif_handle)) {
-        krnlmon_log_info("Populate l2_fwd_lag action in %s ", LNW_L2_FWD_TX_TABLE);
+    goto dealloc_resources;
+  }
 
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD_LAG,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD_LAG, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id,
-                                                &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_L2_FWD_LAG_PARAM_LAG_ID,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_L2_FWD_LAG_PARAM_LAG_ID, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                          (api_l2_tx_info->rif_handle &
-                                          ~(SWITCH_HANDLE_TYPE_LAG <<
-                                          SWITCH_HANDLE_TYPE_SHIFT)));
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to add %s entry, error: %d",
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
                       LNW_L2_FWD_TX_TABLE, status);
-            goto dealloc_resources;
-        }
-    } else {
-        /* Delete an entry from target */
-        status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                     flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete %s table entry, error: %d", 
-                     LNW_L2_FWD_TX_TABLE, status);
-            goto dealloc_resources;
-        }
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table, error: %d",
+                      status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(table_info_hdl, LNW_L2_FWD_TX_TABLE_KEY_DST_MAC,
+                                &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_L2_FWD_TX_TABLE_KEY_DST_MAC, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_set_value_ptr(
+      key_hdl, field_id, (const uint8_t*)&api_l2_tx_info->dst_mac.mac_addr,
+      SWITCH_MAC_LENGTH);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to set value for key ID: %d, error: %d", field_id,
+                      status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(table_info_hdl,
+                                LNW_L2_FWD_TX_TABLE_KEY_TUN_FLAG, &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_L2_FWD_TX_TABLE_KEY_TUN_FLAG, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_set_value(key_hdl, field_id, 0);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to set value for key ID: %d"
+        ", error: %d",
+        field_id, status);
+    goto dealloc_resources;
+  }
+
+  if (entry_add &&
+      api_l2_tx_info->learn_from == SWITCH_L2_FWD_LEARN_TUNNEL_INTERFACE) {
+    krnlmon_log_info(
+        "Populate set_tunnel action in %s for tunnel "
+        "interface %x",
+        LNW_L2_FWD_TX_TABLE, (unsigned int)api_l2_tx_info->rif_handle);
+
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_L2_FWD_TX_TABLE_ACTION_SET_TUNNEL, &action_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_L2_FWD_TX_TABLE_ACTION_SET_TUNNEL, status);
+      goto dealloc_resources;
     }
+
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_SET_TUNNEL_PARAM_TUNNEL_ID, action_id,
+        &data_field_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_SET_TUNNEL_PARAM_TUNNEL_ID, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_set_value_ptr(data_hdl, data_field_id, 0,
+                                          sizeof(uint32_t));
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_SET_TUNNEL_PARAM_DST_ADDR, action_id,
+        &data_field_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_SET_TUNNEL_PARAM_DST_ADDR, status);
+      goto dealloc_resources;
+    }
+
+    network_byte_order = ntohl(api_tunnel_info->dst_ip.ip.v4addr);
+    status = tdi_data_field_set_value_ptr(data_hdl, data_field_id,
+                                          (const uint8_t*)&network_byte_order,
+                                          sizeof(uint32_t));
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to add %s table entry, error: %d",
+                        LNW_L2_FWD_TX_TABLE, status);
+      goto dealloc_resources;
+    }
+
+  } else if (entry_add &&
+             api_l2_tx_info->learn_from == SWITCH_L2_FWD_LEARN_VLAN_INTERFACE) {
+    krnlmon_log_info(
+        "Populate l2_fwd action in %s "
+        "for VLAN netdev: vlan%d",
+        LNW_L2_FWD_TX_TABLE, api_l2_tx_info->port_id + 1);
+
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD, &action_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_id_with_action_get(table_info_hdl,
+                                               LNW_ACTION_L2_FWD_PARAM_PORT,
+                                               action_id, &data_field_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_L2_FWD_PARAM_PORT, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_set_value(data_hdl, data_field_id,
+                                      api_l2_tx_info->port_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to add %s table entry, error: %d",
+                        LNW_L2_FWD_TX_TABLE, status);
+      goto dealloc_resources;
+    }
+
+  } else if (entry_add &&
+             (api_l2_tx_info->learn_from ==
+              SWITCH_L2_FWD_LEARN_PHYSICAL_INTERFACE) &&
+             SWITCH_RIF_HANDLE(api_l2_tx_info->rif_handle)) {
+    krnlmon_log_info(
+        "Populate l2_fwd action in %s "
+        "for physical port: %d",
+        LNW_L2_FWD_TX_TABLE, api_l2_tx_info->port_id);
+
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD, &action_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_id_with_action_get(table_info_hdl,
+                                               LNW_ACTION_L2_FWD_PARAM_PORT,
+                                               action_id, &data_field_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_L2_FWD_PARAM_PORT, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_set_value(data_hdl, data_field_id,
+                                      api_l2_tx_info->port_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to add %s entry, error: %d",
+                        LNW_L2_FWD_TX_TABLE, status);
+      goto dealloc_resources;
+    }
+  } else if (entry_add && SWITCH_LAG_HANDLE(api_l2_tx_info->rif_handle)) {
+    krnlmon_log_info("Populate l2_fwd_lag action in %s ", LNW_L2_FWD_TX_TABLE);
+
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD_LAG, &action_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD_LAG, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_L2_FWD_LAG_PARAM_LAG_ID, action_id,
+        &data_field_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_L2_FWD_LAG_PARAM_LAG_ID, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_set_value(
+        data_hdl, data_field_id,
+        (api_l2_tx_info->rif_handle &
+         ~(SWITCH_HANDLE_TYPE_LAG << SWITCH_HANDLE_TYPE_SHIFT)));
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to add %s entry, error: %d",
+                        LNW_L2_FWD_TX_TABLE, status);
+      goto dealloc_resources;
+    }
+  } else {
+    /* Delete an entry from target */
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to delete %s table entry, error: %d",
+                        LNW_L2_FWD_TX_TABLE, status);
+      goto dealloc_resources;
+    }
+  }
 
 dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
 }
 
 switch_status_t switch_pd_l2_tx_ipv6_forward_table_entry(
-    switch_device_t device,
-    const switch_api_l2_info_t *api_l2_tx_info,
-    const switch_api_tunnel_info_t *api_tunnel_info,
-    bool entry_add) {
+    switch_device_t device, const switch_api_l2_info_t* api_l2_tx_info,
+    const switch_api_tunnel_info_t* api_tunnel_info, bool entry_add) {
+  tdi_status_t status;
 
-    tdi_status_t status;
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
 
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
+  tdi_dev_id_t dev_id = device;
 
-    tdi_dev_id_t dev_id = device;
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
 
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
+  krnlmon_log_debug("%s", __func__);
 
-    krnlmon_log_debug("%s", __func__);
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
-    }
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_flags_create(0, &flags_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
-    }
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_device_get(dev_id, &dev_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
-    }
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_target_create(dev_hdl, &target_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
-    }
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_session_create(dev_hdl, &session);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_L2_FWD_TX_IPV6_TABLE,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                 LNW_L2_FWD_TX_IPV6_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_L2_FWD_TX_IPV6_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_L2_FWD_TX_IPV6_TABLE_KEY_DST_MAC,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-                LNW_L2_FWD_TX_IPV6_TABLE_KEY_DST_MAC, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_set_value_ptr(key_hdl, field_id,
-                                         (const uint8_t *)
-                                         &api_l2_tx_info->dst_mac.mac_addr,
-                                         SWITCH_MAC_LENGTH);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d, error: %d",
-                 field_id, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_L2_FWD_TX_IPV6_TABLE_KEY_TUN_FLAG,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-                LNW_L2_FWD_TX_IPV6_TABLE_KEY_TUN_FLAG, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_set_value(key_hdl, field_id, 0);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d"
-                 ", error: %d", field_id, status);
-        goto dealloc_resources;
-    }
-
-    if (entry_add &&
-        (api_l2_tx_info->learn_from ==
-        SWITCH_L2_FWD_LEARN_PHYSICAL_INTERFACE) &&
-	SWITCH_RIF_HANDLE(api_l2_tx_info->rif_handle)) {
-
-        krnlmon_log_info("Populate l2_fwd action in %s "
-                  "for physical port: %d",
-                  LNW_L2_FWD_TX_IPV6_TABLE, api_l2_tx_info->port_id);
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_L2_FWD_TX_IPV6_TABLE_ACTION_L2_FWD,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_L2_FWD_TX_IPV6_TABLE_ACTION_L2_FWD, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id,
-                                                &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_L2_FWD_PARAM_PORT,
-                                                   action_id,
-                                                   &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_L2_FWD_PARAM_PORT, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                          api_l2_tx_info->port_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to add %s entry, error: %d",
+  status =
+      tdi_table_from_name_get(info_hdl, LNW_L2_FWD_TX_IPV6_TABLE, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
                       LNW_L2_FWD_TX_IPV6_TABLE, status);
-            goto dealloc_resources;
-        }
-    } else if (entry_add && SWITCH_LAG_HANDLE(api_l2_tx_info->rif_handle)) {
+    goto dealloc_resources;
+  }
 
-        krnlmon_log_info("Populate l2_fwd_lag action in %s ",
-                  LNW_L2_FWD_TX_IPV6_TABLE);
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_L2_FWD_TX_IPV6_TABLE_ACTION_L2_FWD_LAG,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_L2_FWD_TX_IPV6_TABLE_ACTION_L2_FWD_LAG, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id,
-                                                &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_L2_FWD_LAG_PARAM_LAG_ID,
-                                                   action_id,
-                                                   &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_L2_FWD_LAG_PARAM_LAG_ID, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                          (api_l2_tx_info->rif_handle &
-                                          ~(SWITCH_HANDLE_TYPE_LAG <<
-                                          SWITCH_HANDLE_TYPE_SHIFT)));
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to add %s entry, error: %d",
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
                       LNW_L2_FWD_TX_IPV6_TABLE, status);
-            goto dealloc_resources;
-        }
-    } else {
-        /* Delete an entry from target */
-        status = tdi_table_entry_del(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete %s table entry, error: %d",
-                     LNW_L2_FWD_TX_IPV6_TABLE, status);
-            goto dealloc_resources;
-        }
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table, error: %d",
+                      status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(
+      table_info_hdl, LNW_L2_FWD_TX_IPV6_TABLE_KEY_DST_MAC, &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_L2_FWD_TX_IPV6_TABLE_KEY_DST_MAC, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_set_value_ptr(
+      key_hdl, field_id, (const uint8_t*)&api_l2_tx_info->dst_mac.mac_addr,
+      SWITCH_MAC_LENGTH);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to set value for key ID: %d, error: %d", field_id,
+                      status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(
+      table_info_hdl, LNW_L2_FWD_TX_IPV6_TABLE_KEY_TUN_FLAG, &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_L2_FWD_TX_IPV6_TABLE_KEY_TUN_FLAG, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_set_value(key_hdl, field_id, 0);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to set value for key ID: %d"
+        ", error: %d",
+        field_id, status);
+    goto dealloc_resources;
+  }
+
+  if (entry_add &&
+      (api_l2_tx_info->learn_from == SWITCH_L2_FWD_LEARN_PHYSICAL_INTERFACE) &&
+      SWITCH_RIF_HANDLE(api_l2_tx_info->rif_handle)) {
+    krnlmon_log_info(
+        "Populate l2_fwd action in %s "
+        "for physical port: %d",
+        LNW_L2_FWD_TX_IPV6_TABLE, api_l2_tx_info->port_id);
+
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_L2_FWD_TX_IPV6_TABLE_ACTION_L2_FWD, &action_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_L2_FWD_TX_IPV6_TABLE_ACTION_L2_FWD, status);
+      goto dealloc_resources;
     }
+
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_id_with_action_get(table_info_hdl,
+                                               LNW_ACTION_L2_FWD_PARAM_PORT,
+                                               action_id, &data_field_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_L2_FWD_PARAM_PORT, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_set_value(data_hdl, data_field_id,
+                                      api_l2_tx_info->port_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to add %s entry, error: %d",
+                        LNW_L2_FWD_TX_IPV6_TABLE, status);
+      goto dealloc_resources;
+    }
+  } else if (entry_add && SWITCH_LAG_HANDLE(api_l2_tx_info->rif_handle)) {
+    krnlmon_log_info("Populate l2_fwd_lag action in %s ",
+                     LNW_L2_FWD_TX_IPV6_TABLE);
+
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_L2_FWD_TX_IPV6_TABLE_ACTION_L2_FWD_LAG, &action_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_L2_FWD_TX_IPV6_TABLE_ACTION_L2_FWD_LAG, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_L2_FWD_LAG_PARAM_LAG_ID, action_id,
+        &data_field_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_L2_FWD_LAG_PARAM_LAG_ID, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_set_value(
+        data_hdl, data_field_id,
+        (api_l2_tx_info->rif_handle &
+         ~(SWITCH_HANDLE_TYPE_LAG << SWITCH_HANDLE_TYPE_SHIFT)));
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to add %s entry, error: %d",
+                        LNW_L2_FWD_TX_IPV6_TABLE, status);
+      goto dealloc_resources;
+    }
+  } else {
+    /* Delete an entry from target */
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to delete %s table entry, error: %d",
+                        LNW_L2_FWD_TX_IPV6_TABLE, status);
+      goto dealloc_resources;
+    }
+  }
 
 dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
 }
 
 switch_status_t switch_pd_sem_bypass_table_entry(
-    switch_device_t device,
-    const switch_api_l2_info_t *api_l2_tx_info,
-    const switch_api_tunnel_info_t *api_tunnel_info,
-    bool entry_add) {
+    switch_device_t device, const switch_api_l2_info_t* api_l2_tx_info,
+    const switch_api_tunnel_info_t* api_tunnel_info, bool entry_add) {
+  tdi_status_t status;
 
-    tdi_status_t status;
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
 
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
+  tdi_dev_id_t dev_id = device;
 
-    tdi_dev_id_t dev_id = device;
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
 
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
+  switch_handle_t rif_handle;
+  switch_rif_info_t* rif_info = NULL;
+  switch_port_t port_id;
 
-    switch_handle_t rif_handle;
-    switch_rif_info_t *rif_info = NULL;
-    switch_port_t port_id;
+  krnlmon_log_debug("%s", __func__);
 
-    krnlmon_log_debug("%s", __func__);
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_from_name_get(info_hdl, LNW_SEM_BYPASS_TABLE, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_SEM_BYPASS_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_SEM_BYPASS_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to get table info handle for table, "
+        "error: %d",
+        status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(table_info_hdl,
+                                LNW_SEM_BYPASS_TABLE_KEY_DST_MAC, &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_SEM_BYPASS_TABLE_KEY_DST_MAC, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_set_value_ptr(
+      key_hdl, field_id, (const uint8_t*)&api_l2_tx_info->dst_mac.mac_addr,
+      SWITCH_MAC_LENGTH);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to set value for key ID: %d, error: %d", field_id,
+                      status);
+    goto dealloc_resources;
+  }
+
+  if (entry_add) {
+    krnlmon_log_info(
+        "Populate set_dest action in %s for tunnel "
+        "interface %x",
+        LNW_SEM_BYPASS_TABLE, (unsigned int)api_l2_tx_info->rif_handle);
+
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_SEM_BYPASS_TABLE_ACTION_SET_DEST, &action_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error(
+          "Unable to get action allocator ID for: %s, "
+          "error: %d",
+          LNW_SEM_BYPASS_TABLE_ACTION_SET_DEST, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_flags_create(0, &flags_hdl);
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_device_get(dev_id, &dev_hdl);
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_SET_DEST_PARAM_PORT_ID, action_id,
+        &data_field_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error(
+          "Unable to get data field id param for: %s, "
+          "error: %d",
+          LNW_ACTION_SET_DEST_PARAM_PORT_ID, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_target_create(dev_hdl, &target_hdl);
+    status = tdi_data_field_set_value(data_hdl, data_field_id,
+                                      api_l2_tx_info->port_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_session_create(dev_hdl, &session);
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to add %s table entry, error: %d",
+                        LNW_SEM_BYPASS_TABLE, status);
+      goto dealloc_resources;
     }
-
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_SEM_BYPASS_TABLE,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                           LNW_SEM_BYPASS_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  } else {
+    /* Delete an entry from target */
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                           LNW_SEM_BYPASS_TABLE, status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to delete %s entry, error: %d",
+                        LNW_SEM_BYPASS_TABLE, status);
+      goto dealloc_resources;
     }
-
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table, "
-			  "error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_SEM_BYPASS_TABLE_KEY_DST_MAC,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-                         LNW_SEM_BYPASS_TABLE_KEY_DST_MAC, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_set_value_ptr(key_hdl, field_id,
-                                         (const uint8_t *)&api_l2_tx_info->dst_mac.mac_addr,
-                                         SWITCH_MAC_LENGTH);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d, error: %d",
-                           field_id, status);
-        goto dealloc_resources;
-    }
-
-    if (entry_add) {
-        krnlmon_log_info("Populate set_dest action in %s for tunnel "
-                         "interface %x", LNW_SEM_BYPASS_TABLE,
-                          (unsigned int)api_l2_tx_info->rif_handle);
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_SEM_BYPASS_TABLE_ACTION_SET_DEST,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, "
-			      "error: %d",
-			       LNW_SEM_BYPASS_TABLE_ACTION_SET_DEST,
-			       status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id,
-                                                &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                              "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_SET_DEST_PARAM_PORT_ID,
-                                                   action_id,
-                                                   &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, "
-			      "error: %d",
-                               LNW_ACTION_SET_DEST_PARAM_PORT_ID, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                          api_l2_tx_info->port_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                               data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add %s table entry, error: %d", 
-                             LNW_SEM_BYPASS_TABLE, status);
-            goto dealloc_resources;
-        }
-    } else {
-        /* Delete an entry from target */
-        status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                    flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete %s entry, error: %d", 
-                               LNW_SEM_BYPASS_TABLE, status);
-            goto dealloc_resources;
-        }
-    }
+  }
 dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
 }
 
 switch_status_t switch_pd_l2_rx_forward_table_entry(
-    switch_device_t device,
-    const switch_api_l2_info_t *api_l2_rx_info,
+    switch_device_t device, const switch_api_l2_info_t* api_l2_rx_info,
     bool entry_add) {
+  tdi_status_t status;
 
-    tdi_status_t status;
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
 
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
+  tdi_dev_id_t dev_id = device;
 
-    tdi_dev_id_t dev_id = device;
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
 
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
+  switch_handle_t rif_handle;
+  switch_rif_info_t* rif_info = NULL;
+  switch_port_t port_id;
 
-    switch_handle_t rif_handle;
-    switch_rif_info_t *rif_info = NULL;
-    switch_port_t port_id;
+  krnlmon_log_debug("%s", __func__);
 
-    krnlmon_log_debug("%s", __func__);
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_from_name_get(info_hdl, LNW_L2_FWD_RX_TABLE, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_L2_FWD_RX_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_L2_FWD_RX_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table, error: %d",
+                      status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(table_info_hdl, LNW_L2_FWD_RX_TABLE_KEY_DST_MAC,
+                                &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_L2_FWD_RX_TABLE_KEY_DST_MAC, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_set_value_ptr(
+      key_hdl, field_id, (const uint8_t*)&api_l2_rx_info->dst_mac.mac_addr,
+      SWITCH_MAC_LENGTH);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to set value for key ID: %d, error: %d", field_id,
+                      status);
+    goto dealloc_resources;
+  }
+
+  if (entry_add && SWITCH_RIF_HANDLE(api_l2_rx_info->rif_handle)) {
+    /* Add an entry to target */
+    krnlmon_log_info(
+        "Populate l2_fwd action in %s for rif handle "
+        "%x ",
+        LNW_L2_FWD_RX_TABLE, (unsigned int)api_l2_rx_info->rif_handle);
+
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_L2_FWD_RX_TABLE_ACTION_L2_FWD, &action_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_L2_FWD_RX_TABLE_ACTION_L2_FWD, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_flags_create(0, &flags_hdl);
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_device_get(dev_id, &dev_hdl);
+    rif_handle = api_l2_rx_info->rif_handle;
+    switch_status_t switch_status =
+        switch_rif_get(device, rif_handle, &rif_info);
+    if (switch_status != SWITCH_STATUS_SUCCESS) {
+      krnlmon_log_error("Unable to get rif info, error: %d", switch_status);
+      goto dealloc_resources;
+    }
+
+    /* While matching l2_fwd_rx_table should receive packet on phy-port
+     * and send to control port. */
+    port_id = rif_info->api_rif_info.port_id;
+
+    status = tdi_data_field_id_with_action_get(table_info_hdl,
+                                               LNW_ACTION_L2_FWD_PARAM_PORT,
+                                               action_id, &data_field_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_L2_FWD_PARAM_PORT, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_target_create(dev_hdl, &target_hdl);
+    status = tdi_data_field_set_value(data_hdl, data_field_id, port_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_session_create(dev_hdl, &session);
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to add %s table entry, error: %d",
+                        LNW_L2_FWD_RX_TABLE, status);
+      goto dealloc_resources;
     }
+  } else if (entry_add && SWITCH_LAG_HANDLE(api_l2_rx_info->rif_handle)) {
+    /* Add an entry to target */
+    krnlmon_log_info(
+        "Populate l2_fwd_rx_lag action in %s for lag handle "
+        "%x ",
+        LNW_L2_FWD_RX_TABLE, (unsigned int)api_l2_rx_info->rif_handle);
 
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_L2_FWD_RX_TABLE,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                 LNW_L2_FWD_RX_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_L2_FWD_RX_TABLE_ACTION_RX_L2_FWD_LAG, &action_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_L2_FWD_RX_TABLE, status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_L2_FWD_RX_TABLE_ACTION_RX_L2_FWD_LAG, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_L2_FWD_RX_TABLE_KEY_DST_MAC,
-                                  &field_id);
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_RX_L2_FWD_LAG_PARAM_LAG_ID, action_id,
+        &data_field_id);
     if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_L2_FWD_RX_TABLE_KEY_DST_MAC, status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_RX_L2_FWD_LAG_PARAM_LAG_ID, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_key_field_set_value_ptr(key_hdl, field_id, 
-                                         (const uint8_t *)
-                                         &api_l2_rx_info->dst_mac.mac_addr, 
-                                         SWITCH_MAC_LENGTH);
+    status = tdi_data_field_set_value(
+        data_hdl, data_field_id,
+        (api_l2_rx_info->rif_handle &
+         ~(SWITCH_HANDLE_TYPE_LAG << SWITCH_HANDLE_TYPE_SHIFT)));
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d, error: %d",
-                 field_id, status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
     }
 
-    if (entry_add && SWITCH_RIF_HANDLE(api_l2_rx_info->rif_handle)) {
-        /* Add an entry to target */
-        krnlmon_log_info("Populate l2_fwd action in %s for rif handle "
-                  "%x ", LNW_L2_FWD_RX_TABLE,
-                  (unsigned int) api_l2_rx_info->rif_handle);
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_L2_FWD_RX_TABLE_ACTION_L2_FWD,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_L2_FWD_RX_TABLE_ACTION_L2_FWD, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id,
-                                                &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        rif_handle = api_l2_rx_info->rif_handle;
-        switch_status_t switch_status = switch_rif_get(device,
-                                                       rif_handle,
-                                                       &rif_info);
-        if (switch_status != SWITCH_STATUS_SUCCESS) {
-            krnlmon_log_error("Unable to get rif info, error: %d", switch_status);
-            goto dealloc_resources;
-        }
-
-        /* While matching l2_fwd_rx_table should receive packet on phy-port
-         * and send to control port. */
-        port_id = rif_info->api_rif_info.port_id;
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_L2_FWD_PARAM_PORT,
-                                                   action_id,
-                                                   &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_L2_FWD_PARAM_PORT, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id, port_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add %s table entry, error: %d", 
-                   LNW_L2_FWD_RX_TABLE, status);
-            goto dealloc_resources;
-        }
-    } else if (entry_add && SWITCH_LAG_HANDLE(api_l2_rx_info->rif_handle)) {
-       /* Add an entry to target */
-        krnlmon_log_info("Populate l2_fwd_rx_lag action in %s for lag handle "
-                  "%x ", LNW_L2_FWD_RX_TABLE,
-                  (unsigned int) api_l2_rx_info->rif_handle);
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_L2_FWD_RX_TABLE_ACTION_RX_L2_FWD_LAG,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_L2_FWD_RX_TABLE_ACTION_RX_L2_FWD_LAG, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id,
-                                                &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_RX_L2_FWD_LAG_PARAM_LAG_ID,
-                                                   action_id,
-                                                   &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_RX_L2_FWD_LAG_PARAM_LAG_ID, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                          (api_l2_rx_info->rif_handle &
-                                          ~(SWITCH_HANDLE_TYPE_LAG <<
-                                          SWITCH_HANDLE_TYPE_SHIFT)));
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add %s table entry, error: %d",
-                   LNW_L2_FWD_RX_TABLE, status);
-            goto dealloc_resources;
-        }
-    } else {
-        /* Delete an entry from target */
-        status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                    flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete %s entry, error: %d", 
-                     LNW_L2_FWD_RX_TABLE, status);
-            goto dealloc_resources;
-        }
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to add %s table entry, error: %d",
+                        LNW_L2_FWD_RX_TABLE, status);
+      goto dealloc_resources;
     }
+  } else {
+    /* Delete an entry from target */
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to delete %s entry, error: %d",
+                        LNW_L2_FWD_RX_TABLE, status);
+      goto dealloc_resources;
+    }
+  }
 
 dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
 }
 
 switch_status_t switch_pd_l2_rx_forward_with_tunnel_table_entry(
-    switch_device_t device,
-    const switch_api_l2_info_t *api_l2_rx_info,
+    switch_device_t device, const switch_api_l2_info_t* api_l2_rx_info,
     bool entry_add) {
+  tdi_status_t status;
 
-    tdi_status_t status;
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
 
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
+  tdi_dev_id_t dev_id = device;
 
-    tdi_dev_id_t dev_id = device;
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
 
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
+  krnlmon_log_debug("%s", __func__);
 
-    krnlmon_log_debug("%s", __func__);
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_from_name_get(info_hdl, LNW_L2_FWD_RX_WITH_TUNNEL_TABLE,
+                                   &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_L2_FWD_RX_WITH_TUNNEL_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_L2_FWD_RX_WITH_TUNNEL_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table");
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(
+      table_info_hdl, LNW_L2_FWD_RX_WITH_TUNNEL_TABLE_KEY_DST_MAC, &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_L2_FWD_RX_WITH_TUNNEL_TABLE_KEY_DST_MAC, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_set_value_ptr(
+      key_hdl, field_id, (const uint8_t*)&api_l2_rx_info->dst_mac.mac_addr,
+      SWITCH_MAC_LENGTH);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to set value for key ID: %d", field_id);
+    goto dealloc_resources;
+  }
+
+  if (entry_add) {
+    /* Add an entry to target */
+    krnlmon_log_info("Populate l2_fwd action in %s for rif handle %x",
+                     LNW_L2_FWD_RX_WITH_TUNNEL_TABLE,
+                     (unsigned int)api_l2_rx_info->rif_handle);
+
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_L2_FWD_RX_WITH_TUNNEL_TABLE_ACTION_L2_FWD,
+        &action_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_L2_FWD_RX_WITH_TUNNEL_TABLE_ACTION_L2_FWD, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_flags_create(0, &flags_hdl);
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_device_get(dev_id, &dev_hdl);
+    status = tdi_data_field_id_with_action_get(table_info_hdl,
+                                               LNW_ACTION_L2_FWD_PARAM_PORT,
+                                               action_id, &data_field_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_L2_FWD_PARAM_PORT, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_target_create(dev_hdl, &target_hdl);
+    status = tdi_data_field_set_value(data_hdl, data_field_id,
+                                      api_l2_rx_info->port_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_session_create(dev_hdl, &session);
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to add %s entry, error: %d",
+                        LNW_L2_FWD_RX_WITH_TUNNEL_TABLE, status);
+      goto dealloc_resources;
     }
-
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_L2_FWD_RX_WITH_TUNNEL_TABLE,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                 LNW_L2_FWD_RX_WITH_TUNNEL_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  } else {
+    /* Delete an entry from target */
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_L2_FWD_RX_WITH_TUNNEL_TABLE, status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to delete %s entry, error: %d",
+                        LNW_L2_FWD_RX_WITH_TUNNEL_TABLE, status);
+      goto dealloc_resources;
     }
-
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table");
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_L2_FWD_RX_WITH_TUNNEL_TABLE_KEY_DST_MAC,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_L2_FWD_RX_WITH_TUNNEL_TABLE_KEY_DST_MAC, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_set_value_ptr(key_hdl, field_id, 
-                                         (const uint8_t *)
-                                         &api_l2_rx_info->dst_mac.mac_addr, 
-                                         SWITCH_MAC_LENGTH);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d", field_id);
-        goto dealloc_resources;
-    }
-
-    if (entry_add) {
-        /* Add an entry to target */
-        krnlmon_log_info("Populate l2_fwd action in %s for rif handle %x",
-                  LNW_L2_FWD_RX_WITH_TUNNEL_TABLE,
-                  (unsigned int) api_l2_rx_info->rif_handle);
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_L2_FWD_RX_WITH_TUNNEL_TABLE_ACTION_L2_FWD,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_L2_FWD_RX_WITH_TUNNEL_TABLE_ACTION_L2_FWD, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                    "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_L2_FWD_PARAM_PORT,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_L2_FWD_PARAM_PORT, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                          api_l2_rx_info->port_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add %s entry, error: %d", 
-                   LNW_L2_FWD_RX_WITH_TUNNEL_TABLE, status);
-            goto dealloc_resources;
-        }
-    } else {
-        /* Delete an entry from target */
-        status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                     flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete %s entry, error: %d", 
-                     LNW_L2_FWD_RX_WITH_TUNNEL_TABLE, status);
-            goto dealloc_resources;
-        }
-    }
+  }
 
 dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
 }

--- a/switchapi/es2k/switch_pd_fdb.c
+++ b/switchapi/es2k/switch_pd_fdb.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/es2k/switch_pd_fdb.h
+++ b/switchapi/es2k/switch_pd_fdb.h
@@ -18,45 +18,36 @@
 #ifndef __SWITCH_PD_FDB_H__
 #define __SWITCH_PD_FDB_H__
 
-#include "switchapi/switch_fdb.h"
-
 #include "switchapi/switch_base_types.h"
+#include "switchapi/switch_fdb.h"
 #include "switchapi/switch_handle.h"
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
 switch_status_t switch_pd_l2_tx_forward_table_entry(
-    switch_device_t device,
-    const switch_api_l2_info_t *api_l2_tx_info,
-    const switch_api_tunnel_info_t *api_tunnel_info_t,
-    bool entry_add);
+    switch_device_t device, const switch_api_l2_info_t* api_l2_tx_info,
+    const switch_api_tunnel_info_t* api_tunnel_info_t, bool entry_add);
 
 switch_status_t switch_pd_l2_tx_ipv6_forward_table_entry(
-    switch_device_t device,
-    const switch_api_l2_info_t *api_l2_tx_info,
-    const switch_api_tunnel_info_t *api_tunnel_info_t,
-    bool entry_add);
+    switch_device_t device, const switch_api_l2_info_t* api_l2_tx_info,
+    const switch_api_tunnel_info_t* api_tunnel_info_t, bool entry_add);
 
 switch_status_t switch_pd_l2_rx_forward_table_entry(
-    switch_device_t device,
-    const switch_api_l2_info_t *api_l2_rx_info,
+    switch_device_t device, const switch_api_l2_info_t* api_l2_rx_info,
     bool entry_add);
 
 switch_status_t switch_pd_l2_rx_forward_with_tunnel_table_entry(
-    switch_device_t device,
-    const switch_api_l2_info_t *api_l2_rx_info,
+    switch_device_t device, const switch_api_l2_info_t* api_l2_rx_info,
     bool entry_add);
 
 switch_status_t switch_pd_sem_bypass_table_entry(
-    switch_device_t device,
-    const switch_api_l2_info_t *api_l2_tx_info,
-    const switch_api_tunnel_info_t *api_tunnel_info,
-    bool entry_add);
+    switch_device_t device, const switch_api_l2_info_t* api_l2_tx_info,
+    const switch_api_tunnel_info_t* api_tunnel_info, bool entry_add);
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 }
 #endif
 
-#endif 
+#endif

--- a/switchapi/es2k/switch_pd_fdb.h
+++ b/switchapi/es2k/switch_pd_fdb.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/es2k/switch_pd_lag.c
+++ b/switchapi/es2k/switch_pd_lag.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Intel Corporation.
+ * Copyright 2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/es2k/switch_pd_lag.h
+++ b/switchapi/es2k/switch_pd_lag.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Intel Corporation.
+ * Copyright 2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/es2k/switch_pd_p4_name_mapping.h
+++ b/switchapi/es2k/switch_pd_p4_name_mapping.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2013-2021 Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/switchapi/es2k/switch_pd_p4_name_mapping.h
+++ b/switchapi/es2k/switch_pd_p4_name_mapping.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2022 Intel Corporation.
  *
  * SPDX-License-Identifier: Apache-2.0
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -28,219 +28,162 @@ extern "C" {
 
 /* VXLAN_ENCAP_MOD_TABLE */
 #define LNW_VXLAN_ENCAP_MOD_TABLE \
-        "linux_networking_control.vxlan_encap_mod_table"
+  "linux_networking_control.vxlan_encap_mod_table"
 
 #define LNW_VXLAN_ENCAP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR \
-          "vmeta.common.mod_blob_ptr"
+  "vmeta.common.mod_blob_ptr"
 
 #define LNW_VXLAN_ENCAP_MOD_TABLE_ACTION_VXLAN_ENCAP \
-        "linux_networking_control.vxlan_encap"
-#define LNW_ACTION_VXLAN_ENCAP_PARAM_SRC_ADDR \
-        "src_addr"
-#define LNW_ACTION_VXLAN_ENCAP_PARAM_DST_ADDR \
-        "dst_addr"
-#define LNW_ACTION_VXLAN_ENCAP_PARAM_DST_PORT \
-        "dst_port"
-#define LNW_ACTION_VXLAN_ENCAP_PARAM_VNI \
-        "vni"
+  "linux_networking_control.vxlan_encap"
+#define LNW_ACTION_VXLAN_ENCAP_PARAM_SRC_ADDR "src_addr"
+#define LNW_ACTION_VXLAN_ENCAP_PARAM_DST_ADDR "dst_addr"
+#define LNW_ACTION_VXLAN_ENCAP_PARAM_DST_PORT "dst_port"
+#define LNW_ACTION_VXLAN_ENCAP_PARAM_VNI "vni"
 
 /* VXLAN_DECAP_MOD_TABLE */
 #define LNW_VXLAN_DECAP_MOD_TABLE \
-        "linux_networking_control.vxlan_decap_mod_table"
+  "linux_networking_control.vxlan_decap_mod_table"
 
 #define LNW_VXLAN_DECAP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR \
-          "vmeta.common.mod_blob_ptr"
+  "vmeta.common.mod_blob_ptr"
 
 #define LNW_VXLAN_DECAP_MOD_TABLE_ACTION_VXLAN_DECAP_OUTER_IPV4 \
-        "linux_networking_control.vxlan_decap_outer_ipv4"
+  "linux_networking_control.vxlan_decap_outer_ipv4"
 
 /* RIF_MOD_TABLE */
-//Verified for MEV - 3 tables instead of 1
-#define LNW_RIF_MOD_TABLE_START \
-        "linux_networking_control.rif_mod_table_start"
+// Verified for MEV - 3 tables instead of 1
+#define LNW_RIF_MOD_TABLE_START "linux_networking_control.rif_mod_table_start"
 
-#define LNW_RIF_MOD_TABLE_START_KEY_RIF_MOD_MAP_ID0 \
-        "rif_mod_map_id0"
+#define LNW_RIF_MOD_TABLE_START_KEY_RIF_MOD_MAP_ID0 "rif_mod_map_id0"
 
 #define LNW_RIF_MOD_TABLE_START_ACTION_SET_SRC_MAC_START \
-        "linux_networking_control.set_src_mac_start"
+  "linux_networking_control.set_src_mac_start"
 
-#define LNW_RIF_MOD_TABLE_MID \
-        "linux_networking_control.rif_mod_table_mid"
+#define LNW_RIF_MOD_TABLE_MID "linux_networking_control.rif_mod_table_mid"
 
-#define LNW_RIF_MOD_TABLE_MID_KEY_RIF_MOD_MAP_ID1 \
-        "rif_mod_map_id1"
+#define LNW_RIF_MOD_TABLE_MID_KEY_RIF_MOD_MAP_ID1 "rif_mod_map_id1"
 
 #define LNW_RIF_MOD_TABLE_MID_ACTION_SET_SRC_MAC_MID \
-        "linux_networking_control.set_src_mac_mid"
+  "linux_networking_control.set_src_mac_mid"
 
-#define LNW_RIF_MOD_TABLE_LAST \
-        "linux_networking_control.rif_mod_table_last"
+#define LNW_RIF_MOD_TABLE_LAST "linux_networking_control.rif_mod_table_last"
 
-#define LNW_RIF_MOD_TABLE_LAST_KEY_RIF_MOD_MAP_ID2 \
-        "rif_mod_map_id2"
+#define LNW_RIF_MOD_TABLE_LAST_KEY_RIF_MOD_MAP_ID2 "rif_mod_map_id2"
 
 #define LNW_RIF_MOD_TABLE_LAST_ACTION_SET_SRC_MAC_LAST \
-        "linux_networking_control.set_src_mac_last"
+  "linux_networking_control.set_src_mac_last"
 
-#define LNW_ACTION_SET_SRC_MAC_PARAM_SRC_MAC_ADDR \
-        "arg"
-
+#define LNW_ACTION_SET_SRC_MAC_PARAM_SRC_MAC_ADDR "arg"
 
 /* NEIGHBOR_MOD_TABLE */
-#define LNW_NEIGHBOR_MOD_TABLE \
-        "linux_networking_control.neighbor_mod_table"
+#define LNW_NEIGHBOR_MOD_TABLE "linux_networking_control.neighbor_mod_table"
 
 #define LNW_NEIGHBOR_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR \
-        "vmeta.common.mod_blob_ptr"
+  "vmeta.common.mod_blob_ptr"
 
 #define LNW_NEIGHBOR_MOD_TABLE_ACTION_SET_OUTER_MAC \
-        "linux_networking_control.set_outer_mac"
-#define LNW_ACTION_SET_OUTER_MAC_PARAM_DST_MAC_ADDR \
-        "dst_mac_addr"
-
+  "linux_networking_control.set_outer_mac"
+#define LNW_ACTION_SET_OUTER_MAC_PARAM_DST_MAC_ADDR "dst_mac_addr"
 
 /* IPV4_TUNNEL_TERM_TABLE */
-//Verified for MEV
+// Verified for MEV
 #define LNW_IPV4_TUNNEL_TERM_TABLE \
-        "linux_networking_control.ipv4_tunnel_term_table"
+  "linux_networking_control.ipv4_tunnel_term_table"
 #define LNW_IPV4_TUNNEL_TERM_TABLE_KEY_TUNNEL_FLAG_TYPE \
-        "user_meta.pmeta.tun_flag1_d0"
-#define LNW_IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_SRC \
-        "ipv4_src"
-#define LNW_IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_DST \
-        "ipv4_dst"
+  "user_meta.pmeta.tun_flag1_d0"
+#define LNW_IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_SRC "ipv4_src"
+#define LNW_IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_DST "ipv4_dst"
 
 #define LNW_IPV4_TUNNEL_TERM_TABLE_ACTION_DECAP_OUTER_IPV4 \
-        "linux_networking_control.decap_outer_ipv4"
-#define LNW_ACTION_DECAP_OUTER_IPV4_PARAM_TUNNEL_ID \
-        "tunnel_id"
-
+  "linux_networking_control.decap_outer_ipv4"
+#define LNW_ACTION_DECAP_OUTER_IPV4_PARAM_TUNNEL_ID "tunnel_id"
 
 /* L2_FWD_RX_TABLE */
-#define LNW_L2_FWD_RX_TABLE \
-        "linux_networking_control.l2_fwd_rx_table"
+#define LNW_L2_FWD_RX_TABLE "linux_networking_control.l2_fwd_rx_table"
 
-#define LNW_L2_FWD_RX_TABLE_KEY_DST_MAC \
-        "dst_mac"
+#define LNW_L2_FWD_RX_TABLE_KEY_DST_MAC "dst_mac"
 
-#define LNW_L2_FWD_RX_TABLE_ACTION_L2_FWD \
-        "linux_networking_control.l2_fwd"
-#define LNW_ACTION_L2_FWD_PARAM_PORT \
-        "port"
+#define LNW_L2_FWD_RX_TABLE_ACTION_L2_FWD "linux_networking_control.l2_fwd"
+#define LNW_ACTION_L2_FWD_PARAM_PORT "port"
 #define LNW_L2_FWD_RX_TABLE_ACTION_RX_L2_FWD_LAG \
-        "linux_networking_control.rx_l2_fwd_lag"
-#define LNW_ACTION_RX_L2_FWD_LAG_PARAM_LAG_ID \
-        "lag_group_id"
-
+  "linux_networking_control.rx_l2_fwd_lag"
+#define LNW_ACTION_RX_L2_FWD_LAG_PARAM_LAG_ID "lag_group_id"
 
 /* RX_LAG_TABLE */
-#define LNW_RX_LAG_TABLE \
-        "linux_networking_control.rx_lag_table"
+#define LNW_RX_LAG_TABLE "linux_networking_control.rx_lag_table"
 
-#define LNW_RX_LAG_TABLE_KEY_PORT_ID \
-        "vmeta.common.port_id"
-#define LNW_RX_LAG_TABLE_KEY_LAG_ID \
-        "user_meta.cmeta.lag_group_id"
+#define LNW_RX_LAG_TABLE_KEY_PORT_ID "vmeta.common.port_id"
+#define LNW_RX_LAG_TABLE_KEY_LAG_ID "user_meta.cmeta.lag_group_id"
 
 #define LNW_RX_LAG_TABLE_ACTION_SET_EGRESS_PORT \
-        "linux_networking_control.set_egress_port"
-#define LNW_ACTION_SET_EGRESS_PORT_PARAM_EGRESS_PORT \
-        "egress_port"
-
+  "linux_networking_control.set_egress_port"
+#define LNW_ACTION_SET_EGRESS_PORT_PARAM_EGRESS_PORT "egress_port"
 
 /* L2_FWD_RX_WITH_TUNNEL_TABLE */
 #define LNW_L2_FWD_RX_WITH_TUNNEL_TABLE \
-        "linux_networking_control.l2_fwd_rx_with_tunnel_table"
+  "linux_networking_control.l2_fwd_rx_with_tunnel_table"
 
-#define LNW_L2_FWD_RX_WITH_TUNNEL_TABLE_KEY_DST_MAC \
-        "dst_mac"
+#define LNW_L2_FWD_RX_WITH_TUNNEL_TABLE_KEY_DST_MAC "dst_mac"
 
 #define LNW_L2_FWD_RX_WITH_TUNNEL_TABLE_ACTION_L2_FWD \
-        "linux_networking_control.l2_fwd"
-
+  "linux_networking_control.l2_fwd"
 
 /* L2_FWD_TX_TABLE */
-#define LNW_L2_FWD_TX_TABLE \
-        "linux_networking_control.l2_fwd_tx_table"
-#define LNW_L2_FWD_TX_TABLE_KEY_DST_MAC \
-        "dst_mac"
-#define LNW_L2_FWD_TX_TABLE_KEY_TUN_FLAG \
-        "user_meta.pmeta.tun_flag1_d0"
+#define LNW_L2_FWD_TX_TABLE "linux_networking_control.l2_fwd_tx_table"
+#define LNW_L2_FWD_TX_TABLE_KEY_DST_MAC "dst_mac"
+#define LNW_L2_FWD_TX_TABLE_KEY_TUN_FLAG "user_meta.pmeta.tun_flag1_d0"
 
-#define LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD \
-        "linux_networking_control.l2_fwd"
+#define LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD "linux_networking_control.l2_fwd"
 
 #define LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD_LAG \
-        "linux_networking_control.l2_fwd_lag"
-#define LNW_ACTION_L2_FWD_LAG_PARAM_LAG_ID \
-        "lag_group_id"
+  "linux_networking_control.l2_fwd_lag"
+#define LNW_ACTION_L2_FWD_LAG_PARAM_LAG_ID "lag_group_id"
 
 #define LNW_L2_FWD_TX_TABLE_ACTION_SET_TUNNEL \
-        "linux_networking_control.set_tunnel"
-#define LNW_ACTION_SET_TUNNEL_PARAM_TUNNEL_ID \
-        "tunnel_id"
-#define LNW_ACTION_SET_TUNNEL_PARAM_DST_ADDR \
-        "dst_addr"
-
+  "linux_networking_control.set_tunnel"
+#define LNW_ACTION_SET_TUNNEL_PARAM_TUNNEL_ID "tunnel_id"
+#define LNW_ACTION_SET_TUNNEL_PARAM_DST_ADDR "dst_addr"
 
 /* L2_FWD_TX_TABLE */
-#define LNW_L2_FWD_TX_IPV6_TABLE \
-        "linux_networking_control.l2_fwd_tx_ipv6_table"
-#define LNW_L2_FWD_TX_IPV6_TABLE_KEY_DST_MAC \
-        "dst_mac"
-#define LNW_L2_FWD_TX_IPV6_TABLE_KEY_TUN_FLAG \
-        "user_meta.pmeta.tun_flag1_d0"
+#define LNW_L2_FWD_TX_IPV6_TABLE "linux_networking_control.l2_fwd_tx_ipv6_table"
+#define LNW_L2_FWD_TX_IPV6_TABLE_KEY_DST_MAC "dst_mac"
+#define LNW_L2_FWD_TX_IPV6_TABLE_KEY_TUN_FLAG "user_meta.pmeta.tun_flag1_d0"
 
-#define LNW_L2_FWD_TX_IPV6_TABLE_ACTION_L2_FWD \
-        "linux_networking_control.l2_fwd"
+#define LNW_L2_FWD_TX_IPV6_TABLE_ACTION_L2_FWD "linux_networking_control.l2_fwd"
 
 #define LNW_L2_FWD_TX_IPV6_TABLE_ACTION_L2_FWD_LAG \
-        "linux_networking_control.l2_fwd_lag"
-
+  "linux_networking_control.l2_fwd_lag"
 
 /* NEXTHOP_TABLE */
-//Verified for MEV
-#define LNW_NEXTHOP_TABLE \
-        "linux_networking_control.nexthop_table"
+// Verified for MEV
+#define LNW_NEXTHOP_TABLE "linux_networking_control.nexthop_table"
 
-#define LNW_NEXTHOP_TABLE_KEY_NEXTHOP_ID \
-        "user_meta.cmeta.nexthop_id"
-#define LNW_NEXTHOP_TABLE_KEY_BIT32_ZEROS \
-        "user_meta.cmeta.bit32_zeros"
+#define LNW_NEXTHOP_TABLE_KEY_NEXTHOP_ID "user_meta.cmeta.nexthop_id"
+#define LNW_NEXTHOP_TABLE_KEY_BIT32_ZEROS "user_meta.cmeta.bit32_zeros"
 
 #define LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP \
-        "linux_networking_control.set_nexthop"
-#define LNW_ACTION_SET_NEXTHOP_PARAM_RIF \
-        "router_interface_id"
-#define LNW_ACTION_SET_NEXTHOP_PARAM_NEIGHBOR_ID \
-        "neighbor_id"
-#define LNW_ACTION_SET_NEXTHOP_PARAM_EGRESS_PORT \
-        "egress_port"
+  "linux_networking_control.set_nexthop"
+#define LNW_ACTION_SET_NEXTHOP_PARAM_RIF "router_interface_id"
+#define LNW_ACTION_SET_NEXTHOP_PARAM_NEIGHBOR_ID "neighbor_id"
+#define LNW_ACTION_SET_NEXTHOP_PARAM_EGRESS_PORT "egress_port"
 
 #define LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP_LAG \
-        "linux_networking_control.set_nexthop_lag"
-#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_RIF \
-        "router_interface_id"
-#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_NEIGHBOR_ID \
-        "neighbor_id"
-#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_LAG_ID \
-        "lag_group_id"
-
+  "linux_networking_control.set_nexthop_lag"
+#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_RIF "router_interface_id"
+#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_NEIGHBOR_ID "neighbor_id"
+#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_LAG_ID "lag_group_id"
 
 /* ECMP_HASH_TABLE */
-#define LNW_ECMP_HASH_TABLE \
-        "linux_networking_control.ecmp_hash_table"
+#define LNW_ECMP_HASH_TABLE "linux_networking_control.ecmp_hash_table"
 
 #define LNW_ECMP_HASH_TABLE_KEY_HOST_INFO_TX_EXT_FLEX \
-        "user_meta.cmeta.flex[15:0]"
-#define LNW_ECMP_HASH_TABLE_KEY_META_COMMON_HASH \
-        "vmeta.common.hash[2:0]"
+  "user_meta.cmeta.flex[15:0]"
+#define LNW_ECMP_HASH_TABLE_KEY_META_COMMON_HASH "vmeta.common.hash[2:0]"
 #define LNW_ECMP_HASH_TABLE_KEY_USER_META_BIT32_ZEROS \
-        "user_meta.cmeta.bit32_zeros[15:3]"
+  "user_meta.cmeta.bit32_zeros[15:3]"
 
 #define LNW_ECMP_HASH_TABLE_ACTION_SET_NEXTHOP_ID \
-        "linux_networking_control.set_nexthop_id"
+  "linux_networking_control.set_nexthop_id"
 
 #define LNW_ECMP_HASH_SIZE 65536
 
@@ -248,18 +191,14 @@ extern "C" {
  * check LNW_ECMP_HASH_TABLE_KEY_META_COMMON_HASH */
 #define LNW_ECMP_PER_GROUP_HASH_SIZE 8
 
-
 /* TX_LAG_TABLE */
-#define LNW_TX_LAG_TABLE \
-        "linux_networking_control.tx_lag_table"
+#define LNW_TX_LAG_TABLE "linux_networking_control.tx_lag_table"
 
-#define LNW_TX_LAG_TABLE_KEY_LAG_ID \
-        "user_meta.cmeta.lag_group_id"
-#define LNW_TX_LAG_TABLE_KEY_VMETA_COMMON_HASH \
-        "hash"
+#define LNW_TX_LAG_TABLE_KEY_LAG_ID "user_meta.cmeta.lag_group_id"
+#define LNW_TX_LAG_TABLE_KEY_VMETA_COMMON_HASH "hash"
 
 #define LNW_TX_LAG_TABLE_ACTION_SET_EGRESS_PORT \
-        "linux_networking_control.set_egress_port"
+  "linux_networking_control.set_egress_port"
 
 #define LNW_LAG_HASH_SIZE 65536
 
@@ -267,83 +206,67 @@ extern "C" {
  * check LNW_TX_LAG_TABLE_KEY_VMETA_COMMON_HASH */
 #define LNW_LAG_PER_GROUP_HASH_SIZE 8
 
-
 /* IPV4_TABLE */
-#define LNW_IPV4_TABLE \
-        "linux_networking_control.ipv4_table"
+#define LNW_IPV4_TABLE "linux_networking_control.ipv4_table"
 
-//TODO_LNW_MEV: One additional key for MEV(ipv4_table has 2 keys for MEV)
-#define LNW_IPV4_TABLE_KEY_IPV4_TABLE_LPM_ROOT \
-        "ipv4_table_lpm_root"
+// TODO_LNW_MEV: One additional key for MEV(ipv4_table has 2 keys for MEV)
+#define LNW_IPV4_TABLE_KEY_IPV4_TABLE_LPM_ROOT "ipv4_table_lpm_root"
 
-#define LNW_IPV4_TABLE_KEY_IPV4_DST_MATCH \
-        "ipv4_dst_match"
+#define LNW_IPV4_TABLE_KEY_IPV4_DST_MATCH "ipv4_dst_match"
 
 #define LNW_IPV4_TABLE_ACTION_IPV4_SET_NEXTHOP_ID \
-        "linux_networking_control.ipv4_set_nexthop_id"
-#define LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID \
-        "nexthop_id"
+  "linux_networking_control.ipv4_set_nexthop_id"
+#define LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID "nexthop_id"
 
 #define LNW_IPV4_TABLE_ACTION_IPV4_SET_NEXTHOP_ID_WITH_MIRROR \
-        "linux_networking_control.ipv4_set_nexthop_id_with_mirror"
+  "linux_networking_control.ipv4_set_nexthop_id_with_mirror"
 
 #define LNW_IPV4_TABLE_ACTION_ECMP_HASH_ACTION \
-        "linux_networking_control.ecmp_hash_action"
-#define LNW_ACTION_ECMP_HASH_ACTION_PARAM_ECMP_GROUP_ID \
-        "ecmp_group_id"
+  "linux_networking_control.ecmp_hash_action"
+#define LNW_ACTION_ECMP_HASH_ACTION_PARAM_ECMP_GROUP_ID "ecmp_group_id"
 
 /* IPV6_TABLE */
-#define LNW_IPV6_TABLE \
-        "linux_networking_control.ipv6_table"
+#define LNW_IPV6_TABLE "linux_networking_control.ipv6_table"
 
-//TODO_LNW_MEV: One additional key for MEV(ipv6_table has 2 keys for MEV)
-#define LNW_IPV6_TABLE_KEY_IPV6_TABLE_LPM_ROOT \
-        "ipv6_table_lpm_root"
+// TODO_LNW_MEV: One additional key for MEV(ipv6_table has 2 keys for MEV)
+#define LNW_IPV6_TABLE_KEY_IPV6_TABLE_LPM_ROOT "ipv6_table_lpm_root"
 
-#define LNW_IPV6_TABLE_KEY_IPV6_DST_MATCH \
-        "ipv6_dst_match"
+#define LNW_IPV6_TABLE_KEY_IPV6_DST_MATCH "ipv6_dst_match"
 
 #define LNW_IPV6_TABLE_ACTION_IPV6_SET_NEXTHOP_ID \
-        "linux_networking_control.ipv6_set_nexthop_id"
+  "linux_networking_control.ipv6_set_nexthop_id"
 
 #define LNW_IPV6_TABLE_ACTION_IPV6_SET_NEXTHOP_ID_WITH_MIRROR \
-        "linux_networking_control.ipv6_set_nexthop_id_with_mirror"
+  "linux_networking_control.ipv6_set_nexthop_id_with_mirror"
 
 #define LNW_IPV6_TABLE_ACTION_ECMP_V6_HASH_ACTION \
-        "linux_networking_control.ecmp_v6_hash_action"
+  "linux_networking_control.ecmp_v6_hash_action"
 
 /* SEM_BYPASS TABLE */
-#define LNW_SEM_BYPASS_TABLE \
-        "linux_networking_control.sem_bypass"
+#define LNW_SEM_BYPASS_TABLE "linux_networking_control.sem_bypass"
 
-#define LNW_SEM_BYPASS_TABLE_KEY_DST_MAC \
-        "dst_mac"
+#define LNW_SEM_BYPASS_TABLE_KEY_DST_MAC "dst_mac"
 
-#define LNW_SEM_BYPASS_TABLE_ACTION_SET_DEST \
-        "linux_networking_control.set_dest"
+#define LNW_SEM_BYPASS_TABLE_ACTION_SET_DEST "linux_networking_control.set_dest"
 
-#define LNW_ACTION_SET_DEST_PARAM_PORT_ID \
-        "port_id"
+#define LNW_ACTION_SET_DEST_PARAM_PORT_ID "port_id"
 
 /* HANDLE_TX_FROM_HOST_TO_OVS_AND_OVS_TO_WIRE_TABLE */
 #define LNW_HANDLE_TX_FROM_HOST_TO_OVS_AND_OVS_TO_WIRE_TABLE \
-     "linux_networking_control.handle_tx_from_host_to_ovs_and_ovs_to_wire_table"
+  "linux_networking_control.handle_tx_from_host_to_ovs_and_ovs_to_wire_table"
 
-#define LNW_HANDLE_OVS_TO_WIRE_TABLE_KEY_META_COMMON_VSI \
-     "vmeta.common.vsi"
+#define LNW_HANDLE_OVS_TO_WIRE_TABLE_KEY_META_COMMON_VSI "vmeta.common.vsi"
 
 #define LNW_HANDLE_OVS_TO_WIRE_TABLE_KEY_USER_META_BIT32_ZEROS \
-     "user_meta.cmeta.bit32_zeros"
+  "user_meta.cmeta.bit32_zeros"
 
 #define LNW_HANDLE_OVS_TO_WIRE_TABLE_ACTION_SET_DEST \
-     "linux_networking_control.set_dest"
+  "linux_networking_control.set_dest"
 
-#define LNW_HANDLE_OVS_TO_WIRE_TABLE_ACTION_SET_DEST_PARAM_PORT_ID \
-     "port_id"
+#define LNW_HANDLE_OVS_TO_WIRE_TABLE_ACTION_SET_DEST_PARAM_PORT_ID "port_id"
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* __SWITCH_PD_P4_NAME_MAPPING__ */
-

--- a/switchapi/es2k/switch_pd_routing.c
+++ b/switchapi/es2k/switch_pd_routing.c
@@ -17,1711 +17,1721 @@
 
 #include "switch_pd_routing.h"
 
+#include "port_mgr/dpdk/bf_dpdk_port_if.h"
+#include "switch_pd_p4_name_mapping.h"
+#include "switch_pd_utils.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_nhop_int.h"
-#include "switch_pd_p4_name_mapping.h"
-#include "switch_pd_utils.h"
-
-#include "port_mgr/dpdk/bf_dpdk_port_if.h"
 
 // Table match type definitions.
 #define NEXTHOP_TABLE_TERNARY_MATCH 1
 
-switch_status_t switch_routing_table_entry (
-        switch_device_t device,
-        const switch_pd_routing_info_t *api_routing_info,
-        bool entry_type)
-{
+switch_status_t switch_routing_table_entry(
+    switch_device_t device, const switch_pd_routing_info_t* api_routing_info,
+    bool entry_type) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   krnlmon_log_debug("%s", __func__);
 
-  //update nexthop table
+  // update nexthop table
   status = switch_pd_nexthop_table_entry(device, api_routing_info, entry_type);
-  if (status != SWITCH_STATUS_SUCCESS){
-     krnlmon_log_error("nexthop table update failed, error: %d", status);
-     return status;
+  if (status != SWITCH_STATUS_SUCCESS) {
+    krnlmon_log_error("nexthop table update failed, error: %d", status);
+    return status;
   }
 
-  //update neighbor mod table
+  // update neighbor mod table
   status = switch_pd_neighbor_table_entry(device, api_routing_info, entry_type);
-  if (status != SWITCH_STATUS_SUCCESS){
-      krnlmon_log_error( "neighbor table update failed, error: %d", status);
-      return status;
+  if (status != SWITCH_STATUS_SUCCESS) {
+    krnlmon_log_error("neighbor table update failed, error: %d", status);
+    return status;
   }
   return status;
 }
 
-switch_status_t switch_pd_rmac_table_entry (
-        switch_device_t device,
-        switch_rmac_entry_t *rmac_entry,
-        switch_handle_t rif_handle,
-        bool entry_type)
-{
+switch_status_t switch_pd_rmac_table_entry(switch_device_t device,
+                                           switch_rmac_entry_t* rmac_entry,
+                                           switch_handle_t rif_handle,
+                                           bool entry_type) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   krnlmon_log_debug("%s", __func__);
 
   if (!rmac_entry) {
-      krnlmon_log_error("Empty router_mac entry, error: %d", status);
-      return status;
+    krnlmon_log_error("Empty router_mac entry, error: %d", status);
+    return status;
   }
 
-  //update rif mod table start
-  status = switch_pd_rif_mod_start_entry(device, rmac_entry, rif_handle,
-		                         entry_type);
-  if (status != SWITCH_STATUS_SUCCESS){
-      krnlmon_log_error("rid mod table start entry failed, error: %d", status);
-      return status;
+  // update rif mod table start
+  status =
+      switch_pd_rif_mod_start_entry(device, rmac_entry, rif_handle, entry_type);
+  if (status != SWITCH_STATUS_SUCCESS) {
+    krnlmon_log_error("rid mod table start entry failed, error: %d", status);
+    return status;
   }
 
-  //update rif mod table mid
-  status = switch_pd_rif_mod_mid_entry(device, rmac_entry, rif_handle,
-		                       entry_type);
-  if (status != SWITCH_STATUS_SUCCESS){
-      krnlmon_log_error("rid mod table mid entry failed, error: %d", status);
-      return status;
+  // update rif mod table mid
+  status =
+      switch_pd_rif_mod_mid_entry(device, rmac_entry, rif_handle, entry_type);
+  if (status != SWITCH_STATUS_SUCCESS) {
+    krnlmon_log_error("rid mod table mid entry failed, error: %d", status);
+    return status;
   }
 
-  //update rif mod table last
-  status = switch_pd_rif_mod_last_entry(device, rmac_entry, rif_handle,
-		                        entry_type);
-  if (status != SWITCH_STATUS_SUCCESS){
-      krnlmon_log_error("rid mod table last entry failed, error: %d", status);
-      return status;
+  // update rif mod table last
+  status =
+      switch_pd_rif_mod_last_entry(device, rmac_entry, rif_handle, entry_type);
+  if (status != SWITCH_STATUS_SUCCESS) {
+    krnlmon_log_error("rid mod table last entry failed, error: %d", status);
+    return status;
   }
 
   return status;
 }
 
 switch_status_t switch_pd_nexthop_table_entry(
-    switch_device_t device,
-    const switch_pd_routing_info_t  *api_nexthop_pd_info,
+    switch_device_t device, const switch_pd_routing_info_t* api_nexthop_pd_info,
     bool entry_add) {
+  tdi_status_t status;
 
-    tdi_status_t status;
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
 
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
+  tdi_dev_id_t dev_id = device;
 
-    tdi_dev_id_t dev_id = device;
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
+  uint16_t network_byte_order_rif_id = 0;
+  uint16_t lag_id = 0;
 
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
-    uint16_t network_byte_order_rif_id = 0;
-    uint16_t lag_id = 0;
+  krnlmon_log_debug("%s", __func__);
 
-    krnlmon_log_debug("%s", __func__);
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
-    }
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_flags_create(0, &flags_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
-    }
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_device_get(dev_id, &dev_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
-    }
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_target_create(dev_hdl, &target_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
-    }
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_session_create(dev_hdl, &session);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
-    }
+  status = tdi_table_from_name_get(info_hdl, LNW_NEXTHOP_TABLE, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_NEXTHOP_TABLE, status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_table_from_name_get(info_hdl,
-                                       LNW_NEXTHOP_TABLE,
-                                       &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                 LNW_NEXTHOP_TABLE, status);
-        goto dealloc_resources;
-    }
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_NEXTHOP_TABLE, status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_NEXTHOP_TABLE, status);
-        goto dealloc_resources;
-    }
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to get table info handle for table, "
+        "error: %d",
+        status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table, "
-			  "error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_NEXTHOP_TABLE_KEY_NEXTHOP_ID,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_NEXTHOP_TABLE_KEY_NEXTHOP_ID, status);
-        goto dealloc_resources;
-    }
+  status = tdi_key_field_id_get(table_info_hdl,
+                                LNW_NEXTHOP_TABLE_KEY_NEXTHOP_ID, &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_NEXTHOP_TABLE_KEY_NEXTHOP_ID, status);
+    goto dealloc_resources;
+  }
 
 #if NEXTHOP_TABLE_TERNARY_MATCH
-    // When Nexthop table is of type ternary Match
-    status = tdi_key_field_set_value_and_mask(key_hdl, field_id,
-                                     (api_nexthop_pd_info->nexthop_handle &
-                                     ~(SWITCH_HANDLE_TYPE_NHOP <<
-                                     SWITCH_HANDLE_TYPE_SHIFT)), 0xFFFF);
+  // When Nexthop table is of type ternary Match
+  status = tdi_key_field_set_value_and_mask(
+      key_hdl, field_id,
+      (api_nexthop_pd_info->nexthop_handle &
+       ~(SWITCH_HANDLE_TYPE_NHOP << SWITCH_HANDLE_TYPE_SHIFT)),
+      0xFFFF);
 #else
-    // When Nexthop table is of type exact Match
-    status = tdi_key_field_set_value(key_hdl, field_id,
-                                     (api_nexthop_pd_info->nexthop_handle &
-                                     ~(SWITCH_HANDLE_TYPE_NHOP <<
-                                     SWITCH_HANDLE_TYPE_SHIFT)));
+  // When Nexthop table is of type exact Match
+  status = tdi_key_field_set_value(
+      key_hdl, field_id,
+      (api_nexthop_pd_info->nexthop_handle &
+       ~(SWITCH_HANDLE_TYPE_NHOP << SWITCH_HANDLE_TYPE_SHIFT)));
 #endif
 
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d for nexthop_table,"
-                          " error: %d", field_id, status);
-        goto dealloc_resources;
-    }
-
-    if (entry_add && SWITCH_RIF_HANDLE(api_nexthop_pd_info->rif_handle)) {
-        /* Add an entry to target */
-        krnlmon_log_info("Populate set_nexthop action with neighbor id: 0x%x in"
-                          " nexthop_table for nexthop_id 0x%x",
-                          (unsigned int) api_nexthop_pd_info->neighbor_handle,
-                          (unsigned int) api_nexthop_pd_info->nexthop_handle);
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, "
-			      "error: %d",
-                               LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id,
-			                        &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(
-                            table_info_hdl,
-                            LNW_ACTION_SET_NEXTHOP_PARAM_RIF,
-                            action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, "
-                              "error: %d",
-                               LNW_ACTION_SET_NEXTHOP_PARAM_RIF, status);
-            goto dealloc_resources;
-        }
-
-	// For ES2K we need to program RIF_id action in Big endian
-        network_byte_order_rif_id = api_nexthop_pd_info->rif_handle &
-                                     ~(SWITCH_HANDLE_TYPE_RIF <<
-                                     SWITCH_HANDLE_TYPE_SHIFT);
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                          network_byte_order_rif_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_SET_NEXTHOP_PARAM_NEIGHBOR_ID,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_SET_NEXTHOP_PARAM_NEIGHBOR_ID, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                          (api_nexthop_pd_info->neighbor_handle &
-                                          ~(SWITCH_HANDLE_TYPE_NEIGHBOR <<
-                                          SWITCH_HANDLE_TYPE_SHIFT)));
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_SET_NEXTHOP_PARAM_EGRESS_PORT,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                   LNW_ACTION_SET_NEXTHOP_PARAM_EGRESS_PORT, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                          api_nexthop_pd_info->port_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d", 
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add %s entry, error: %d", 
-                   LNW_NEXTHOP_TABLE, status);
-            goto dealloc_resources;
-        }
-    } else if (entry_add &&
-               SWITCH_LAG_HANDLE(api_nexthop_pd_info->rif_handle)) {
-
-        /* Add an entry to target */
-        krnlmon_log_info("Populate set_nexthop_lag with neighbor id: 0x%x"
-                          " in nexthop_table for nexthop_id 0x%x",
-                          (unsigned int) api_nexthop_pd_info->neighbor_handle,
-                          (unsigned int) api_nexthop_pd_info->nexthop_handle);
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP_LAG,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, "
-			      "error: %d",
-                               LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP_LAG, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id,
-			                        &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get( table_info_hdl,
-                     LNW_ACTION_SET_NEXTHOP_LAG_PARAM_RIF, action_id,
-                     &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, "
-                              "error: %d",
-                               LNW_ACTION_SET_NEXTHOP_LAG_PARAM_RIF, status);
-            goto dealloc_resources;
-        }
-
-        lag_id = api_nexthop_pd_info->rif_handle &
-            ~(SWITCH_HANDLE_TYPE_LAG << SWITCH_HANDLE_TYPE_SHIFT);
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                          lag_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                     LNW_ACTION_SET_NEXTHOP_LAG_PARAM_NEIGHBOR_ID,
-                     action_id, &data_field_id);
-
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_SET_NEXTHOP_LAG_PARAM_NEIGHBOR_ID, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                          (api_nexthop_pd_info->neighbor_handle &
-                                          ~(SWITCH_HANDLE_TYPE_NEIGHBOR <<
-                                          SWITCH_HANDLE_TYPE_SHIFT)));
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                     LNW_ACTION_SET_NEXTHOP_LAG_PARAM_LAG_ID,
-                     action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                   LNW_ACTION_SET_NEXTHOP_LAG_PARAM_LAG_ID, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                          lag_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d", 
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add %s entry, error: %d", 
-                   LNW_NEXTHOP_TABLE, status);
-            goto dealloc_resources;
-        }
-    } else {
-        /* Delete an entry from target */
-        krnlmon_log_info("Delete nexthop_table entry");
-        status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                     flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete %s entry, error: %d", 
-                     LNW_NEXTHOP_TABLE, status);
-            goto dealloc_resources;
-        }
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to set value for key ID: %d for nexthop_table,"
+        " error: %d",
+        field_id, status);
+    goto dealloc_resources;
   }
 
-dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
-}
+  if (entry_add && SWITCH_RIF_HANDLE(api_nexthop_pd_info->rif_handle)) {
+    /* Add an entry to target */
+    krnlmon_log_info(
+        "Populate set_nexthop action with neighbor id: 0x%x in"
+        " nexthop_table for nexthop_id 0x%x",
+        (unsigned int)api_nexthop_pd_info->neighbor_handle,
+        (unsigned int)api_nexthop_pd_info->nexthop_handle);
 
-switch_status_t switch_pd_neighbor_table_entry(
-    switch_device_t device,
-    const switch_pd_routing_info_t  *api_neighbor_pd_info,
-    bool entry_add) {
-
-    tdi_status_t status;
-
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
-
-    tdi_dev_id_t dev_id = device;
-
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
-
-    krnlmon_log_debug("%s", __func__);
-
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP, &action_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_flags_create(0, &flags_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_device_get(dev_id, &dev_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_target_create(dev_hdl, &target_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_session_create(dev_hdl, &session);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_NEIGHBOR_MOD_TABLE,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                 LNW_NEIGHBOR_MOD_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_NEIGHBOR_MOD_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_NEIGHBOR_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_NEIGHBOR_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_set_value(key_hdl, field_id,
-                                     (api_neighbor_pd_info->neighbor_handle &
-                                     ~(SWITCH_HANDLE_TYPE_NEIGHBOR <<
-                                     SWITCH_HANDLE_TYPE_SHIFT)));
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d for neighbor_mod_table",
-                 field_id);
-        goto dealloc_resources;
-    }
-
-    if (entry_add) {
-        /* Add an entry to target */
-        krnlmon_log_info("Populate set_outer_mac action in neighbor_mod_table for "
-                  "neighbor handle %x",
-                  (unsigned int) api_neighbor_pd_info->neighbor_handle);
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_NEIGHBOR_MOD_TABLE_ACTION_SET_OUTER_MAC,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_NEIGHBOR_MOD_TABLE_ACTION_SET_OUTER_MAC, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_SET_OUTER_MAC_PARAM_DST_MAC_ADDR,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                   LNW_ACTION_SET_OUTER_MAC_PARAM_DST_MAC_ADDR, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value_ptr(data_hdl, data_field_id,
-                                              (const uint8_t *)
-                                              &api_neighbor_pd_info->dst_mac_addr.mac_addr,
-                                              SWITCH_MAC_LENGTH);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add neighbor_mod_table entry, error: %d", status);
-            goto dealloc_resources;
-        }
-    } else {
-        /* Delete an entry from target */
-        krnlmon_log_info("Delete neighbor_mod_table entry");
-        status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                     flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete nexthop_table entry, error: %d", status);
-            goto dealloc_resources;
-        }
-    }
-
-dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
-}
-
-switch_status_t switch_pd_rif_mod_start_entry(
-  switch_device_t device,
-  switch_rmac_entry_t *rmac_entry,
-  switch_handle_t rif_handle,
-  bool entry_add) {
-    tdi_status_t status;
-
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
-
-    tdi_dev_id_t dev_id = device;
-
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
-
-    krnlmon_log_debug("%s", __func__);
-
-    status = tdi_flags_create(0, &flags_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_device_get(dev_id, &dev_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_target_create(dev_hdl, &target_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_session_create(dev_hdl, &session);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_RIF_MOD_TABLE_START,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                 LNW_RIF_MOD_TABLE_START, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_RIF_MOD_TABLE_START, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_RIF_MOD_TABLE_START_KEY_RIF_MOD_MAP_ID0,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_RIF_MOD_TABLE_START_KEY_RIF_MOD_MAP_ID0, status);
-        goto dealloc_resources;
-    }
-
-    if (SWITCH_RIF_HANDLE(rif_handle)) {
-      status = tdi_key_field_set_value(key_hdl, field_id,
-                                       (rif_handle &
-                                       ~(SWITCH_HANDLE_TYPE_RIF <<
-                                       SWITCH_HANDLE_TYPE_SHIFT)));
-    } else if (SWITCH_LAG_HANDLE(rif_handle)) {
-      status = tdi_key_field_set_value(key_hdl, field_id,
-                                       (rif_handle &
-                                       ~(SWITCH_HANDLE_TYPE_LAG <<
-                                       SWITCH_HANDLE_TYPE_SHIFT)));
-    } else {
-      krnlmon_log_error("Unable to set value for key ID: %d for rif_mod_table_start",
-               field_id);
+      krnlmon_log_error(
+          "Unable to get action allocator ID for: %s, "
+          "error: %d",
+          LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP, status);
       goto dealloc_resources;
-    }
-
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d for rif_mod_table_start",
-                 field_id);
-        goto dealloc_resources;
-    }
-
-    if (entry_add) {
-        /* Add an entry to target */
-        krnlmon_log_info("Populate set_src_mac_start action in rif_mod_table_start");
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_RIF_MOD_TABLE_START_ACTION_SET_SRC_MAC_START,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_RIF_MOD_TABLE_START_ACTION_SET_SRC_MAC_START, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_SET_SRC_MAC_PARAM_SRC_MAC_ADDR,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                   LNW_ACTION_SET_SRC_MAC_PARAM_SRC_MAC_ADDR, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value_ptr(data_hdl, data_field_id,
-                                              (const uint8_t *)
-                                              &rmac_entry->mac.mac_addr + RMAC_START_OFFSET,
-                                              RMAC_BYTES_OFFSET);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add %s entry, error: %d", LNW_RIF_MOD_TABLE_START, status);
-            goto dealloc_resources;
-        }
-    } else {
-        /* Delete an entry from target */
-        krnlmon_log_info("Delete rif_mod_table_start entry");
-        status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                     flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete %s entry, error: %d", LNW_RIF_MOD_TABLE_START, status);
-            goto dealloc_resources;
-        }
-  }
-
-dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
-}
-
-switch_status_t switch_pd_rif_mod_mid_entry(
-  switch_device_t device,
-  switch_rmac_entry_t *rmac_entry,
-  switch_handle_t rif_handle,
-  bool entry_add) {
-    tdi_status_t status;
-
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
-
-    tdi_dev_id_t dev_id = device;
-
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
-
-    krnlmon_log_debug("%s", __func__);
-
-    status = tdi_flags_create(0, &flags_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_device_get(dev_id, &dev_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_target_create(dev_hdl, &target_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_session_create(dev_hdl, &session);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_RIF_MOD_TABLE_MID,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                 LNW_RIF_MOD_TABLE_MID, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_RIF_MOD_TABLE_MID, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_RIF_MOD_TABLE_MID_KEY_RIF_MOD_MAP_ID1,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_RIF_MOD_TABLE_MID_KEY_RIF_MOD_MAP_ID1, status);
-        goto dealloc_resources;
-    }
-
-    if (SWITCH_RIF_HANDLE(rif_handle)) {
-      status = tdi_key_field_set_value(key_hdl, field_id,
-                                       (rif_handle &
-                                       ~(SWITCH_HANDLE_TYPE_RIF <<
-                                       SWITCH_HANDLE_TYPE_SHIFT)));
-    } else if (SWITCH_LAG_HANDLE(rif_handle)) {
-      status = tdi_key_field_set_value(key_hdl, field_id,
-                                       (rif_handle &
-                                       ~(SWITCH_HANDLE_TYPE_LAG <<
-                                       SWITCH_HANDLE_TYPE_SHIFT)));
-    } else {
-      krnlmon_log_error("Unable to set value for key ID: %d for rif_mod_table_mid",
-               field_id);
-      goto dealloc_resources;
-    }
-
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d for rif_mod_table_mid",
-                 field_id);
-        goto dealloc_resources;
-    }
-
-    if (entry_add) {
-        /* Add an entry to target */
-        krnlmon_log_info("Populate set_src_mac_start action in rif_mod_table_mid");
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_RIF_MOD_TABLE_MID_ACTION_SET_SRC_MAC_MID,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_RIF_MOD_TABLE_MID_ACTION_SET_SRC_MAC_MID, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_SET_SRC_MAC_PARAM_SRC_MAC_ADDR,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                   LNW_ACTION_SET_SRC_MAC_PARAM_SRC_MAC_ADDR, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value_ptr(data_hdl, data_field_id,
-                                              (const uint8_t *)
-                                              &rmac_entry->mac.mac_addr + RMAC_MID_OFFSET,
-                                              RMAC_BYTES_OFFSET);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add %s entry, error: %d", LNW_RIF_MOD_TABLE_MID, status);
-            goto dealloc_resources;
-        }
-    } else {
-        /* Delete an entry from target */
-        krnlmon_log_info("Delete rif_mod_table_start entry");
-        status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                     flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete %s entry, error: %d", LNW_RIF_MOD_TABLE_MID, status);
-            goto dealloc_resources;
-        }
-  }
-
-dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
-}
-
-switch_status_t switch_pd_rif_mod_last_entry(
-  switch_device_t device,
-  switch_rmac_entry_t *rmac_entry,
-  switch_handle_t rif_handle,
-  bool entry_add) {
-    tdi_status_t status;
-
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
-
-    tdi_dev_id_t dev_id = device;
-
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
-
-    krnlmon_log_debug("%s", __func__);
-
-    status = tdi_flags_create(0, &flags_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_device_get(dev_id, &dev_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_target_create(dev_hdl, &target_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_session_create(dev_hdl, &session);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_RIF_MOD_TABLE_LAST,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                 LNW_RIF_MOD_TABLE_LAST, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_RIF_MOD_TABLE_LAST, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_RIF_MOD_TABLE_LAST_KEY_RIF_MOD_MAP_ID2,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_RIF_MOD_TABLE_LAST_KEY_RIF_MOD_MAP_ID2, status);
-        goto dealloc_resources;
-    }
-
-    if (SWITCH_RIF_HANDLE(rif_handle)) {
-      status = tdi_key_field_set_value(key_hdl, field_id,
-                                       (rif_handle &
-                                       ~(SWITCH_HANDLE_TYPE_RIF <<
-                                       SWITCH_HANDLE_TYPE_SHIFT)));
-    } else if (SWITCH_LAG_HANDLE(rif_handle)) {
-      status = tdi_key_field_set_value(key_hdl, field_id,
-                                       (rif_handle &
-                                       ~(SWITCH_HANDLE_TYPE_LAG <<
-                                       SWITCH_HANDLE_TYPE_SHIFT)));
-    } else {
-      krnlmon_log_error("Unable to set value for key ID: %d for rif_mod_table_last",
-               field_id);
-      goto dealloc_resources;
-    }
-
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d for rif_mod_table_last",
-                 field_id);
-        goto dealloc_resources;
-    }
-
-    if (entry_add) {
-        /* Add an entry to target */
-        krnlmon_log_info("Populate set_src_mac_start action in rif_mod_table_last");
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_RIF_MOD_TABLE_LAST_ACTION_SET_SRC_MAC_LAST,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_RIF_MOD_TABLE_LAST_ACTION_SET_SRC_MAC_LAST, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_SET_SRC_MAC_PARAM_SRC_MAC_ADDR,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                   LNW_ACTION_SET_SRC_MAC_PARAM_SRC_MAC_ADDR, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value_ptr(data_hdl, data_field_id,
-                                              (const uint8_t *)
-                                              &rmac_entry->mac.mac_addr + RMAC_LAST_OFFSET,
-                                              RMAC_BYTES_OFFSET);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add %s entry, error: %d", LNW_RIF_MOD_TABLE_LAST, status);
-            goto dealloc_resources;
-        }
-
-    } else {
-        /* Delete an entry from target */
-        krnlmon_log_info("Delete rif_mod_table_start entry");
-        status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                     flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete %s entry, error: %d", LNW_RIF_MOD_TABLE_LAST, status);
-            goto dealloc_resources;
-        }
-  }
-
-dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
-}
-
-switch_status_t switch_pd_ipv6_table_entry (switch_device_t device,
-    const switch_api_route_entry_t *api_route_entry,
-    bool entry_add, switch_ip_table_action_t action)
-{
-    tdi_status_t status;
-
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
-
-    tdi_dev_id_t dev_id = device;
-
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
-    uint32_t network_byte_order = 0;
-
-    krnlmon_log_debug("%s", __func__);
-
-    if (action == SWITCH_ACTION_NONE &&
-        entry_add) {
-        krnlmon_log_debug("Ignore NONE action for ipv6 table entry addition");
-        return SWITCH_STATUS_SUCCESS;
-    }
-
-    status = tdi_flags_create(0, &flags_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_device_get(dev_id, &dev_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_target_create(dev_hdl, &target_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_session_create(dev_hdl, &session);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_IPV6_TABLE,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                LNW_IPV6_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_IPV6_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_IPV6_TABLE_KEY_IPV6_DST_MATCH,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_IPV6_TABLE_KEY_IPV6_DST_MATCH, status);
-        goto dealloc_resources;
-    }
-
-    /* Use LPM API for LPM match type*/
-    status = tdi_key_field_set_value_lpm_ptr(key_hdl, field_id,
-                                             (const uint8_t *)&api_route_entry->ip_address.ip.v6addr.u.addr8,
-                                             (const uint16_t)api_route_entry->ip_address.prefix_len,
-                                             16);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d for ipv4_table, error: %d",
-                 field_id, status);
-        goto dealloc_resources;
-    }
-
-    if (entry_add) {
-        if(action == SWITCH_ACTION_NHOP) {
-        krnlmon_log_info("Populate set_nexthop_id action in ipv4_table for "
-                  "route handle %x",
-                  (unsigned int) api_route_entry->route_handle);
-
-            status = tdi_action_name_to_id(table_info_hdl,
-                                           LNW_IPV6_TABLE_ACTION_IPV6_SET_NEXTHOP_ID,
-                                           &action_id);
-            if (status != TDI_SUCCESS) {
-                krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                         LNW_IPV6_TABLE_ACTION_IPV6_SET_NEXTHOP_ID, status);
-                goto dealloc_resources;
-            }
-
-            status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
-            if (status != TDI_SUCCESS) {
-                krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                         "error: %d", action_id, status);
-                goto dealloc_resources;
-            }
-
-            status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                       LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID,
-                                                       action_id, &data_field_id);
-            if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID, status);
-                goto dealloc_resources;
-            }
-
-            network_byte_order = api_route_entry->nhop_handle &
-                                  ~(SWITCH_HANDLE_TYPE_NHOP <<
-                                   SWITCH_HANDLE_TYPE_SHIFT);
-
-            status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                              network_byte_order);
-            if (status != TDI_SUCCESS) {
-                krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                         data_field_id, status);
-                goto dealloc_resources;
-            }
-        }
-
-        if(action == SWITCH_ACTION_NHOP_GROUP) {
-            status = tdi_action_name_to_id(table_info_hdl,
-                                           LNW_IPV6_TABLE_ACTION_ECMP_V6_HASH_ACTION,
-                                           &action_id);
-            if (status != TDI_SUCCESS) {
-                krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                         LNW_IPV6_TABLE_ACTION_ECMP_V6_HASH_ACTION, status);
-                goto dealloc_resources;
-            }
-
-            status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
-            if (status != TDI_SUCCESS) {
-                krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                         "error: %d", action_id, status);
-                goto dealloc_resources;
-            }
-
-            status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                       LNW_ACTION_ECMP_HASH_ACTION_PARAM_ECMP_GROUP_ID,
-                                                       action_id, &data_field_id);
-            if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                              LNW_ACTION_ECMP_HASH_ACTION_PARAM_ECMP_GROUP_ID,
-                              status);
-                goto dealloc_resources;
-            }
-
-            status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                              (api_route_entry->nhop_handle &
-                                              ~(SWITCH_HANDLE_TYPE_NHOP_GROUP <<
-                                              SWITCH_HANDLE_TYPE_SHIFT)));
-            if (status != TDI_SUCCESS) {
-                krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                         data_field_id, status);
-                goto dealloc_resources;
-            }
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to add %s entry, error: %d", LNW_IPV6_TABLE, status);
-            goto dealloc_resources;
-        }
-  } else {
-        /* Delete an entry from target */
-        krnlmon_log_info("Delete ipv6_table entry");
-        status = tdi_table_entry_del(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete %s entry, error: %d", LNW_IPV6_TABLE, status);
-            goto dealloc_resources;
-        }
-  }
-
-dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
-}
-
-switch_status_t switch_pd_ipv4_table_entry (switch_device_t device,
-    const switch_api_route_entry_t *api_route_entry,
-    bool entry_add, switch_ip_table_action_t action)
-{
-    tdi_status_t status;
-
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
-
-    tdi_dev_id_t dev_id = device;
-
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
-    uint32_t network_byte_order = 0;
-
-    krnlmon_log_debug("%s", __func__);
-
-    if (action == SWITCH_ACTION_NONE &&
-        entry_add) {
-        krnlmon_log_debug("Ignore NONE action for ipv4 table entry addition");
-        return SWITCH_STATUS_SUCCESS;
-    }
-
-    status = tdi_flags_create(0, &flags_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_device_get(dev_id, &dev_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_target_create(dev_hdl, &target_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_session_create(dev_hdl, &session);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_IPV4_TABLE,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                LNW_IPV4_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_IPV4_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_IPV4_TABLE_KEY_IPV4_DST_MATCH,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_IPV4_TABLE_KEY_IPV4_DST_MATCH, status);
-        goto dealloc_resources;
-    }
-
-    /* Use LPM API for LPM match type*/
-    network_byte_order = ntohl(api_route_entry->ip_address.ip.v4addr);
-    status = tdi_key_field_set_value_lpm_ptr(key_hdl, field_id,
-                                             (const uint8_t *)&network_byte_order,
-                                             (const uint16_t)api_route_entry->ip_address.prefix_len,
-                                             sizeof(uint32_t));
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d for ipv4_table, error: %d",
-                 field_id, status);
-        goto dealloc_resources;
-    }
-
-    if (entry_add) {
-        if(action == SWITCH_ACTION_NHOP) {
-        krnlmon_log_info("Populate set_nexthop_id action in ipv4_table for "
-                  "route handle %x",
-                  (unsigned int) api_route_entry->route_handle);
-
-            status = tdi_action_name_to_id(table_info_hdl,
-                                           LNW_IPV4_TABLE_ACTION_IPV4_SET_NEXTHOP_ID,
-                                           &action_id);
-            if (status != TDI_SUCCESS) {
-                krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                         LNW_IPV4_TABLE_ACTION_IPV4_SET_NEXTHOP_ID, status);
-                goto dealloc_resources;
-            }
-
-            status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
-            if (status != TDI_SUCCESS) {
-                krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                         "error: %d", action_id, status);
-                goto dealloc_resources;
-            }
-
-            status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                       LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID,
-                                                       action_id, &data_field_id);
-            if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID, status);
-                goto dealloc_resources;
-            }
-
-            network_byte_order = api_route_entry->nhop_handle &
-                                  ~(SWITCH_HANDLE_TYPE_NHOP <<
-                                  SWITCH_HANDLE_TYPE_SHIFT);
-
-            status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                              network_byte_order);
-            if (status != TDI_SUCCESS) {
-                krnlmon_log_error("Unable to set action value for ID: %d, error: %d", 
-                         data_field_id, status);
-                goto dealloc_resources;
-            }
-        }
-
-        if(action == SWITCH_ACTION_NHOP_GROUP) {
-            status = tdi_action_name_to_id(table_info_hdl,
-                                           LNW_IPV4_TABLE_ACTION_ECMP_HASH_ACTION,
-                                           &action_id);
-            if (status != TDI_SUCCESS) {
-                krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                         LNW_IPV4_TABLE_ACTION_ECMP_HASH_ACTION, status);
-                goto dealloc_resources;
-            }
-
-            status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
-            if (status != TDI_SUCCESS) {
-                krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                         "error: %d", action_id, status);
-                goto dealloc_resources;
-            }
-
-            status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                       LNW_ACTION_ECMP_HASH_ACTION_PARAM_ECMP_GROUP_ID,
-                                                       action_id, &data_field_id);
-            if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_ECMP_HASH_ACTION_PARAM_ECMP_GROUP_ID, status);
-                goto dealloc_resources;
-            }
-
-            status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                              (api_route_entry->nhop_handle &
-                                              ~(SWITCH_HANDLE_TYPE_NHOP_GROUP <<
-                                              SWITCH_HANDLE_TYPE_SHIFT)));
-            if (status != TDI_SUCCESS) {
-                krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                         data_field_id, status);
-                goto dealloc_resources;
-            }
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to add %s entry, error: %d", LNW_IPV4_TABLE, status);
-            goto dealloc_resources;
-        }
-  } else {
-        /* Delete an entry from target */
-        krnlmon_log_info("Delete ipv4_table entry");
-        status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                     flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete %s entry, error: %d", LNW_IPV4_TABLE, status);
-            goto dealloc_resources;
-        }
-  }
-
-dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
-}
-
-switch_status_t switch_pd_ecmp_hash_table_entry(switch_device_t device,
-    const switch_nhop_group_info_t *ecmp_info, bool entry_add)
-{
-    tdi_status_t status;
-
-    tdi_id_t field_id_group_id = 0;
-    tdi_id_t field_id_meta_bit32_zero = 0;
-    tdi_id_t field_id_meta_common_hash = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
-
-    tdi_dev_id_t dev_id = device;
-
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
-
-    uint16_t network_byte_order_ecmp_id = -1;
-    uint32_t network_byte_order = -1;
-    static uint32_t total_ecmp_list = 0;
-    switch_list_t nhop_members;
-    uint32_t ecmp_list = 0;
-    uint8_t nhop_count = 0;
-
-    switch_node_t *node = NULL;
-    switch_nhop_member_t *ecmp_member = NULL;
-    switch_handle_t ecmp_handle = SWITCH_API_INVALID_HANDLE;
-    switch_handle_t nhop_handle = SWITCH_API_INVALID_HANDLE;
-
-    krnlmon_log_debug("%s", __func__);
-
-    status = tdi_flags_create(0, &flags_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_device_get(dev_id, &dev_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_target_create(dev_hdl, &target_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_session_create(dev_hdl, &session);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_ECMP_HASH_TABLE,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                 LNW_ECMP_HASH_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_ECMP_HASH_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_ECMP_HASH_TABLE_KEY_HOST_INFO_TX_EXT_FLEX,
-                                  &field_id_group_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_ECMP_HASH_TABLE_KEY_HOST_INFO_TX_EXT_FLEX, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_ECMP_HASH_TABLE_KEY_META_COMMON_HASH,
-                                  &field_id_meta_common_hash);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_ECMP_HASH_TABLE_KEY_META_COMMON_HASH, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_ECMP_HASH_TABLE_KEY_USER_META_BIT32_ZEROS,
-                                  &field_id_meta_bit32_zero);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_ECMP_HASH_TABLE_KEY_USER_META_BIT32_ZEROS, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_action_name_to_id(table_info_hdl,
-                                   LNW_ECMP_HASH_TABLE_ACTION_SET_NEXTHOP_ID,
-                                   &action_id);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                 LNW_ECMP_HASH_TABLE_ACTION_SET_NEXTHOP_ID, status);
-        goto dealloc_resources;
     }
 
     status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                 "error: %d", action_id, status);
-        goto dealloc_resources;
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
     }
 
     status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                               LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID,
+                                               LNW_ACTION_SET_NEXTHOP_PARAM_RIF,
                                                action_id, &data_field_id);
     if (status != TDI_SUCCESS) {
-    krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-             LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID, status);
-        goto dealloc_resources;
+      krnlmon_log_error(
+          "Unable to get data field id param for: %s, "
+          "error: %d",
+          LNW_ACTION_SET_NEXTHOP_PARAM_RIF, status);
+      goto dealloc_resources;
     }
 
-    ecmp_handle = ecmp_info->nhop_group_handle;
-    nhop_members = (switch_list_t) ecmp_info->members;
+    // For ES2K we need to program RIF_id action in Big endian
+    network_byte_order_rif_id =
+        api_nexthop_pd_info->rif_handle &
+        ~(SWITCH_HANDLE_TYPE_RIF << SWITCH_HANDLE_TYPE_SHIFT);
 
-    // For ES2K program ECMP Group ID in host byte order
-    network_byte_order_ecmp_id = ecmp_handle &
-                                  ~(SWITCH_HANDLE_TYPE_NHOP_GROUP <<
-                                   SWITCH_HANDLE_TYPE_SHIFT);
-
-    while ((total_ecmp_list < LNW_ECMP_HASH_SIZE) &&
-           (ecmp_list < LNW_ECMP_PER_GROUP_HASH_SIZE)) {
-        nhop_count = 0;
-        FOR_EACH_IN_LIST(nhop_members, node) {
-            ecmp_member = (switch_nhop_member_t *)node->data;
-            nhop_handle = ecmp_member->nhop_handle;
-
-            status = tdi_key_field_set_value(key_hdl, field_id_group_id,
-                                             network_byte_order_ecmp_id);
-            if (status != TDI_SUCCESS) {
-                krnlmon_log_error("Unable to set value for key ID: %d for ecmp_hash_table"
-                         ", error: %d", field_id_group_id, status);
-                goto dealloc_resources;
-            }
-
-            status = tdi_key_field_set_value(key_hdl, field_id_meta_common_hash,
-                                             ecmp_list + nhop_count);
-            if (status != TDI_SUCCESS) {
-                krnlmon_log_error("Unable to set value for key ID: %d for ecmp_hash_table"
-                         ", error: %d", field_id_meta_common_hash, status);
-                goto dealloc_resources;
-            }
-
-            status = tdi_key_field_set_value(key_hdl, field_id_meta_bit32_zero,
-                                             0);
-            if (status != TDI_SUCCESS) {
-                krnlmon_log_error("Unable to set value for key ID: %d for ecmp_hash_table"
-                         ", error: %d", field_id_meta_bit32_zero, status);
-                goto dealloc_resources;
-            }
-
-            if (entry_add) {
-                network_byte_order = nhop_handle &
-                                      ~(SWITCH_HANDLE_TYPE_NHOP <<
-                                      SWITCH_HANDLE_TYPE_SHIFT);
-
-                status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                                  network_byte_order);
-                if (status != TDI_SUCCESS) {
-                    krnlmon_log_error("Unable to set action value for ID: %d, error: %d", 
-                             data_field_id, status);
-                    goto dealloc_resources;
-                }
-
-                status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                             flags_hdl, key_hdl, data_hdl);
-                if (status != TDI_SUCCESS) {
-                krnlmon_log_error("Unable to add %s entry, error: %d", LNW_ECMP_HASH_TABLE, status);
-                    goto dealloc_resources;
-                }
-                total_ecmp_list++;
-            } else {
-                /* Delete an entry from target */
-                krnlmon_log_info("Delete ecmp_hash_table entry");
-                status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                             flags_hdl, key_hdl);
-                if (status != TDI_SUCCESS) {
-                    krnlmon_log_error("Unable to delete %s entry, error: %d",
-                             LNW_ECMP_HASH_TABLE, status);
-                    goto dealloc_resources;
-                }
-                total_ecmp_list--;
-            }
-            nhop_count++;
-        }
-        FOR_EACH_IN_LIST_END();
-        ecmp_list += nhop_count;
+    status = tdi_data_field_set_value(data_hdl, data_field_id,
+                                      network_byte_order_rif_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
     }
-    krnlmon_log_debug("Total ECMP hash entries created are: %d", total_ecmp_list);
+
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_SET_NEXTHOP_PARAM_NEIGHBOR_ID, action_id,
+        &data_field_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_SET_NEXTHOP_PARAM_NEIGHBOR_ID, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_set_value(
+        data_hdl, data_field_id,
+        (api_nexthop_pd_info->neighbor_handle &
+         ~(SWITCH_HANDLE_TYPE_NEIGHBOR << SWITCH_HANDLE_TYPE_SHIFT)));
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_SET_NEXTHOP_PARAM_EGRESS_PORT, action_id,
+        &data_field_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_SET_NEXTHOP_PARAM_EGRESS_PORT, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_set_value(data_hdl, data_field_id,
+                                      api_nexthop_pd_info->port_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to add %s entry, error: %d", LNW_NEXTHOP_TABLE,
+                        status);
+      goto dealloc_resources;
+    }
+  } else if (entry_add && SWITCH_LAG_HANDLE(api_nexthop_pd_info->rif_handle)) {
+    /* Add an entry to target */
+    krnlmon_log_info(
+        "Populate set_nexthop_lag with neighbor id: 0x%x"
+        " in nexthop_table for nexthop_id 0x%x",
+        (unsigned int)api_nexthop_pd_info->neighbor_handle,
+        (unsigned int)api_nexthop_pd_info->nexthop_handle);
+
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP_LAG, &action_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error(
+          "Unable to get action allocator ID for: %s, "
+          "error: %d",
+          LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP_LAG, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_SET_NEXTHOP_LAG_PARAM_RIF, action_id,
+        &data_field_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error(
+          "Unable to get data field id param for: %s, "
+          "error: %d",
+          LNW_ACTION_SET_NEXTHOP_LAG_PARAM_RIF, status);
+      goto dealloc_resources;
+    }
+
+    lag_id = api_nexthop_pd_info->rif_handle &
+             ~(SWITCH_HANDLE_TYPE_LAG << SWITCH_HANDLE_TYPE_SHIFT);
+
+    status = tdi_data_field_set_value(data_hdl, data_field_id, lag_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_SET_NEXTHOP_LAG_PARAM_NEIGHBOR_ID, action_id,
+        &data_field_id);
+
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_SET_NEXTHOP_LAG_PARAM_NEIGHBOR_ID, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_set_value(
+        data_hdl, data_field_id,
+        (api_nexthop_pd_info->neighbor_handle &
+         ~(SWITCH_HANDLE_TYPE_NEIGHBOR << SWITCH_HANDLE_TYPE_SHIFT)));
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_SET_NEXTHOP_LAG_PARAM_LAG_ID, action_id,
+        &data_field_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_SET_NEXTHOP_LAG_PARAM_LAG_ID, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_set_value(data_hdl, data_field_id, lag_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to add %s entry, error: %d", LNW_NEXTHOP_TABLE,
+                        status);
+      goto dealloc_resources;
+    }
+  } else {
+    /* Delete an entry from target */
+    krnlmon_log_info("Delete nexthop_table entry");
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to delete %s entry, error: %d",
+                        LNW_NEXTHOP_TABLE, status);
+      goto dealloc_resources;
+    }
+  }
 
 dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
+}
+
+switch_status_t switch_pd_neighbor_table_entry(
+    switch_device_t device,
+    const switch_pd_routing_info_t* api_neighbor_pd_info, bool entry_add) {
+  tdi_status_t status;
+
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
+
+  tdi_dev_id_t dev_id = device;
+
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
+
+  krnlmon_log_debug("%s", __func__);
+
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status =
+      tdi_table_from_name_get(info_hdl, LNW_NEIGHBOR_MOD_TABLE, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_NEIGHBOR_MOD_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_NEIGHBOR_MOD_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table, error: %d",
+                      status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(
+      table_info_hdl, LNW_NEIGHBOR_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR,
+      &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_NEIGHBOR_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR,
+                      status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_set_value(
+      key_hdl, field_id,
+      (api_neighbor_pd_info->neighbor_handle &
+       ~(SWITCH_HANDLE_TYPE_NEIGHBOR << SWITCH_HANDLE_TYPE_SHIFT)));
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to set value for key ID: %d for neighbor_mod_table", field_id);
+    goto dealloc_resources;
+  }
+
+  if (entry_add) {
+    /* Add an entry to target */
+    krnlmon_log_info(
+        "Populate set_outer_mac action in neighbor_mod_table for "
+        "neighbor handle %x",
+        (unsigned int)api_neighbor_pd_info->neighbor_handle);
+
+    status = tdi_action_name_to_id(table_info_hdl,
+                                   LNW_NEIGHBOR_MOD_TABLE_ACTION_SET_OUTER_MAC,
+                                   &action_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_NEIGHBOR_MOD_TABLE_ACTION_SET_OUTER_MAC, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_SET_OUTER_MAC_PARAM_DST_MAC_ADDR, action_id,
+        &data_field_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_SET_OUTER_MAC_PARAM_DST_MAC_ADDR, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_set_value_ptr(
+        data_hdl, data_field_id,
+        (const uint8_t*)&api_neighbor_pd_info->dst_mac_addr.mac_addr,
+        SWITCH_MAC_LENGTH);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to add neighbor_mod_table entry, error: %d",
+                        status);
+      goto dealloc_resources;
+    }
+  } else {
+    /* Delete an entry from target */
+    krnlmon_log_info("Delete neighbor_mod_table entry");
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to delete nexthop_table entry, error: %d",
+                        status);
+      goto dealloc_resources;
+    }
+  }
+
+dealloc_resources:
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
+}
+
+switch_status_t switch_pd_rif_mod_start_entry(switch_device_t device,
+                                              switch_rmac_entry_t* rmac_entry,
+                                              switch_handle_t rif_handle,
+                                              bool entry_add) {
+  tdi_status_t status;
+
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
+
+  tdi_dev_id_t dev_id = device;
+
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
+
+  krnlmon_log_debug("%s", __func__);
+
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status =
+      tdi_table_from_name_get(info_hdl, LNW_RIF_MOD_TABLE_START, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_RIF_MOD_TABLE_START, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_RIF_MOD_TABLE_START, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table, error: %d",
+                      status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(
+      table_info_hdl, LNW_RIF_MOD_TABLE_START_KEY_RIF_MOD_MAP_ID0, &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_RIF_MOD_TABLE_START_KEY_RIF_MOD_MAP_ID0, status);
+    goto dealloc_resources;
+  }
+
+  if (SWITCH_RIF_HANDLE(rif_handle)) {
+    status = tdi_key_field_set_value(
+        key_hdl, field_id,
+        (rif_handle & ~(SWITCH_HANDLE_TYPE_RIF << SWITCH_HANDLE_TYPE_SHIFT)));
+  } else if (SWITCH_LAG_HANDLE(rif_handle)) {
+    status = tdi_key_field_set_value(
+        key_hdl, field_id,
+        (rif_handle & ~(SWITCH_HANDLE_TYPE_LAG << SWITCH_HANDLE_TYPE_SHIFT)));
+  } else {
+    krnlmon_log_error(
+        "Unable to set value for key ID: %d for rif_mod_table_start", field_id);
+    goto dealloc_resources;
+  }
+
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to set value for key ID: %d for rif_mod_table_start", field_id);
+    goto dealloc_resources;
+  }
+
+  if (entry_add) {
+    /* Add an entry to target */
+    krnlmon_log_info(
+        "Populate set_src_mac_start action in rif_mod_table_start");
+
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_RIF_MOD_TABLE_START_ACTION_SET_SRC_MAC_START,
+        &action_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_RIF_MOD_TABLE_START_ACTION_SET_SRC_MAC_START,
+                        status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_SET_SRC_MAC_PARAM_SRC_MAC_ADDR, action_id,
+        &data_field_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_SET_SRC_MAC_PARAM_SRC_MAC_ADDR, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_set_value_ptr(
+        data_hdl, data_field_id,
+        (const uint8_t*)&rmac_entry->mac.mac_addr + RMAC_START_OFFSET,
+        RMAC_BYTES_OFFSET);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to add %s entry, error: %d",
+                        LNW_RIF_MOD_TABLE_START, status);
+      goto dealloc_resources;
+    }
+  } else {
+    /* Delete an entry from target */
+    krnlmon_log_info("Delete rif_mod_table_start entry");
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to delete %s entry, error: %d",
+                        LNW_RIF_MOD_TABLE_START, status);
+      goto dealloc_resources;
+    }
+  }
+
+dealloc_resources:
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
+}
+
+switch_status_t switch_pd_rif_mod_mid_entry(switch_device_t device,
+                                            switch_rmac_entry_t* rmac_entry,
+                                            switch_handle_t rif_handle,
+                                            bool entry_add) {
+  tdi_status_t status;
+
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
+
+  tdi_dev_id_t dev_id = device;
+
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
+
+  krnlmon_log_debug("%s", __func__);
+
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_from_name_get(info_hdl, LNW_RIF_MOD_TABLE_MID, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_RIF_MOD_TABLE_MID, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_RIF_MOD_TABLE_MID, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table, error: %d",
+                      status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(
+      table_info_hdl, LNW_RIF_MOD_TABLE_MID_KEY_RIF_MOD_MAP_ID1, &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_RIF_MOD_TABLE_MID_KEY_RIF_MOD_MAP_ID1, status);
+    goto dealloc_resources;
+  }
+
+  if (SWITCH_RIF_HANDLE(rif_handle)) {
+    status = tdi_key_field_set_value(
+        key_hdl, field_id,
+        (rif_handle & ~(SWITCH_HANDLE_TYPE_RIF << SWITCH_HANDLE_TYPE_SHIFT)));
+  } else if (SWITCH_LAG_HANDLE(rif_handle)) {
+    status = tdi_key_field_set_value(
+        key_hdl, field_id,
+        (rif_handle & ~(SWITCH_HANDLE_TYPE_LAG << SWITCH_HANDLE_TYPE_SHIFT)));
+  } else {
+    krnlmon_log_error(
+        "Unable to set value for key ID: %d for rif_mod_table_mid", field_id);
+    goto dealloc_resources;
+  }
+
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to set value for key ID: %d for rif_mod_table_mid", field_id);
+    goto dealloc_resources;
+  }
+
+  if (entry_add) {
+    /* Add an entry to target */
+    krnlmon_log_info("Populate set_src_mac_start action in rif_mod_table_mid");
+
+    status = tdi_action_name_to_id(table_info_hdl,
+                                   LNW_RIF_MOD_TABLE_MID_ACTION_SET_SRC_MAC_MID,
+                                   &action_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_RIF_MOD_TABLE_MID_ACTION_SET_SRC_MAC_MID, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_SET_SRC_MAC_PARAM_SRC_MAC_ADDR, action_id,
+        &data_field_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_SET_SRC_MAC_PARAM_SRC_MAC_ADDR, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_set_value_ptr(
+        data_hdl, data_field_id,
+        (const uint8_t*)&rmac_entry->mac.mac_addr + RMAC_MID_OFFSET,
+        RMAC_BYTES_OFFSET);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to add %s entry, error: %d",
+                        LNW_RIF_MOD_TABLE_MID, status);
+      goto dealloc_resources;
+    }
+  } else {
+    /* Delete an entry from target */
+    krnlmon_log_info("Delete rif_mod_table_start entry");
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to delete %s entry, error: %d",
+                        LNW_RIF_MOD_TABLE_MID, status);
+      goto dealloc_resources;
+    }
+  }
+
+dealloc_resources:
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
+}
+
+switch_status_t switch_pd_rif_mod_last_entry(switch_device_t device,
+                                             switch_rmac_entry_t* rmac_entry,
+                                             switch_handle_t rif_handle,
+                                             bool entry_add) {
+  tdi_status_t status;
+
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
+
+  tdi_dev_id_t dev_id = device;
+
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
+
+  krnlmon_log_debug("%s", __func__);
+
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status =
+      tdi_table_from_name_get(info_hdl, LNW_RIF_MOD_TABLE_LAST, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_RIF_MOD_TABLE_LAST, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_RIF_MOD_TABLE_LAST, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table, error: %d",
+                      status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(
+      table_info_hdl, LNW_RIF_MOD_TABLE_LAST_KEY_RIF_MOD_MAP_ID2, &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_RIF_MOD_TABLE_LAST_KEY_RIF_MOD_MAP_ID2, status);
+    goto dealloc_resources;
+  }
+
+  if (SWITCH_RIF_HANDLE(rif_handle)) {
+    status = tdi_key_field_set_value(
+        key_hdl, field_id,
+        (rif_handle & ~(SWITCH_HANDLE_TYPE_RIF << SWITCH_HANDLE_TYPE_SHIFT)));
+  } else if (SWITCH_LAG_HANDLE(rif_handle)) {
+    status = tdi_key_field_set_value(
+        key_hdl, field_id,
+        (rif_handle & ~(SWITCH_HANDLE_TYPE_LAG << SWITCH_HANDLE_TYPE_SHIFT)));
+  } else {
+    krnlmon_log_error(
+        "Unable to set value for key ID: %d for rif_mod_table_last", field_id);
+    goto dealloc_resources;
+  }
+
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to set value for key ID: %d for rif_mod_table_last", field_id);
+    goto dealloc_resources;
+  }
+
+  if (entry_add) {
+    /* Add an entry to target */
+    krnlmon_log_info("Populate set_src_mac_start action in rif_mod_table_last");
+
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_RIF_MOD_TABLE_LAST_ACTION_SET_SRC_MAC_LAST,
+        &action_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_RIF_MOD_TABLE_LAST_ACTION_SET_SRC_MAC_LAST, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_SET_SRC_MAC_PARAM_SRC_MAC_ADDR, action_id,
+        &data_field_id);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_SET_SRC_MAC_PARAM_SRC_MAC_ADDR, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_data_field_set_value_ptr(
+        data_hdl, data_field_id,
+        (const uint8_t*)&rmac_entry->mac.mac_addr + RMAC_LAST_OFFSET,
+        RMAC_BYTES_OFFSET);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
+    }
+
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to add %s entry, error: %d",
+                        LNW_RIF_MOD_TABLE_LAST, status);
+      goto dealloc_resources;
+    }
+
+  } else {
+    /* Delete an entry from target */
+    krnlmon_log_info("Delete rif_mod_table_start entry");
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to delete %s entry, error: %d",
+                        LNW_RIF_MOD_TABLE_LAST, status);
+      goto dealloc_resources;
+    }
+  }
+
+dealloc_resources:
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
+}
+
+switch_status_t switch_pd_ipv6_table_entry(
+    switch_device_t device, const switch_api_route_entry_t* api_route_entry,
+    bool entry_add, switch_ip_table_action_t action) {
+  tdi_status_t status;
+
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
+
+  tdi_dev_id_t dev_id = device;
+
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
+  uint32_t network_byte_order = 0;
+
+  krnlmon_log_debug("%s", __func__);
+
+  if (action == SWITCH_ACTION_NONE && entry_add) {
+    krnlmon_log_debug("Ignore NONE action for ipv6 table entry addition");
+    return SWITCH_STATUS_SUCCESS;
+  }
+
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_from_name_get(info_hdl, LNW_IPV6_TABLE, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_IPV6_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_IPV6_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table, error: %d",
+                      status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(table_info_hdl,
+                                LNW_IPV6_TABLE_KEY_IPV6_DST_MATCH, &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_IPV6_TABLE_KEY_IPV6_DST_MATCH, status);
+    goto dealloc_resources;
+  }
+
+  /* Use LPM API for LPM match type*/
+  status = tdi_key_field_set_value_lpm_ptr(
+      key_hdl, field_id,
+      (const uint8_t*)&api_route_entry->ip_address.ip.v6addr.u.addr8,
+      (const uint16_t)api_route_entry->ip_address.prefix_len, 16);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to set value for key ID: %d for ipv4_table, error: %d",
+        field_id, status);
+    goto dealloc_resources;
+  }
+
+  if (entry_add) {
+    if (action == SWITCH_ACTION_NHOP) {
+      krnlmon_log_info(
+          "Populate set_nexthop_id action in ipv4_table for "
+          "route handle %x",
+          (unsigned int)api_route_entry->route_handle);
+
+      status = tdi_action_name_to_id(table_info_hdl,
+                                     LNW_IPV6_TABLE_ACTION_IPV6_SET_NEXTHOP_ID,
+                                     &action_id);
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error(
+            "Unable to get action allocator ID for: %s, error: %d",
+            LNW_IPV6_TABLE_ACTION_IPV6_SET_NEXTHOP_ID, status);
+        goto dealloc_resources;
+      }
+
+      status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error(
+            "Unable to get action allocator for ID: %d, "
+            "error: %d",
+            action_id, status);
+        goto dealloc_resources;
+      }
+
+      status = tdi_data_field_id_with_action_get(
+          table_info_hdl, LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID, action_id,
+          &data_field_id);
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error(
+            "Unable to get data field id param for: %s, error: %d",
+            LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID, status);
+        goto dealloc_resources;
+      }
+
+      network_byte_order =
+          api_route_entry->nhop_handle &
+          ~(SWITCH_HANDLE_TYPE_NHOP << SWITCH_HANDLE_TYPE_SHIFT);
+
+      status =
+          tdi_data_field_set_value(data_hdl, data_field_id, network_byte_order);
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                          data_field_id, status);
+        goto dealloc_resources;
+      }
+    }
+
+    if (action == SWITCH_ACTION_NHOP_GROUP) {
+      status = tdi_action_name_to_id(table_info_hdl,
+                                     LNW_IPV6_TABLE_ACTION_ECMP_V6_HASH_ACTION,
+                                     &action_id);
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error(
+            "Unable to get action allocator ID for: %s, error: %d",
+            LNW_IPV6_TABLE_ACTION_ECMP_V6_HASH_ACTION, status);
+        goto dealloc_resources;
+      }
+
+      status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error(
+            "Unable to get action allocator for ID: %d, "
+            "error: %d",
+            action_id, status);
+        goto dealloc_resources;
+      }
+
+      status = tdi_data_field_id_with_action_get(
+          table_info_hdl, LNW_ACTION_ECMP_HASH_ACTION_PARAM_ECMP_GROUP_ID,
+          action_id, &data_field_id);
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error(
+            "Unable to get data field id param for: %s, error: %d",
+            LNW_ACTION_ECMP_HASH_ACTION_PARAM_ECMP_GROUP_ID, status);
+        goto dealloc_resources;
+      }
+
+      status = tdi_data_field_set_value(
+          data_hdl, data_field_id,
+          (api_route_entry->nhop_handle &
+           ~(SWITCH_HANDLE_TYPE_NHOP_GROUP << SWITCH_HANDLE_TYPE_SHIFT)));
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                          data_field_id, status);
+        goto dealloc_resources;
+      }
+    }
+
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to add %s entry, error: %d", LNW_IPV6_TABLE,
+                        status);
+      goto dealloc_resources;
+    }
+  } else {
+    /* Delete an entry from target */
+    krnlmon_log_info("Delete ipv6_table entry");
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to delete %s entry, error: %d", LNW_IPV6_TABLE,
+                        status);
+      goto dealloc_resources;
+    }
+  }
+
+dealloc_resources:
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
+}
+
+switch_status_t switch_pd_ipv4_table_entry(
+    switch_device_t device, const switch_api_route_entry_t* api_route_entry,
+    bool entry_add, switch_ip_table_action_t action) {
+  tdi_status_t status;
+
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
+
+  tdi_dev_id_t dev_id = device;
+
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
+  uint32_t network_byte_order = 0;
+
+  krnlmon_log_debug("%s", __func__);
+
+  if (action == SWITCH_ACTION_NONE && entry_add) {
+    krnlmon_log_debug("Ignore NONE action for ipv4 table entry addition");
+    return SWITCH_STATUS_SUCCESS;
+  }
+
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_from_name_get(info_hdl, LNW_IPV4_TABLE, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_IPV4_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_IPV4_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table, error: %d",
+                      status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(table_info_hdl,
+                                LNW_IPV4_TABLE_KEY_IPV4_DST_MATCH, &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_IPV4_TABLE_KEY_IPV4_DST_MATCH, status);
+    goto dealloc_resources;
+  }
+
+  /* Use LPM API for LPM match type*/
+  network_byte_order = ntohl(api_route_entry->ip_address.ip.v4addr);
+  status = tdi_key_field_set_value_lpm_ptr(
+      key_hdl, field_id, (const uint8_t*)&network_byte_order,
+      (const uint16_t)api_route_entry->ip_address.prefix_len, sizeof(uint32_t));
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to set value for key ID: %d for ipv4_table, error: %d",
+        field_id, status);
+    goto dealloc_resources;
+  }
+
+  if (entry_add) {
+    if (action == SWITCH_ACTION_NHOP) {
+      krnlmon_log_info(
+          "Populate set_nexthop_id action in ipv4_table for "
+          "route handle %x",
+          (unsigned int)api_route_entry->route_handle);
+
+      status = tdi_action_name_to_id(table_info_hdl,
+                                     LNW_IPV4_TABLE_ACTION_IPV4_SET_NEXTHOP_ID,
+                                     &action_id);
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error(
+            "Unable to get action allocator ID for: %s, error: %d",
+            LNW_IPV4_TABLE_ACTION_IPV4_SET_NEXTHOP_ID, status);
+        goto dealloc_resources;
+      }
+
+      status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error(
+            "Unable to get action allocator for ID: %d, "
+            "error: %d",
+            action_id, status);
+        goto dealloc_resources;
+      }
+
+      status = tdi_data_field_id_with_action_get(
+          table_info_hdl, LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID, action_id,
+          &data_field_id);
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error(
+            "Unable to get data field id param for: %s, error: %d",
+            LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID, status);
+        goto dealloc_resources;
+      }
+
+      network_byte_order =
+          api_route_entry->nhop_handle &
+          ~(SWITCH_HANDLE_TYPE_NHOP << SWITCH_HANDLE_TYPE_SHIFT);
+
+      status =
+          tdi_data_field_set_value(data_hdl, data_field_id, network_byte_order);
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                          data_field_id, status);
+        goto dealloc_resources;
+      }
+    }
+
+    if (action == SWITCH_ACTION_NHOP_GROUP) {
+      status = tdi_action_name_to_id(
+          table_info_hdl, LNW_IPV4_TABLE_ACTION_ECMP_HASH_ACTION, &action_id);
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error(
+            "Unable to get action allocator ID for: %s, error: %d",
+            LNW_IPV4_TABLE_ACTION_ECMP_HASH_ACTION, status);
+        goto dealloc_resources;
+      }
+
+      status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error(
+            "Unable to get action allocator for ID: %d, "
+            "error: %d",
+            action_id, status);
+        goto dealloc_resources;
+      }
+
+      status = tdi_data_field_id_with_action_get(
+          table_info_hdl, LNW_ACTION_ECMP_HASH_ACTION_PARAM_ECMP_GROUP_ID,
+          action_id, &data_field_id);
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error(
+            "Unable to get data field id param for: %s, error: %d",
+            LNW_ACTION_ECMP_HASH_ACTION_PARAM_ECMP_GROUP_ID, status);
+        goto dealloc_resources;
+      }
+
+      status = tdi_data_field_set_value(
+          data_hdl, data_field_id,
+          (api_route_entry->nhop_handle &
+           ~(SWITCH_HANDLE_TYPE_NHOP_GROUP << SWITCH_HANDLE_TYPE_SHIFT)));
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                          data_field_id, status);
+        goto dealloc_resources;
+      }
+    }
+
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to add %s entry, error: %d", LNW_IPV4_TABLE,
+                        status);
+      goto dealloc_resources;
+    }
+  } else {
+    /* Delete an entry from target */
+    krnlmon_log_info("Delete ipv4_table entry");
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to delete %s entry, error: %d", LNW_IPV4_TABLE,
+                        status);
+      goto dealloc_resources;
+    }
+  }
+
+dealloc_resources:
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
+}
+
+switch_status_t switch_pd_ecmp_hash_table_entry(
+    switch_device_t device, const switch_nhop_group_info_t* ecmp_info,
+    bool entry_add) {
+  tdi_status_t status;
+
+  tdi_id_t field_id_group_id = 0;
+  tdi_id_t field_id_meta_bit32_zero = 0;
+  tdi_id_t field_id_meta_common_hash = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
+
+  tdi_dev_id_t dev_id = device;
+
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
+
+  uint16_t network_byte_order_ecmp_id = -1;
+  uint32_t network_byte_order = -1;
+  static uint32_t total_ecmp_list = 0;
+  switch_list_t nhop_members;
+  uint32_t ecmp_list = 0;
+  uint8_t nhop_count = 0;
+
+  switch_node_t* node = NULL;
+  switch_nhop_member_t* ecmp_member = NULL;
+  switch_handle_t ecmp_handle = SWITCH_API_INVALID_HANDLE;
+  switch_handle_t nhop_handle = SWITCH_API_INVALID_HANDLE;
+
+  krnlmon_log_debug("%s", __func__);
+
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_from_name_get(info_hdl, LNW_ECMP_HASH_TABLE, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_ECMP_HASH_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_ECMP_HASH_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table, error: %d",
+                      status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(table_info_hdl,
+                                LNW_ECMP_HASH_TABLE_KEY_HOST_INFO_TX_EXT_FLEX,
+                                &field_id_group_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_ECMP_HASH_TABLE_KEY_HOST_INFO_TX_EXT_FLEX, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(table_info_hdl,
+                                LNW_ECMP_HASH_TABLE_KEY_META_COMMON_HASH,
+                                &field_id_meta_common_hash);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_ECMP_HASH_TABLE_KEY_META_COMMON_HASH, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(table_info_hdl,
+                                LNW_ECMP_HASH_TABLE_KEY_USER_META_BIT32_ZEROS,
+                                &field_id_meta_bit32_zero);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_ECMP_HASH_TABLE_KEY_USER_META_BIT32_ZEROS, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_action_name_to_id(
+      table_info_hdl, LNW_ECMP_HASH_TABLE_ACTION_SET_NEXTHOP_ID, &action_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                      LNW_ECMP_HASH_TABLE_ACTION_SET_NEXTHOP_ID, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to get action allocator for ID: %d, "
+        "error: %d",
+        action_id, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_data_field_id_with_action_get(
+      table_info_hdl, LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID, action_id,
+      &data_field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                      LNW_ACTION_SET_NEXTHOP_ID_PARAM_NEXTHOP_ID, status);
+    goto dealloc_resources;
+  }
+
+  ecmp_handle = ecmp_info->nhop_group_handle;
+  nhop_members = (switch_list_t)ecmp_info->members;
+
+  // For ES2K program ECMP Group ID in host byte order
+  network_byte_order_ecmp_id = ecmp_handle & ~(SWITCH_HANDLE_TYPE_NHOP_GROUP
+                                               << SWITCH_HANDLE_TYPE_SHIFT);
+
+  while ((total_ecmp_list < LNW_ECMP_HASH_SIZE) &&
+         (ecmp_list < LNW_ECMP_PER_GROUP_HASH_SIZE)) {
+    nhop_count = 0;
+    FOR_EACH_IN_LIST(nhop_members, node) {
+      ecmp_member = (switch_nhop_member_t*)node->data;
+      nhop_handle = ecmp_member->nhop_handle;
+
+      status = tdi_key_field_set_value(key_hdl, field_id_group_id,
+                                       network_byte_order_ecmp_id);
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error(
+            "Unable to set value for key ID: %d for ecmp_hash_table"
+            ", error: %d",
+            field_id_group_id, status);
+        goto dealloc_resources;
+      }
+
+      status = tdi_key_field_set_value(key_hdl, field_id_meta_common_hash,
+                                       ecmp_list + nhop_count);
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error(
+            "Unable to set value for key ID: %d for ecmp_hash_table"
+            ", error: %d",
+            field_id_meta_common_hash, status);
+        goto dealloc_resources;
+      }
+
+      status = tdi_key_field_set_value(key_hdl, field_id_meta_bit32_zero, 0);
+      if (status != TDI_SUCCESS) {
+        krnlmon_log_error(
+            "Unable to set value for key ID: %d for ecmp_hash_table"
+            ", error: %d",
+            field_id_meta_bit32_zero, status);
+        goto dealloc_resources;
+      }
+
+      if (entry_add) {
+        network_byte_order = nhop_handle & ~(SWITCH_HANDLE_TYPE_NHOP
+                                             << SWITCH_HANDLE_TYPE_SHIFT);
+
+        status = tdi_data_field_set_value(data_hdl, data_field_id,
+                                          network_byte_order);
+        if (status != TDI_SUCCESS) {
+          krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                            data_field_id, status);
+          goto dealloc_resources;
+        }
+
+        status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                     key_hdl, data_hdl);
+        if (status != TDI_SUCCESS) {
+          krnlmon_log_error("Unable to add %s entry, error: %d",
+                            LNW_ECMP_HASH_TABLE, status);
+          goto dealloc_resources;
+        }
+        total_ecmp_list++;
+      } else {
+        /* Delete an entry from target */
+        krnlmon_log_info("Delete ecmp_hash_table entry");
+        status = tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl,
+                                     key_hdl);
+        if (status != TDI_SUCCESS) {
+          krnlmon_log_error("Unable to delete %s entry, error: %d",
+                            LNW_ECMP_HASH_TABLE, status);
+          goto dealloc_resources;
+        }
+        total_ecmp_list--;
+      }
+      nhop_count++;
+    }
+    FOR_EACH_IN_LIST_END();
+    ecmp_list += nhop_count;
+  }
+  krnlmon_log_debug("Total ECMP hash entries created are: %d", total_ecmp_list);
+
+dealloc_resources:
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
 }

--- a/switchapi/es2k/switch_pd_routing.c
+++ b/switchapi/es2k/switch_pd_routing.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/es2k/switch_pd_routing.h
+++ b/switchapi/es2k/switch_pd_routing.h
@@ -24,25 +24,23 @@
 #include "switchapi/switch_nhop.h"
 #include "switchapi/switch_rmac_int.h"
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
 /** enum to decide the proper key and action based on ecmp or nhop
  * */
-typedef enum switch_ip_table_action_s
-{
+typedef enum switch_ip_table_action_s {
   SWITCH_ACTION_NHOP = 0,
   SWITCH_ACTION_NHOP_GROUP = 1,
   SWITCH_ACTION_NONE = 2
-}switch_ip_table_action_t;
+} switch_ip_table_action_t;
 
 /**
  * create pd_routing structure to hold
  * the data to be sent to
  * the backend to update the table */
-typedef struct switch_pd_routing_info_s
-{
+typedef struct switch_pd_routing_info_s {
   switch_handle_t neighbor_handle;
 
   switch_handle_t nexthop_handle;
@@ -56,57 +54,51 @@ typedef struct switch_pd_routing_info_s
 } switch_pd_routing_info_t;
 
 switch_status_t switch_pd_nexthop_table_entry(
-    switch_device_t device,
-    const switch_pd_routing_info_t  *api_nexthop_pd_info,
+    switch_device_t device, const switch_pd_routing_info_t* api_nexthop_pd_info,
     bool entry_add);
 
 switch_status_t switch_pd_neighbor_table_entry(
     switch_device_t device,
-    const switch_pd_routing_info_t  *api_neighbor_pd_info,
+    const switch_pd_routing_info_t* api_neighbor_pd_info, bool entry_add);
+
+switch_status_t switch_pd_rmac_table_entry(switch_device_t device,
+                                           switch_rmac_entry_t* rmac_entry,
+                                           switch_handle_t rif_handle,
+                                           bool entry_type);
+
+switch_status_t switch_pd_rif_mod_start_entry(switch_device_t device,
+                                              switch_rmac_entry_t* rmac_entry,
+                                              switch_handle_t rif_handle,
+                                              bool entry_add);
+
+switch_status_t switch_pd_rif_mod_mid_entry(switch_device_t device,
+                                            switch_rmac_entry_t* rmac_entry,
+                                            switch_handle_t rif_handle,
+                                            bool entry_add);
+
+switch_status_t switch_pd_rif_mod_last_entry(switch_device_t device,
+                                             switch_rmac_entry_t* rmac_entry,
+                                             switch_handle_t rif_handle,
+                                             bool entry_add);
+
+switch_status_t switch_pd_ipv4_table_entry(
+    switch_device_t device, const switch_api_route_entry_t* api_route_entry,
+    bool entry_add, switch_ip_table_action_t action);
+
+switch_status_t switch_pd_ipv6_table_entry(
+    switch_device_t device, const switch_api_route_entry_t* api_route_entry,
+    bool entry_add, switch_ip_table_action_t action);
+
+switch_status_t switch_pd_ecmp_hash_table_entry(
+    switch_device_t device, const switch_nhop_group_info_t* ecmp_info,
     bool entry_add);
 
-switch_status_t switch_pd_rmac_table_entry (
-    switch_device_t device,
-    switch_rmac_entry_t *rmac_entry,
-    switch_handle_t rif_handle,
+switch_status_t switch_routing_table_entry(
+    switch_device_t device, const switch_pd_routing_info_t* api_routing_info,
     bool entry_type);
 
-switch_status_t switch_pd_rif_mod_start_entry(
-    switch_device_t device,
-    switch_rmac_entry_t *rmac_entry,
-    switch_handle_t rif_handle,
-    bool entry_add);
-
-switch_status_t switch_pd_rif_mod_mid_entry(
-    switch_device_t device,
-    switch_rmac_entry_t *rmac_entry,
-    switch_handle_t rif_handle,
-    bool entry_add);
-
-switch_status_t switch_pd_rif_mod_last_entry(
-    switch_device_t device,
-    switch_rmac_entry_t *rmac_entry,
-    switch_handle_t rif_handle,
-    bool entry_add);
-
-switch_status_t switch_pd_ipv4_table_entry (switch_device_t device,
-    const switch_api_route_entry_t *api_route_entry,
-    bool entry_add, switch_ip_table_action_t action);
-
-switch_status_t switch_pd_ipv6_table_entry (switch_device_t device,
-    const switch_api_route_entry_t *api_route_entry,
-    bool entry_add, switch_ip_table_action_t action);
-
-switch_status_t switch_pd_ecmp_hash_table_entry(switch_device_t device,
-    const switch_nhop_group_info_t *ecmp_info, bool entry_add);
-
-switch_status_t switch_routing_table_entry (
-        switch_device_t device,
-        const switch_pd_routing_info_t *api_routing_info,
-        bool entry_type);
-
-#ifdef  __cplusplus
+#ifdef __cplusplus
 }
 #endif
 
-#endif 
+#endif

--- a/switchapi/es2k/switch_pd_routing.h
+++ b/switchapi/es2k/switch_pd_routing.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/es2k/switch_pd_tunnel.c
+++ b/switchapi/es2k/switch_pd_tunnel.c
@@ -15,565 +15,567 @@
  * limitations under the License.
  */
 
-#include "switchapi/switch_tunnel.h"
 #include "switch_pd_tunnel.h"
 
-#include "switchapi/switch_internal.h"
 #include "switch_pd_p4_name_mapping.h"
 #include "switch_pd_utils.h"
+#include "switchapi/switch_internal.h"
+#include "switchapi/switch_tunnel.h"
 
 switch_status_t switch_pd_tunnel_entry(
-    switch_device_t device,
-    const switch_api_tunnel_info_t *api_tunnel_info_t,
+    switch_device_t device, const switch_api_tunnel_info_t* api_tunnel_info_t,
     bool entry_add) {
+  tdi_status_t status;
 
-    tdi_status_t status;
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
 
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
+  tdi_dev_id_t dev_id = device;
 
-    tdi_dev_id_t dev_id = device;
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
+  uint32_t network_byte_order = 0;
 
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
-    uint32_t network_byte_order = 0;
+  krnlmon_log_debug("%s", __func__);
 
-    krnlmon_log_debug("%s", __func__);
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status =
+      tdi_table_from_name_get(info_hdl, LNW_VXLAN_ENCAP_MOD_TABLE, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_VXLAN_ENCAP_MOD_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_VXLAN_ENCAP_MOD_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table, error: %d",
+                      status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(
+      table_info_hdl, LNW_VXLAN_ENCAP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR,
+      &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_VXLAN_ENCAP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR,
+                      status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_set_value(key_hdl, field_id, 0 /*vni value*/);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to set value for key ID: %d for vxlan_encap_mod_table"
+        ", error: %d",
+        field_id, status);
+    goto dealloc_resources;
+  }
+
+  if (entry_add) {
+    /* Add an entry to target */
+    krnlmon_log_info(
+        "Populate vxlan encap action in vxlan_encap_mod_table for "
+        "tunnel interface %x",
+        (unsigned int)api_tunnel_info_t->overlay_rif_handle);
+
+    status = tdi_action_name_to_id(table_info_hdl,
+                                   LNW_VXLAN_ENCAP_MOD_TABLE_ACTION_VXLAN_ENCAP,
+                                   &action_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_VXLAN_ENCAP_MOD_TABLE_ACTION_VXLAN_ENCAP, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_flags_create(0, &flags_hdl);
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %s, "
+          "error: %d",
+          LNW_VXLAN_ENCAP_MOD_TABLE_ACTION_VXLAN_ENCAP, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_device_get(dev_id, &dev_hdl);
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_VXLAN_ENCAP_PARAM_SRC_ADDR, action_id,
+        &data_field_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_VXLAN_ENCAP_PARAM_SRC_ADDR, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_target_create(dev_hdl, &target_hdl);
+    network_byte_order = ntohl(api_tunnel_info_t->src_ip.ip.v4addr);
+    status = tdi_data_field_set_value_ptr(data_hdl, data_field_id,
+                                          (const uint8_t*)&network_byte_order,
+                                          sizeof(uint32_t));
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
     }
-    
-    status = tdi_session_create(dev_hdl, &session);
+
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_VXLAN_ENCAP_PARAM_DST_ADDR, action_id,
+        &data_field_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_VXLAN_ENCAP_PARAM_DST_ADDR, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_VXLAN_ENCAP_MOD_TABLE,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                 LNW_VXLAN_ENCAP_MOD_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
+    network_byte_order = ntohl(api_tunnel_info_t->dst_ip.ip.v4addr);
+    status = tdi_data_field_set_value_ptr(data_hdl, data_field_id,
+                                          (const uint8_t*)&network_byte_order,
+                                          sizeof(uint32_t));
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_VXLAN_ENCAP_MOD_TABLE, status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_VXLAN_ENCAP_PARAM_DST_PORT, action_id,
+        &data_field_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_VXLAN_ENCAP_PARAM_DST_PORT, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_VXLAN_ENCAP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR,
-                                  &field_id);
+    uint16_t network_byte_order_udp = ntohs(api_tunnel_info_t->udp_port);
+    status = tdi_data_field_set_value_ptr(
+        data_hdl, data_field_id, (const uint8_t*)&network_byte_order_udp,
+        sizeof(uint16_t));
     if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_VXLAN_ENCAP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR, status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_key_field_set_value(key_hdl, field_id, 0 /*vni value*/);
+    status = tdi_data_field_id_with_action_get(table_info_hdl,
+                                               LNW_ACTION_VXLAN_ENCAP_PARAM_VNI,
+                                               action_id, &data_field_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d for vxlan_encap_mod_table"
-                 ", error: %d", field_id, status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_VXLAN_ENCAP_PARAM_VNI, status);
+      goto dealloc_resources;
     }
 
-    if (entry_add) {
-        /* Add an entry to target */
-        krnlmon_log_info("Populate vxlan encap action in vxlan_encap_mod_table for "
-                  "tunnel interface %x",
-                  (unsigned int) api_tunnel_info_t->overlay_rif_handle);
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_VXLAN_ENCAP_MOD_TABLE_ACTION_VXLAN_ENCAP,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_VXLAN_ENCAP_MOD_TABLE_ACTION_VXLAN_ENCAP, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %s, "
-                     "error: %d", LNW_VXLAN_ENCAP_MOD_TABLE_ACTION_VXLAN_ENCAP, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_VXLAN_ENCAP_PARAM_SRC_ADDR,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_VXLAN_ENCAP_PARAM_SRC_ADDR, status);
-            goto dealloc_resources;
-        }
-
-        network_byte_order = ntohl(api_tunnel_info_t->src_ip.ip.v4addr);
-        status = tdi_data_field_set_value_ptr(data_hdl, data_field_id,
-                                              (const uint8_t *)&network_byte_order,
-                                              sizeof(uint32_t));
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_VXLAN_ENCAP_PARAM_DST_ADDR,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_VXLAN_ENCAP_PARAM_DST_ADDR, status);
-            goto dealloc_resources;
-        }
-
-        network_byte_order = ntohl(api_tunnel_info_t->dst_ip.ip.v4addr);
-        status = tdi_data_field_set_value_ptr(data_hdl, data_field_id,
-                                              (const uint8_t *)&network_byte_order,
-                                              sizeof(uint32_t));
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_VXLAN_ENCAP_PARAM_DST_PORT,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_VXLAN_ENCAP_PARAM_DST_PORT, status);
-            goto dealloc_resources;
-        }
-
-        uint16_t network_byte_order_udp = ntohs(api_tunnel_info_t->udp_port);
-        status = tdi_data_field_set_value_ptr(data_hdl, data_field_id,
-                                              (const uint8_t *)&network_byte_order_udp,
-                                              sizeof(uint16_t));
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_VXLAN_ENCAP_PARAM_VNI,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_VXLAN_ENCAP_PARAM_VNI, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value_ptr(data_hdl, data_field_id, 0,
-                                              sizeof(uint32_t));
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add %s entry, error: %d", 
-                   LNW_VXLAN_ENCAP_MOD_TABLE, status);
-            goto dealloc_resources;
-        }
-    } else {
-        /* Delete an entry from target */
-        krnlmon_log_info("Delete vxlan_encap_mod_table entry");
-        status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                     flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete %s entry, error: %d", 
-                     LNW_VXLAN_ENCAP_MOD_TABLE, status);
-            goto dealloc_resources;
-        }
+    status = tdi_data_field_set_value_ptr(data_hdl, data_field_id, 0,
+                                          sizeof(uint32_t));
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
     }
+
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to add %s entry, error: %d",
+                        LNW_VXLAN_ENCAP_MOD_TABLE, status);
+      goto dealloc_resources;
+    }
+  } else {
+    /* Delete an entry from target */
+    krnlmon_log_info("Delete vxlan_encap_mod_table entry");
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to delete %s entry, error: %d",
+                        LNW_VXLAN_ENCAP_MOD_TABLE, status);
+      goto dealloc_resources;
+    }
+  }
 
 dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
 }
 
 switch_status_t switch_pd_tunnel_term_entry(
     switch_device_t device,
-    const switch_api_tunnel_term_info_t *api_tunnel_term_info_t,
+    const switch_api_tunnel_term_info_t* api_tunnel_term_info_t,
     bool entry_add) {
+  tdi_status_t status;
 
-    tdi_status_t status;
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
 
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
+  tdi_dev_id_t dev_id = device;
 
-    tdi_dev_id_t dev_id = device;
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
+  uint32_t network_byte_order = 0;
 
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
-    uint32_t network_byte_order = 0;
+  krnlmon_log_debug("%s", __func__);
 
-    krnlmon_log_debug("%s", __func__);
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status =
+      tdi_table_from_name_get(info_hdl, LNW_IPV4_TUNNEL_TERM_TABLE, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_IPV4_TUNNEL_TERM_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_IPV4_TUNNEL_TERM_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table");
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(table_info_hdl,
+                                LNW_IPV4_TUNNEL_TERM_TABLE_KEY_TUNNEL_FLAG_TYPE,
+                                &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_IPV4_TUNNEL_TERM_TABLE_KEY_TUNNEL_FLAG_TYPE, status);
+    goto dealloc_resources;
+  }
+
+  /* From p4 file the value expected is TUNNEL_TYPE_VXLAN=2 */
+  status = tdi_key_field_set_value(key_hdl, field_id, 2);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to set value for key ID: %d of "
+        "ipv4_tunnel_term_table , error: %d",
+        field_id, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(
+      table_info_hdl, LNW_IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_SRC, &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s",
+                      LNW_IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_SRC);
+    goto dealloc_resources;
+  }
+
+  /* This refers to incoming packet fields, where SIP will be the remote_ip
+   * configured while creating tunnel */
+  network_byte_order = ntohl(api_tunnel_term_info_t->dst_ip.ip.v4addr);
+  status = tdi_key_field_set_value_ptr(
+      key_hdl, field_id, (const uint8_t*)&network_byte_order, sizeof(uint32_t));
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to set value for key ID: %d", field_id);
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(
+      table_info_hdl, LNW_IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_DST, &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s",
+                      LNW_IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_DST);
+    goto dealloc_resources;
+  }
+
+  /* This refers to incoming packet fields, where DIP will be the local_ip
+   * configured while creating tunnel */
+  network_byte_order = ntohl(api_tunnel_term_info_t->src_ip.ip.v4addr);
+  status = tdi_key_field_set_value_ptr(
+      key_hdl, field_id, (const uint8_t*)&network_byte_order, sizeof(uint32_t));
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to set value for key ID: %d", field_id);
+    goto dealloc_resources;
+  }
+
+  if (entry_add) {
+    krnlmon_log_info(
+        "Populate decap_outer_ipv4 action in ipv4_tunnel_term_table "
+        "for tunnel interface %x",
+        (unsigned int)api_tunnel_term_info_t->tunnel_handle);
+
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_IPV4_TUNNEL_TERM_TABLE_ACTION_DECAP_OUTER_IPV4,
+        &action_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_IPV4_TUNNEL_TERM_TABLE_ACTION_DECAP_OUTER_IPV4,
+                        status);
+      goto dealloc_resources;
     }
 
-    status = tdi_flags_create(0, &flags_hdl);
+    /* Add an entry to target */
+    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error(
+          "Unable to get action allocator for ID: %d, "
+          "error: %d",
+          action_id, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_device_get(dev_id, &dev_hdl);
+    status = tdi_data_field_id_with_action_get(
+        table_info_hdl, LNW_ACTION_DECAP_OUTER_IPV4_PARAM_TUNNEL_ID, action_id,
+        &data_field_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                        LNW_ACTION_DECAP_OUTER_IPV4_PARAM_TUNNEL_ID, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_target_create(dev_hdl, &target_hdl);
+    status = tdi_data_field_set_value(data_hdl, data_field_id,
+                                      api_tunnel_term_info_t->tunnel_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                        data_field_id, status);
+      goto dealloc_resources;
     }
-    
-    status = tdi_session_create(dev_hdl, &session);
+
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to add %s entry, error: %d",
+                        LNW_IPV4_TUNNEL_TERM_TABLE, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_IPV4_TUNNEL_TERM_TABLE,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                 LNW_IPV4_TUNNEL_TERM_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  } else {
+    /* Delete an entry from target */
+    krnlmon_log_info("Delete ipv4_tunnel_term_table entry");
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_IPV4_TUNNEL_TERM_TABLE, status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to delete %s entry, error: %d",
+                        LNW_IPV4_TUNNEL_TERM_TABLE, status);
+      goto dealloc_resources;
     }
-
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table");
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_IPV4_TUNNEL_TERM_TABLE_KEY_TUNNEL_FLAG_TYPE,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-                         LNW_IPV4_TUNNEL_TERM_TABLE_KEY_TUNNEL_FLAG_TYPE,
-			 status);
-        goto dealloc_resources;
-    }
-
-    /* From p4 file the value expected is TUNNEL_TYPE_VXLAN=2 */
-    status = tdi_key_field_set_value(key_hdl, field_id, 2);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d of "
-			  "ipv4_tunnel_term_table , error: %d",
-			  field_id, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_SRC,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get field ID for key: %s",
-                           LNW_IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_SRC);
-        goto dealloc_resources;
-    }
-
-    /* This refers to incoming packet fields, where SIP will be the remote_ip
-     * configured while creating tunnel */
-    network_byte_order = ntohl(api_tunnel_term_info_t->dst_ip.ip.v4addr);
-    status = tdi_key_field_set_value_ptr(key_hdl, field_id,
-                                         (const uint8_t *)&network_byte_order,
-                                         sizeof(uint32_t));
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d", field_id);
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_DST,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get field ID for key: %s",
-                 LNW_IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_DST);
-        goto dealloc_resources;
-    }
-
-    /* This refers to incoming packet fields, where DIP will be the local_ip
-     * configured while creating tunnel */
-    network_byte_order = ntohl(api_tunnel_term_info_t->src_ip.ip.v4addr);
-    status = tdi_key_field_set_value_ptr(key_hdl, field_id,
-                                         (const uint8_t *)&network_byte_order,
-                                         sizeof(uint32_t));
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d", field_id);
-        goto dealloc_resources;
-    }
-
-    if (entry_add) {
-        krnlmon_log_info("Populate decap_outer_ipv4 action in ipv4_tunnel_term_table "
-                  "for tunnel interface %x",
-                   (unsigned int) api_tunnel_term_info_t->tunnel_handle);
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_IPV4_TUNNEL_TERM_TABLE_ACTION_DECAP_OUTER_IPV4,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_IPV4_TUNNEL_TERM_TABLE_ACTION_DECAP_OUTER_IPV4, status);
-            goto dealloc_resources;
-        }
-
-        /* Add an entry to target */
-        status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator for ID: %d, "
-                     "error: %d", action_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_id_with_action_get(table_info_hdl,
-                                                   LNW_ACTION_DECAP_OUTER_IPV4_PARAM_TUNNEL_ID,
-                                                   action_id, &data_field_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
-                     LNW_ACTION_DECAP_OUTER_IPV4_PARAM_TUNNEL_ID, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_data_field_set_value(data_hdl, data_field_id,
-                                          api_tunnel_term_info_t->tunnel_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                     data_field_id, status);
-            goto dealloc_resources;
-        }
-
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add %s entry, error: %d", 
-                   LNW_IPV4_TUNNEL_TERM_TABLE, status);
-            goto dealloc_resources;
-        }
-
-    } else {
-        /* Delete an entry from target */
-        krnlmon_log_info("Delete ipv4_tunnel_term_table entry");
-        status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                     flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete %s entry, error: %d", 
-                     LNW_IPV4_TUNNEL_TERM_TABLE, status);
-            goto dealloc_resources;
-        }
-    }
+  }
 
 dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
 }
 
 switch_status_t switch_pd_vxlan_decap_mod_entry(
     switch_device_t device,
-    const switch_api_tunnel_term_info_t *api_tunnel_term_info_t,
+    const switch_api_tunnel_term_info_t* api_tunnel_term_info_t,
     bool entry_add) {
+  tdi_status_t status;
 
-    tdi_status_t status;
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
 
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
+  tdi_dev_id_t dev_id = device;
 
-    tdi_dev_id_t dev_id = device;
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
+  uint32_t network_byte_order = 0;
 
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
-    uint32_t network_byte_order = 0;
+  krnlmon_log_debug("%s", __func__);
 
-    krnlmon_log_debug("%s", __func__);
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_flags_create(0, &flags_hdl);
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
+
+  status =
+      tdi_table_from_name_get(info_hdl, LNW_VXLAN_DECAP_MOD_TABLE, &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_VXLAN_DECAP_MOD_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_IPV4_TUNNEL_TERM_TABLE, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table");
+    goto dealloc_resources;
+  }
+
+  status = tdi_key_field_id_get(
+      table_info_hdl, LNW_VXLAN_DECAP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR,
+      &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_VXLAN_DECAP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR,
+                      status);
+    goto dealloc_resources;
+  }
+
+  /* From p4 file the value expected is MOD_BLOB_PTR=0 */
+  status = tdi_key_field_set_value(key_hdl, field_id, 0);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to set value for key ID: %d of vxlan_decap_mod_table"
+        ", error: %d",
+        field_id, status);
+    goto dealloc_resources;
+  }
+
+  if (entry_add) {
+    krnlmon_log_info(
+        "Populate vxlan_decap_outer_ipv4 action in vxlan_decap_mod_table "
+        "for tunnel interface %x",
+        (unsigned int)api_tunnel_term_info_t->tunnel_handle);
+
+    status = tdi_action_name_to_id(
+        table_info_hdl, LNW_VXLAN_DECAP_MOD_TABLE_ACTION_VXLAN_DECAP_OUTER_IPV4,
+        &action_id);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                        LNW_VXLAN_DECAP_MOD_TABLE_ACTION_VXLAN_DECAP_OUTER_IPV4,
+                        status);
+      goto dealloc_resources;
     }
 
-    status = tdi_device_get(dev_id, &dev_hdl);
+    /* Add an entry to target */
+    status = tdi_table_entry_add(table_hdl, session, target_hdl, flags_hdl,
+                                 key_hdl, data_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to add %s entry, error: %d",
+                        LNW_VXLAN_DECAP_MOD_TABLE, status);
+      goto dealloc_resources;
     }
 
-    status = tdi_target_create(dev_hdl, &target_hdl);
+  } else {
+    /* Delete an entry from target */
+    krnlmon_log_info("Delete vxlan_decap_mod_table entry");
+    status =
+        tdi_table_entry_del(table_hdl, session, target_hdl, flags_hdl, key_hdl);
     if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
+      krnlmon_log_error("Unable to delete %s entry, error: %d",
+                        LNW_VXLAN_DECAP_MOD_TABLE, status);
+      goto dealloc_resources;
     }
-    
-    status = tdi_session_create(dev_hdl, &session);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_from_name_get(info_hdl,
-                                     LNW_VXLAN_DECAP_MOD_TABLE,
-                                     &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                 LNW_VXLAN_DECAP_MOD_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_IPV4_TUNNEL_TERM_TABLE, status);
-        goto dealloc_resources;
-    }
-
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table");
-        goto dealloc_resources;
-    }
-
-    status = tdi_key_field_id_get(table_info_hdl,
-                                  LNW_VXLAN_DECAP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR,
-                                  &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_VXLAN_DECAP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR, status);
-        goto dealloc_resources;
-    }
-
-    /* From p4 file the value expected is MOD_BLOB_PTR=0 */
-    status = tdi_key_field_set_value(key_hdl, field_id, 0);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d of vxlan_decap_mod_table"
-                 ", error: %d", field_id, status);
-        goto dealloc_resources;
-    }
-
-    if (entry_add) {
-        krnlmon_log_info("Populate vxlan_decap_outer_ipv4 action in vxlan_decap_mod_table "
-                  "for tunnel interface %x",
-                   (unsigned int) api_tunnel_term_info_t->tunnel_handle);
-
-        status = tdi_action_name_to_id(table_info_hdl,
-                                       LNW_VXLAN_DECAP_MOD_TABLE_ACTION_VXLAN_DECAP_OUTER_IPV4,
-                                       &action_id);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                     LNW_VXLAN_DECAP_MOD_TABLE_ACTION_VXLAN_DECAP_OUTER_IPV4, status);
-            goto dealloc_resources;
-        }
-
-        /* Add an entry to target */
-        status = tdi_table_entry_add(table_hdl, session, target_hdl,
-                                     flags_hdl, key_hdl, data_hdl);
-        if (status != TDI_SUCCESS) {
-          krnlmon_log_error("Unable to add %s entry, error: %d",
-                   LNW_VXLAN_DECAP_MOD_TABLE, status);
-            goto dealloc_resources;
-        }
-
-    } else {
-        /* Delete an entry from target */
-        krnlmon_log_info("Delete vxlan_decap_mod_table entry");
-        status = tdi_table_entry_del(table_hdl, session, target_hdl, 
-                                     flags_hdl, key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to delete %s entry, error: %d",
-                     LNW_VXLAN_DECAP_MOD_TABLE, status);
-            goto dealloc_resources;
-        }
-    }
+  }
 
 dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, entry_add);
-    return switch_pd_tdi_status_to_status(status);
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, entry_add);
+  return switch_pd_tdi_status_to_status(status);
 }

--- a/switchapi/es2k/switch_pd_tunnel.c
+++ b/switchapi/es2k/switch_pd_tunnel.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/es2k/switch_pd_tunnel.h
+++ b/switchapi/es2k/switch_pd_tunnel.h
@@ -21,27 +21,26 @@
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_handle.h"
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
 switch_status_t switch_pd_tunnel_entry(
-    switch_device_t device,
-    const switch_api_tunnel_info_t *api_tunnel_info_t,
+    switch_device_t device, const switch_api_tunnel_info_t* api_tunnel_info_t,
     bool entry_add);
 
 switch_status_t switch_pd_tunnel_term_entry(
     switch_device_t device,
-    const switch_api_tunnel_term_info_t *api_tunnel_term_info_t,
+    const switch_api_tunnel_term_info_t* api_tunnel_term_info_t,
     bool entry_add);
 
 switch_status_t switch_pd_vxlan_decap_mod_entry(
     switch_device_t device,
-    const switch_api_tunnel_term_info_t *api_tunnel_term_info_t,
+    const switch_api_tunnel_term_info_t* api_tunnel_term_info_t,
     bool entry_add);
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 }
 #endif
 
-#endif 
+#endif

--- a/switchapi/es2k/switch_pd_tunnel.h
+++ b/switchapi/es2k/switch_pd_tunnel.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_handle.h"
+#include "switchapi/switch_tunnel.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/switchapi/es2k/switch_pd_utils.c
+++ b/switchapi/es2k/switch_pd_utils.c
@@ -15,323 +15,324 @@
  * limitations under the License.
  */
 
-#include <net/if.h>
-
 #include "switch_pd_utils.h"
 
+#include <net/if.h>
+
+#include "bf_rt/bf_rt_common.h"
+#include "bf_types.h"
+#include "port_mgr/dpdk/bf_dpdk_port_if.h"
+#include "switch_pd_p4_name_mapping.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_rmac_int.h"
-#include "switch_pd_p4_name_mapping.h"
-
-#include "bf_types.h"
-#include "port_mgr/dpdk/bf_dpdk_port_if.h"
-#include "bf_rt/bf_rt_common.h"
 
 tdi_status_t switch_pd_get_physical_port_id(switch_device_t device,
                                             uint32_t netdev_port_id,
-                                            uint8_t *physical_port_id) {
-    tdi_status_t status;
+                                            uint8_t* physical_port_id) {
+  tdi_status_t status;
 
-    tdi_id_t field_id = 0;
-    tdi_id_t action_id = 0;
-    tdi_id_t data_field_id = 0;
+  tdi_id_t field_id = 0;
+  tdi_id_t action_id = 0;
+  tdi_id_t data_field_id = 0;
 
-    tdi_dev_id_t dev_id = device;
+  tdi_dev_id_t dev_id = device;
 
-    tdi_flags_hdl *flags_hdl = NULL;
-    tdi_target_hdl *target_hdl = NULL;
-    const tdi_device_hdl *dev_hdl = NULL;
-    tdi_session_hdl *session = NULL;
-    const tdi_info_hdl *info_hdl = NULL;
-    tdi_table_key_hdl *key_hdl = NULL;
-    tdi_table_data_hdl *data_hdl = NULL;
-    const tdi_table_hdl *table_hdl = NULL;
-    const tdi_table_info_hdl *table_info_hdl = NULL;
-    uint32_t network_byte_order = 0;
-    uint64_t get_pd_phy_port = 0;
+  tdi_flags_hdl* flags_hdl = NULL;
+  tdi_target_hdl* target_hdl = NULL;
+  const tdi_device_hdl* dev_hdl = NULL;
+  tdi_session_hdl* session = NULL;
+  const tdi_info_hdl* info_hdl = NULL;
+  tdi_table_key_hdl* key_hdl = NULL;
+  tdi_table_data_hdl* data_hdl = NULL;
+  const tdi_table_hdl* table_hdl = NULL;
+  const tdi_table_info_hdl* table_info_hdl = NULL;
+  uint32_t network_byte_order = 0;
+  uint64_t get_pd_phy_port = 0;
 
-    krnlmon_log_debug("Entered: %s", __func__);
+  krnlmon_log_debug("Entered: %s", __func__);
 
-    status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
-        goto dealloc_resources;
-    }
+  status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_flags_create(0, &flags_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create flags handle, error: %d", status);
-        goto dealloc_resources;
-    }
+  status = tdi_flags_create(0, &flags_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create flags handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_device_get(dev_id, &dev_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get device handle, error: %d", status);
-        goto dealloc_resources;
-    }
+  status = tdi_device_get(dev_id, &dev_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get device handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_target_create(dev_hdl, &target_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create target handle, error: %d", status);
-        goto dealloc_resources;
-    }
+  status = tdi_target_create(dev_hdl, &target_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create target handle, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_session_create(dev_hdl, &session);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to create tdi session, error: %d", status);
-        goto dealloc_resources;
-    }
+  status = tdi_session_create(dev_hdl, &session);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to create tdi session, error: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_table_from_name_get(
-                         info_hdl,
-                         LNW_HANDLE_TX_FROM_HOST_TO_OVS_AND_OVS_TO_WIRE_TABLE,
-                         &table_hdl);
-    if (status != TDI_SUCCESS || !table_hdl) {
-        krnlmon_log_error("Unable to get table handle for: %s, error: %d",
-                 LNW_HANDLE_TX_FROM_HOST_TO_OVS_AND_OVS_TO_WIRE_TABLE,
-                 status);
-        goto dealloc_resources;
-    }
+  status = tdi_table_from_name_get(
+      info_hdl, LNW_HANDLE_TX_FROM_HOST_TO_OVS_AND_OVS_TO_WIRE_TABLE,
+      &table_hdl);
+  if (status != TDI_SUCCESS || !table_hdl) {
+    krnlmon_log_error("Unable to get table handle for: %s, error: %d",
+                      LNW_HANDLE_TX_FROM_HOST_TO_OVS_AND_OVS_TO_WIRE_TABLE,
+                      status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_table_key_allocate(table_hdl, &key_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
-                 LNW_HANDLE_TX_FROM_HOST_TO_OVS_AND_OVS_TO_WIRE_TABLE,
-                 status);
-        goto dealloc_resources;
-    }
+  status = tdi_table_key_allocate(table_hdl, &key_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to allocate key handle for: %s, error: %d",
+                      LNW_HANDLE_TX_FROM_HOST_TO_OVS_AND_OVS_TO_WIRE_TABLE,
+                      status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_table_info_get(table_hdl, &table_info_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get table info handle for table, error: %d", status);
-        goto dealloc_resources;
-    }
+  status = tdi_table_info_get(table_hdl, &table_info_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get table info handle for table, error: %d",
+                      status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_key_field_id_get(table_info_hdl,
-                            LNW_HANDLE_OVS_TO_WIRE_TABLE_KEY_META_COMMON_VSI,
-                            &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_HANDLE_OVS_TO_WIRE_TABLE_KEY_META_COMMON_VSI, status);
-        goto dealloc_resources;
-    }
+  status = tdi_key_field_id_get(
+      table_info_hdl, LNW_HANDLE_OVS_TO_WIRE_TABLE_KEY_META_COMMON_VSI,
+      &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_HANDLE_OVS_TO_WIRE_TABLE_KEY_META_COMMON_VSI, status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_key_field_set_value(key_hdl, field_id, netdev_port_id - SWITCH_PD_TARGET_VPORT_OFFSET);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d for vxlan_encap_mod_table"
-                 ", error: %d", field_id, status);
-        goto dealloc_resources;
-    }
+  status = tdi_key_field_set_value(
+      key_hdl, field_id, netdev_port_id - SWITCH_PD_TARGET_VPORT_OFFSET);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to set value for key ID: %d for vxlan_encap_mod_table"
+        ", error: %d",
+        field_id, status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_key_field_id_get(table_info_hdl,
-                        LNW_HANDLE_OVS_TO_WIRE_TABLE_KEY_USER_META_BIT32_ZEROS,
-                        &field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
-               LNW_HANDLE_OVS_TO_WIRE_TABLE_KEY_USER_META_BIT32_ZEROS, status);
-        goto dealloc_resources;
-    }
+  status = tdi_key_field_id_get(
+      table_info_hdl, LNW_HANDLE_OVS_TO_WIRE_TABLE_KEY_USER_META_BIT32_ZEROS,
+      &field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get field ID for key: %s, error: %d",
+                      LNW_HANDLE_OVS_TO_WIRE_TABLE_KEY_USER_META_BIT32_ZEROS,
+                      status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_key_field_set_value(key_hdl, field_id, 0);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to set value for key ID: %d for vxlan_encap_mod_table"
-                 ", error: %d", field_id, status);
-        goto dealloc_resources;
-    }
+  status = tdi_key_field_set_value(key_hdl, field_id, 0);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to set value for key ID: %d for vxlan_encap_mod_table"
+        ", error: %d",
+        field_id, status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_action_name_to_id(table_info_hdl,
-                                   LNW_HANDLE_OVS_TO_WIRE_TABLE_ACTION_SET_DEST,
-                                   &action_id);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                 LNW_HANDLE_OVS_TO_WIRE_TABLE_ACTION_SET_DEST, status);
-        goto dealloc_resources;
-    }
+  status = tdi_action_name_to_id(
+      table_info_hdl, LNW_HANDLE_OVS_TO_WIRE_TABLE_ACTION_SET_DEST, &action_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
+                      LNW_HANDLE_OVS_TO_WIRE_TABLE_ACTION_SET_DEST, status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get action allocator for ID: %s, "
-                 "error: %d", LNW_HANDLE_OVS_TO_WIRE_TABLE_ACTION_SET_DEST,
-                 status);
-        goto dealloc_resources;
-    }
+  status = tdi_table_action_data_allocate(table_hdl, action_id, &data_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to get action allocator for ID: %s, "
+        "error: %d",
+        LNW_HANDLE_OVS_TO_WIRE_TABLE_ACTION_SET_DEST, status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_table_entry_get(table_hdl, session, target_hdl, flags_hdl,
-                                 key_hdl, data_hdl);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get data handle for netdev: %d", status);
-        goto dealloc_resources;
-    }
+  status = tdi_table_entry_get(table_hdl, session, target_hdl, flags_hdl,
+                               key_hdl, data_hdl);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get data handle for netdev: %d", status);
+    goto dealloc_resources;
+  }
 
-    status = tdi_data_field_id_with_action_get(table_info_hdl,
-                     LNW_HANDLE_OVS_TO_WIRE_TABLE_ACTION_SET_DEST_PARAM_PORT_ID,
-                     action_id,
-                     &data_field_id);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Unable to get action allocator ID for: %s, error: %d",
-                 LNW_HANDLE_OVS_TO_WIRE_TABLE_ACTION_SET_DEST_PARAM_PORT_ID,
-                 status);
-        goto dealloc_resources;
-    }
-//    status = tdi_data_field_get_value_ptr(data_hdl, data_field_id,
-//                                          sizeof(*physical_port_id),
-//                                          physical_port_id);
-    status = tdi_data_field_get_value(data_hdl, data_field_id,
-                                      &get_pd_phy_port);
-    if (status != TDI_SUCCESS) {
-        krnlmon_log_error("Failed to get value for the handle: %d", status);
-        goto dealloc_resources;
-    }
-    *physical_port_id = (uint8_t) (get_pd_phy_port & 0xff);
+  status = tdi_data_field_id_with_action_get(
+      table_info_hdl,
+      LNW_HANDLE_OVS_TO_WIRE_TABLE_ACTION_SET_DEST_PARAM_PORT_ID, action_id,
+      &data_field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error(
+        "Unable to get action allocator ID for: %s, error: %d",
+        LNW_HANDLE_OVS_TO_WIRE_TABLE_ACTION_SET_DEST_PARAM_PORT_ID, status);
+    goto dealloc_resources;
+  }
+  //    status = tdi_data_field_get_value_ptr(data_hdl, data_field_id,
+  //                                          sizeof(*physical_port_id),
+  //                                          physical_port_id);
+  status = tdi_data_field_get_value(data_hdl, data_field_id, &get_pd_phy_port);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Failed to get value for the handle: %d", status);
+    goto dealloc_resources;
+  }
+  *physical_port_id = (uint8_t)(get_pd_phy_port & 0xff);
 dealloc_resources:
-    status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl,
-                                                key_hdl, data_hdl,
-                                                session, true);
-    return switch_pd_tdi_status_to_status(status);
+  status = tdi_switch_pd_deallocate_resources(flags_hdl, target_hdl, key_hdl,
+                                              data_hdl, session, true);
+  return switch_pd_tdi_status_to_status(status);
 }
 
-void
-switch_pd_to_get_port_id(switch_api_rif_info_t *port_rif_info)
-{
-    switch_handle_t rmac_handle = SWITCH_API_INVALID_HANDLE;
-    switch_status_t status = SWITCH_STATUS_SUCCESS;
-    switch_rmac_info_t *rmac_info = NULL;
-    switch_rmac_entry_t *rmac_entry = NULL;
-    switch_node_t *node = NULL;
-    bf_dev_id_t bf_dev_id = 0;
-    static char mac_str[SWITCH_PD_MAC_STR_LENGTH];
-    bf_status_t bf_status;
-    uint32_t port_id = 0;
+void switch_pd_to_get_port_id(switch_api_rif_info_t* port_rif_info) {
+  switch_handle_t rmac_handle = SWITCH_API_INVALID_HANDLE;
+  switch_status_t status = SWITCH_STATUS_SUCCESS;
+  switch_rmac_info_t* rmac_info = NULL;
+  switch_rmac_entry_t* rmac_entry = NULL;
+  switch_node_t* node = NULL;
+  bf_dev_id_t bf_dev_id = 0;
+  static char mac_str[SWITCH_PD_MAC_STR_LENGTH];
+  bf_status_t bf_status;
+  uint32_t port_id = 0;
 
-    /*rmac_handle will have source mac info. get rmac_info from rmac_handle */
-    rmac_handle = port_rif_info->rmac_handle;
-    status = switch_rmac_get(bf_dev_id, rmac_handle, &rmac_info);
-    if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error("Cannot get rmac info for handle 0x%x, error: %d",
-                  rmac_handle, status);
-        return;
-    }
-
-    SWITCH_LIST_GET_HEAD(rmac_info->rmac_list, node);
-    rmac_entry = (switch_rmac_entry_t *)node->data;
-
-    if (!rmac_entry) {
-        krnlmon_log_error("Cannot get rmac_entry for handle 0x%x", rmac_handle);
-        return;
-    }
-
-    snprintf(mac_str, sizeof(mac_str),
-             "%02x:%02x:%02x:%02x:%02x:%02x", rmac_entry->mac.mac_addr[0],
-                                              rmac_entry->mac.mac_addr[1],
-                                              rmac_entry->mac.mac_addr[2],
-                                              rmac_entry->mac.mac_addr[3],
-                                              rmac_entry->mac.mac_addr[4],
-                                              rmac_entry->mac.mac_addr[5]);
-    mac_str[SWITCH_PD_MAC_STR_LENGTH-1] = '\0';
-
-    bf_status = bf_pal_get_port_id_from_mac(bf_dev_id, mac_str, &port_id);
-    if (bf_status != BF_SUCCESS) {
-        // First SWITCH_PD_TARGET_VPORT_OFFSET entries are reserved for
-        // MEV h/w ports. Hence VSI ID/Port ID should be offset with
-        // SWITCH_PD_TARGET_VPORT_OFFSET
-        // As per CP_INIT conf file on IMC, VSI_ID/Port ID is added as part of
-        // 2nd byte in interface MAC address.
-        // Example: If MAC address of an IPDF interface is 00:11:22:33:44:55,
-        //          then VSI_ID/Port ID is 0x11 for that interface.
-        port_id = rmac_entry->mac.mac_addr[1] + SWITCH_PD_TARGET_VPORT_OFFSET;
-        krnlmon_log_info("Failed to get the port ID, error: %d, Deriving "
-                          "port ID from second byte of MAC address: "
-                          "%s", bf_status, mac_str);
-    }
-
-    port_rif_info->port_id = port_id;
-
-    krnlmon_log_debug("Found port ID: %d for MAC: %s", port_id, mac_str);
+  /*rmac_handle will have source mac info. get rmac_info from rmac_handle */
+  rmac_handle = port_rif_info->rmac_handle;
+  status = switch_rmac_get(bf_dev_id, rmac_handle, &rmac_info);
+  if (status != SWITCH_STATUS_SUCCESS) {
+    krnlmon_log_error("Cannot get rmac info for handle 0x%x, error: %d",
+                      rmac_handle, status);
     return;
+  }
+
+  SWITCH_LIST_GET_HEAD(rmac_info->rmac_list, node);
+  rmac_entry = (switch_rmac_entry_t*)node->data;
+
+  if (!rmac_entry) {
+    krnlmon_log_error("Cannot get rmac_entry for handle 0x%x", rmac_handle);
+    return;
+  }
+
+  snprintf(mac_str, sizeof(mac_str), "%02x:%02x:%02x:%02x:%02x:%02x",
+           rmac_entry->mac.mac_addr[0], rmac_entry->mac.mac_addr[1],
+           rmac_entry->mac.mac_addr[2], rmac_entry->mac.mac_addr[3],
+           rmac_entry->mac.mac_addr[4], rmac_entry->mac.mac_addr[5]);
+  mac_str[SWITCH_PD_MAC_STR_LENGTH - 1] = '\0';
+
+  bf_status = bf_pal_get_port_id_from_mac(bf_dev_id, mac_str, &port_id);
+  if (bf_status != BF_SUCCESS) {
+    // First SWITCH_PD_TARGET_VPORT_OFFSET entries are reserved for
+    // MEV h/w ports. Hence VSI ID/Port ID should be offset with
+    // SWITCH_PD_TARGET_VPORT_OFFSET
+    // As per CP_INIT conf file on IMC, VSI_ID/Port ID is added as part of
+    // 2nd byte in interface MAC address.
+    // Example: If MAC address of an IPDF interface is 00:11:22:33:44:55,
+    //          then VSI_ID/Port ID is 0x11 for that interface.
+    port_id = rmac_entry->mac.mac_addr[1] + SWITCH_PD_TARGET_VPORT_OFFSET;
+    krnlmon_log_info(
+        "Failed to get the port ID, error: %d, Deriving "
+        "port ID from second byte of MAC address: "
+        "%s",
+        bf_status, mac_str);
+  }
+
+  port_rif_info->port_id = port_id;
+
+  krnlmon_log_debug("Found port ID: %d for MAC: %s", port_id, mac_str);
+  return;
 }
 
-tdi_status_t tdi_switch_pd_deallocate_resources(tdi_flags_hdl *flags_hdl,
-                                                tdi_target_hdl *target_hdl,
-                                                tdi_table_key_hdl *key_hdl,
-                                                tdi_table_data_hdl *data_hdl,
-                                                tdi_session_hdl *session,
+tdi_status_t tdi_switch_pd_deallocate_resources(tdi_flags_hdl* flags_hdl,
+                                                tdi_target_hdl* target_hdl,
+                                                tdi_table_key_hdl* key_hdl,
+                                                tdi_table_data_hdl* data_hdl,
+                                                tdi_session_hdl* session,
                                                 bool entry_type) {
-    tdi_status_t retval = TDI_SUCCESS;
-    tdi_status_t status;
+  tdi_status_t retval = TDI_SUCCESS;
+  tdi_status_t status;
 
-    status = tdi_deallocate_flag(flags_hdl);
+  status = tdi_deallocate_flag(flags_hdl);
+  if (!retval) retval = status;
+
+  status = tdi_deallocate_target(target_hdl);
+  if (!retval) retval = status;
+
+  if (entry_type) {
+    // Data handle is created only when entry is added to backend
+    status = tdi_deallocate_table_data(data_hdl);
     if (!retval) retval = status;
+  }
 
-    status = tdi_deallocate_target(target_hdl);
-    if (!retval) retval = status;
+  status = tdi_deallocate_table_key(key_hdl);
+  if (!retval) retval = status;
 
-    if (entry_type) {
-        // Data handle is created only when entry is added to backend
-        status = tdi_deallocate_table_data(data_hdl);
-        if (!retval) retval = status;
-    }
+  status = tdi_deallocate_session(session);
+  if (!retval) retval = status;
 
-    status = tdi_deallocate_table_key(key_hdl);
-    if (!retval) retval = status;
-
-    status = tdi_deallocate_session(session);
-    if (!retval) retval = status;
-
-    return retval;
+  return retval;
 }
 
-tdi_status_t tdi_deallocate_flag(tdi_flags_hdl *flags_hdl) {
-    tdi_status_t status = TDI_SUCCESS;
-    if (flags_hdl) {
-        status = tdi_flags_delete(flags_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to deallocate flags handle, error: %d", status);
-        }
+tdi_status_t tdi_deallocate_flag(tdi_flags_hdl* flags_hdl) {
+  tdi_status_t status = TDI_SUCCESS;
+  if (flags_hdl) {
+    status = tdi_flags_delete(flags_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to deallocate flags handle, error: %d", status);
     }
-    return status;
+  }
+  return status;
 }
 
-tdi_status_t tdi_deallocate_target(tdi_target_hdl *target_hdl) {
-    tdi_status_t status = TDI_SUCCESS;
-    if (target_hdl) {
-        status = tdi_target_delete(target_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Unable to deallocate target handle, error: %d", status);
-        }
+tdi_status_t tdi_deallocate_target(tdi_target_hdl* target_hdl) {
+  tdi_status_t status = TDI_SUCCESS;
+  if (target_hdl) {
+    status = tdi_target_delete(target_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Unable to deallocate target handle, error: %d",
+                        status);
     }
-    return status;
+  }
+  return status;
 }
 
-tdi_status_t tdi_deallocate_table_data(tdi_table_data_hdl *data_hdl) {
-    tdi_status_t status = TDI_SUCCESS;
-    if (data_hdl) {
-        status = tdi_table_data_deallocate(data_hdl);
-        if(status != TDI_SUCCESS) {
-            krnlmon_log_error("Failed to deallocate data handle, error: %d", status);
-        }
+tdi_status_t tdi_deallocate_table_data(tdi_table_data_hdl* data_hdl) {
+  tdi_status_t status = TDI_SUCCESS;
+  if (data_hdl) {
+    status = tdi_table_data_deallocate(data_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Failed to deallocate data handle, error: %d", status);
     }
-    return status;
+  }
+  return status;
 }
 
-tdi_status_t tdi_deallocate_table_key(tdi_table_key_hdl *key_hdl) {
-    tdi_status_t status = TDI_SUCCESS;
-    if (key_hdl) {
-        status = tdi_table_key_deallocate(key_hdl);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Failed to deallocate key handle, error: %d", status);
-        }
+tdi_status_t tdi_deallocate_table_key(tdi_table_key_hdl* key_hdl) {
+  tdi_status_t status = TDI_SUCCESS;
+  if (key_hdl) {
+    status = tdi_table_key_deallocate(key_hdl);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Failed to deallocate key handle, error: %d", status);
     }
-    return status;
+  }
+  return status;
 }
 
-tdi_status_t tdi_deallocate_session(tdi_session_hdl *session) {
-    tdi_status_t status = TDI_SUCCESS;
-    if (session) {
-        status = tdi_session_destroy(session);
-        if (status != TDI_SUCCESS) {
-            krnlmon_log_error("Failed to destroy session, error: %d", status);
-        }
+tdi_status_t tdi_deallocate_session(tdi_session_hdl* session) {
+  tdi_status_t status = TDI_SUCCESS;
+  if (session) {
+    status = tdi_session_destroy(session);
+    if (status != TDI_SUCCESS) {
+      krnlmon_log_error("Failed to destroy session, error: %d", status);
     }
-    return status;
+  }
+  return status;
 }

--- a/switchapi/es2k/switch_pd_utils.h
+++ b/switchapi/es2k/switch_pd_utils.h
@@ -15,26 +15,24 @@
  * limitations under the License.
  */
 
-#include "switchapi/switch_base_types.h"
-#include "switchapi/switch_handle.h"
-#include "switchapi/switch_rif.h"
-
 #include "bf_pal/bf_pal_port_intf.h"
 #include "bf_rt/bf_rt_common.h"
 #include "bf_types.h"
 #include "port_mgr/dpdk/bf_dpdk_port_if.h"
-
-#include "tdi/common/tdi_defs.h"
+#include "switchapi/switch_base_types.h"
+#include "switchapi/switch_handle.h"
+#include "switchapi/switch_rif.h"
+#include "tdi/common/c_frontend/tdi_info.h"
 #include "tdi/common/c_frontend/tdi_init.h"
 #include "tdi/common/c_frontend/tdi_session.h"
-#include "tdi/common/c_frontend/tdi_info.h"
 #include "tdi/common/c_frontend/tdi_table.h"
 #include "tdi/common/c_frontend/tdi_table_info.h"
+#include "tdi/common/tdi_defs.h"
 
 #ifndef __SWITCH_PD_UTILS_H__
 #define __SWITCH_PD_UTILS_H__
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -49,47 +47,45 @@ extern "C" {
 #define RMAC_BASE 0
 #define RMAC_BYTES_OFFSET 2
 #define RMAC_START_OFFSET RMAC_BASE
-#define RMAC_MID_OFFSET RMAC_START_OFFSET+RMAC_BYTES_OFFSET
-#define RMAC_LAST_OFFSET RMAC_MID_OFFSET+RMAC_BYTES_OFFSET
+#define RMAC_MID_OFFSET RMAC_START_OFFSET + RMAC_BYTES_OFFSET
+#define RMAC_LAST_OFFSET RMAC_MID_OFFSET + RMAC_BYTES_OFFSET
 
 tdi_status_t switch_pd_get_physical_port_id(switch_device_t device,
                                             uint32_t netdev_port_id,
-                                            uint8_t *physical_port_id);
+                                            uint8_t* physical_port_id);
 
 bf_status_t switch_pd_allocate_handle_session(const bf_dev_id_t device_id,
-                                              const char *pipeline_name,
-                                              bf_rt_info_hdl **bfrt_info_hdl_t,
-                                              bf_rt_session_hdl **session_t);
+                                              const char* pipeline_name,
+                                              bf_rt_info_hdl** bfrt_info_hdl_t,
+                                              bf_rt_session_hdl** session_t);
 
-bf_status_t switch_pd_deallocate_handle_session(bf_rt_table_key_hdl *key_hdl_t,
-                                                bf_rt_table_data_hdl *data_hdl_t,
-                                                bf_rt_session_hdl *session_t,
-                                                bool entry_type);
+bf_status_t switch_pd_deallocate_handle_session(
+    bf_rt_table_key_hdl* key_hdl_t, bf_rt_table_data_hdl* data_hdl_t,
+    bf_rt_session_hdl* session_t, bool entry_type);
 
-void switch_pd_to_get_port_id(switch_api_rif_info_t *port_rif_info);
+void switch_pd_to_get_port_id(switch_api_rif_info_t* port_rif_info);
 
-tdi_status_t tdi_switch_pd_deallocate_resources(tdi_flags_hdl *flags_hdl,
-                                                tdi_target_hdl *target_hdl,
-                                                tdi_table_key_hdl *key_hdl,
-                                                tdi_table_data_hdl *data_hdl,
-                                                tdi_session_hdl *session,
+tdi_status_t tdi_switch_pd_deallocate_resources(tdi_flags_hdl* flags_hdl,
+                                                tdi_target_hdl* target_hdl,
+                                                tdi_table_key_hdl* key_hdl,
+                                                tdi_table_data_hdl* data_hdl,
+                                                tdi_session_hdl* session,
                                                 bool entry_type);
 
 switch_status_t switch_pd_tdi_status_to_status(tdi_status_t pd_status);
 
-tdi_status_t tdi_deallocate_flag(tdi_flags_hdl *flags_hdl);
+tdi_status_t tdi_deallocate_flag(tdi_flags_hdl* flags_hdl);
 
-tdi_status_t tdi_deallocate_target(tdi_target_hdl *target_hdl);
+tdi_status_t tdi_deallocate_target(tdi_target_hdl* target_hdl);
 
-tdi_status_t tdi_deallocate_table_data(tdi_table_data_hdl *data_hdl);
+tdi_status_t tdi_deallocate_table_data(tdi_table_data_hdl* data_hdl);
 
-tdi_status_t tdi_deallocate_table_key(tdi_table_key_hdl *key_hdl);
+tdi_status_t tdi_deallocate_table_key(tdi_table_key_hdl* key_hdl);
 
-tdi_status_t tdi_deallocate_session(tdi_session_hdl *session);
+tdi_status_t tdi_deallocate_session(tdi_session_hdl* session);
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 }
 #endif
 
 #endif
-

--- a/switchapi/es2k/switch_pd_utils.h
+++ b/switchapi/es2k/switch_pd_utils.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 
+#ifndef __SWITCH_PD_UTILS_H__
+#define __SWITCH_PD_UTILS_H__
+
 #include "bf_pal/bf_pal_port_intf.h"
 #include "bf_rt/bf_rt_common.h"
 #include "bf_types.h"
@@ -22,15 +25,17 @@
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_handle.h"
 #include "switchapi/switch_rif.h"
+
+// clang-format off
+// tdi_info.h does not include the header files it depends on,
+// so we force tdi_defs.h to precede it.
+#include "tdi/common/tdi_defs.h"
 #include "tdi/common/c_frontend/tdi_info.h"
 #include "tdi/common/c_frontend/tdi_init.h"
 #include "tdi/common/c_frontend/tdi_session.h"
 #include "tdi/common/c_frontend/tdi_table.h"
 #include "tdi/common/c_frontend/tdi_table_info.h"
-#include "tdi/common/tdi_defs.h"
-
-#ifndef __SWITCH_PD_UTILS_H__
-#define __SWITCH_PD_UTILS_H__
+// clang-format on
 
 #ifdef __cplusplus
 extern "C" {

--- a/switchapi/es2k/switch_rif.c
+++ b/switchapi/es2k/switch_rif.c
@@ -18,16 +18,14 @@
 #include <net/if.h>
 
 /* Local header includes */
-#include "switchapi/switch_rif.h"
-#include "switchapi/switch_rif_int.h"
-
+#include "bf_types.h"
+#include "switch_pd_utils.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_device.h"
 #include "switchapi/switch_internal.h"
+#include "switchapi/switch_rif.h"
+#include "switchapi/switch_rif_int.h"
 #include "switchapi/switch_status.h"
-#include "switch_pd_utils.h"
-
-#include "bf_types.h"
 
 /*
  * Routine Description:
@@ -75,11 +73,9 @@ switch_status_t switch_rif_free(switch_device_t device) {
 }
 
 switch_status_t switch_api_rif_attribute_get(
-    const switch_device_t device,
-    const switch_handle_t rif_handle,
-    const switch_uint64_t rif_flags,
-    switch_api_rif_info_t *api_rif_info) {
-  switch_rif_info_t *rif_info = NULL;
+    const switch_device_t device, const switch_handle_t rif_handle,
+    const switch_uint64_t rif_flags, switch_api_rif_info_t* api_rif_info) {
+  switch_rif_info_t* rif_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!SWITCH_RIF_HANDLE(rif_handle)) {
@@ -88,9 +84,7 @@ switch_status_t switch_api_rif_attribute_get(
         "rif attribute get: Invalid rif handle on device %d, "
         "rif handle 0x%lx: "
         "error: %s\n",
-        device,
-        rif_handle,
-        switch_error_to_string(status));
+        device, rif_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -103,12 +97,11 @@ switch_status_t switch_api_rif_attribute_get(
   return status;
 }
 
-switch_status_t switch_api_rif_create(
-    switch_device_t device,
-    switch_api_rif_info_t *api_rif_info,
-    switch_handle_t *rif_handle) {
+switch_status_t switch_api_rif_create(switch_device_t device,
+                                      switch_api_rif_info_t* api_rif_info,
+                                      switch_handle_t* rif_handle) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
-  switch_rif_info_t *rif_info = NULL;
+  switch_rif_info_t* rif_info = NULL;
 
   if (api_rif_info->rmac_handle == SWITCH_API_INVALID_HANDLE) {
     status = switch_api_device_default_rmac_handle_get(
@@ -121,8 +114,7 @@ switch_status_t switch_api_rif_create(
     krnlmon_log_error(
         "rif create: Invalid rmac handle on device %d: "
         "error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -132,24 +124,23 @@ switch_status_t switch_api_rif_create(
   status = switch_rif_get(device, *rif_handle, &rif_info);
   CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
 
-  /* When multipipe support is available in P4-OVS, make port_id as 
+  /* When multipipe support is available in P4-OVS, make port_id as
    * in_port_id and out_port_id. Use accordingly for respective pipelines. */
   api_rif_info->port_id = -1;
   api_rif_info->phy_port_id = -1;
 
   switch_pd_to_get_port_id(api_rif_info);
 
-  SWITCH_MEMCPY(&rif_info->api_rif_info,
-                api_rif_info,
+  SWITCH_MEMCPY(&rif_info->api_rif_info, api_rif_info,
                 sizeof(switch_api_rif_info_t));
-  
+
   return status;
 }
 
 switch_status_t switch_api_rif_delete(switch_device_t device,
-                                               switch_handle_t rif_handle) {
+                                      switch_handle_t rif_handle) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
-  switch_rif_info_t *rif_info = NULL;
+  switch_rif_info_t* rif_info = NULL;
 
   status = switch_rif_get(device, rif_handle, &rif_info);
   CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
@@ -159,4 +150,3 @@ switch_status_t switch_api_rif_delete(switch_device_t device,
 
   return status;
 }
-

--- a/switchapi/es2k/switch_rif.c
+++ b/switchapi/es2k/switch_rif.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/es2k/switch_rmac.c
+++ b/switchapi/es2k/switch_rmac.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/es2k/switch_rmac.c
+++ b/switchapi/es2k/switch_rmac.c
@@ -16,10 +16,10 @@
  */
 
 #include "switchapi/switch_rmac.h"
-#include "switchapi/switch_rmac_int.h"
 
-#include "switchapi/switch_internal.h"
 #include "switch_pd_routing.h"
+#include "switchapi/switch_internal.h"
+#include "switchapi/switch_rmac_int.h"
 
 /*
  * Routine Description:
@@ -33,7 +33,7 @@
  *             Failure status code on error
  */
 switch_status_t switch_rmac_init(switch_device_t device) {
-  switch_rmac_context_t *rmac_ctx = NULL;
+  switch_rmac_context_t* rmac_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   rmac_ctx = SWITCH_MALLOC(device, sizeof(switch_rmac_context_t), 0x1);
@@ -42,19 +42,17 @@ switch_status_t switch_rmac_init(switch_device_t device) {
     krnlmon_log_error(
         "rmac_init:Failed to allocate memory for switch_rmac_context_t "
         "on device %d ,error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
-  status = switch_device_api_context_set(
-      device, SWITCH_API_TYPE_RMAC, (void *)rmac_ctx);
+  status = switch_device_api_context_set(device, SWITCH_API_TYPE_RMAC,
+                                         (void*)rmac_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "rmac_init: Failed to set device api context on device %d "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -63,13 +61,13 @@ switch_status_t switch_rmac_init(switch_device_t device) {
 
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
-        "rmac init: Failed to initialize handle SWITCH_HANDLE_TYPE_RMAC on device %d "
+        "rmac init: Failed to initialize handle SWITCH_HANDLE_TYPE_RMAC on "
+        "device %d "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
-  
+
   krnlmon_log_info("rmac init successful on device %d\n", device);
   return status;
 }
@@ -86,17 +84,16 @@ switch_status_t switch_rmac_init(switch_device_t device) {
  *             Failure status code on error
  */
 switch_status_t switch_rmac_free(switch_device_t device) {
-  switch_rmac_context_t *rmac_ctx = NULL;
+  switch_rmac_context_t* rmac_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_RMAC, (void **)&rmac_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_RMAC,
+                                         (void**)&rmac_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "rmac free: Failed to get device api context on device %d "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -105,10 +102,9 @@ switch_status_t switch_rmac_free(switch_device_t device) {
     krnlmon_log_error(
         "rmac free: Failed to free handle SWITCH_HANDLE_TYPE_RMAC on device %d "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
   }
-  
+
   SWITCH_FREE(device, rmac_ctx);
   status = switch_device_api_context_set(device, SWITCH_API_TYPE_RMAC, NULL);
   SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
@@ -117,10 +113,9 @@ switch_status_t switch_rmac_free(switch_device_t device) {
 }
 
 switch_status_t switch_api_router_mac_group_create(
-    const switch_device_t device,
-    const switch_rmac_type_t rmac_type,
-    switch_handle_t *rmac_handle) {
-  switch_rmac_info_t *rmac_info = NULL;
+    const switch_device_t device, const switch_rmac_type_t rmac_type,
+    switch_handle_t* rmac_handle) {
+  switch_rmac_info_t* rmac_info = NULL;
   switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
@@ -130,8 +125,7 @@ switch_status_t switch_api_router_mac_group_create(
     krnlmon_log_error(
         "rmac group create: Failed to create rmac handle on device %d "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -140,8 +134,7 @@ switch_status_t switch_api_router_mac_group_create(
     krnlmon_log_error(
         "rmac group create: Failed to get rmac info on device %d "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -155,8 +148,7 @@ switch_status_t switch_api_router_mac_group_create(
   krnlmon_log_info(
       "rmac group created on device %d, "
       "rmac handle 0x%lx \n",
-      device,
-      handle);
+      device, handle);
 
   return status;
 }
@@ -164,19 +156,17 @@ switch_status_t switch_api_router_mac_group_create(
 switch_status_t switch_api_router_mac_group_delete(
     const switch_device_t device, const switch_handle_t rif_handle,
     const switch_handle_t rmac_handle) {
-  switch_rmac_info_t *rmac_info = NULL;
-  switch_rmac_entry_t *rmac_entry = NULL;
-  switch_node_t *node = NULL;
+  switch_rmac_info_t* rmac_info = NULL;
+  switch_rmac_entry_t* rmac_entry = NULL;
+  switch_node_t* node = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
-  
+
   if (!SWITCH_RMAC_HANDLE(rmac_handle)) {
     status = SWITCH_STATUS_INVALID_HANDLE;
     krnlmon_log_error(
         "rmac group delete: Invalid rmac handle 0x%lx: on device %d "
         ",error: %s\n",
-        rmac_handle,
-        device,
-        switch_error_to_string(status));
+        rmac_handle, device, switch_error_to_string(status));
     return status;
   }
 
@@ -186,24 +176,19 @@ switch_status_t switch_api_router_mac_group_delete(
     krnlmon_log_error(
         "rmac group delete: Failed to get rmac info on device %d rmac hadle "
         "0x%lx: ,error: %s\n",
-        device,
-        rmac_handle,
-        switch_error_to_string(status));
+        device, rmac_handle, switch_error_to_string(status));
     return status;
   }
 
   FOR_EACH_IN_LIST(rmac_info->rmac_list, node) {
     rmac_entry = node->data;
-    status =
-        switch_api_router_mac_delete(device, rif_handle, rmac_handle,
-                                     &rmac_entry->mac);
+    status = switch_api_router_mac_delete(device, rif_handle, rmac_handle,
+                                          &rmac_entry->mac);
     if (status != SWITCH_STATUS_SUCCESS) {
       krnlmon_log_error(
           "rmac group delete: Failed to delete router mac on device %d "
           "rmac handle 0x%lx: ,error: %s\n",
-          device,
-          rmac_handle,
-          switch_error_to_string(status));
+          device, rmac_handle, switch_error_to_string(status));
     }
   }
   FOR_EACH_IN_LIST_END();
@@ -213,29 +198,25 @@ switch_status_t switch_api_router_mac_group_delete(
     krnlmon_log_error(
         "rmac group delete: Failed to delete rmac handle 0x%lx: on device %d "
         ",error: %s\n",
-        rmac_handle,
-        device,
-        switch_error_to_string(status));
+        rmac_handle, device, switch_error_to_string(status));
     return status;
   }
 
   krnlmon_log_info(
       "rmac group deleted on device %d, "
       "rmac handle 0x%lx\n",
-      device,
-      rmac_handle);
+      device, rmac_handle);
 
   return status;
 }
 
-switch_status_t switch_api_router_mac_delete(
-    const switch_device_t device,
-    const switch_handle_t rif_handle,
-    const switch_handle_t rmac_handle,
-    const switch_mac_addr_t *mac) {
-  switch_rmac_info_t *rmac_info = NULL;
-  switch_rmac_entry_t *rmac_entry = NULL;
-  switch_node_t *node = NULL;
+switch_status_t switch_api_router_mac_delete(const switch_device_t device,
+                                             const switch_handle_t rif_handle,
+                                             const switch_handle_t rmac_handle,
+                                             const switch_mac_addr_t* mac) {
+  switch_rmac_info_t* rmac_info = NULL;
+  switch_rmac_entry_t* rmac_entry = NULL;
+  switch_node_t* node = NULL;
   bool entry_found = FALSE;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
@@ -244,9 +225,7 @@ switch_status_t switch_api_router_mac_delete(
     krnlmon_log_error(
         "router mac delete: Invalid rmac handle 0x%lx, mac %s: on device %d "
         ",error: %s\n",
-        rmac_handle,
-        switch_macaddress_to_string(mac),
-        device,
+        rmac_handle, switch_macaddress_to_string(mac), device,
         switch_error_to_string(status));
     return status;
   }
@@ -257,13 +236,12 @@ switch_status_t switch_api_router_mac_delete(
     krnlmon_log_error(
         "router mac delete: Failed to get rmac info, handle 0x%lx "
         ",error: %s\n",
-        rmac_handle,
-        switch_error_to_string(status));
+        rmac_handle, switch_error_to_string(status));
     return status;
   }
 
   FOR_EACH_IN_LIST(rmac_info->rmac_list, node) {
-    rmac_entry = (switch_rmac_entry_t *)node->data;
+    rmac_entry = (switch_rmac_entry_t*)node->data;
     if (SWITCH_MEMCMP(&(rmac_entry->mac), mac, sizeof(switch_mac_addr_t)) ==
         0) {
       entry_found = TRUE;
@@ -277,9 +255,7 @@ switch_status_t switch_api_router_mac_delete(
     krnlmon_log_error(
         "router mac delete: Failed to find rmac entry on device %d, rmac "
         "handle 0x%lx, mac %s: ,error: %s\n",
-        device,
-        rmac_handle,
-        switch_macaddress_to_string(mac),
+        device, rmac_handle, switch_macaddress_to_string(mac),
         switch_error_to_string(status));
     return status;
   }
@@ -288,13 +264,11 @@ switch_status_t switch_api_router_mac_delete(
     status = switch_pd_rmac_table_entry(device, rmac_entry, rif_handle, false);
     if (status != SWITCH_STATUS_SUCCESS) {
       krnlmon_log_error(
-        "router mac delete: Failed to delete PD rmac entry on device %d ,"
-        "rmac handle 0x%lx, mac %s: "
-        ",error: %s\n",
-        device,
-        rmac_handle,
-        switch_macaddress_to_string(mac),
-        switch_error_to_string(status));
+          "router mac delete: Failed to delete PD rmac entry on device %d ,"
+          "rmac handle 0x%lx, mac %s: "
+          ",error: %s\n",
+          device, rmac_handle, switch_macaddress_to_string(mac),
+          switch_error_to_string(status));
       return status;
     }
   }
@@ -305,17 +279,13 @@ switch_status_t switch_api_router_mac_delete(
         "router mac delete: Failed to delete from switch list on device %d ,"
         "rmac handle 0x%lx, mac %s: "
         ",error: %s\n",
-        device,
-        rmac_handle,
-        switch_macaddress_to_string(mac),
+        device, rmac_handle, switch_macaddress_to_string(mac),
         switch_error_to_string(status));
     return status;
   }
 
   krnlmon_log_info("rmac deleted on device %d, rmac handle 0x%lx, mac %s\n",
-                   device,
-                   rmac_handle,
-                   switch_macaddress_to_string(mac));
+                   device, rmac_handle, switch_macaddress_to_string(mac));
 
   if (rmac_entry) {
     SWITCH_FREE(device, rmac_entry);
@@ -324,13 +294,12 @@ switch_status_t switch_api_router_mac_delete(
   return status;
 }
 
-switch_status_t switch_api_router_mac_add(
-    const switch_device_t device,
-    const switch_handle_t rmac_handle,
-    const switch_mac_addr_t *mac) {
-  switch_rmac_info_t *rmac_info = NULL;
-  switch_rmac_entry_t *rmac_entry = NULL;
-  switch_node_t *node = NULL;
+switch_status_t switch_api_router_mac_add(const switch_device_t device,
+                                          const switch_handle_t rmac_handle,
+                                          const switch_mac_addr_t* mac) {
+  switch_rmac_info_t* rmac_info = NULL;
+  switch_rmac_entry_t* rmac_entry = NULL;
+  switch_node_t* node = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!SWITCH_RMAC_HANDLE(rmac_handle)) {
@@ -338,9 +307,7 @@ switch_status_t switch_api_router_mac_add(
     krnlmon_log_error(
         "router mac add: Invalid rmac handle 0x%lx: on device %d "
         ",error: %s\n",
-        rmac_handle,
-        device,
-        switch_error_to_string(status));
+        rmac_handle, device, switch_error_to_string(status));
     return status;
   }
 
@@ -350,9 +317,7 @@ switch_status_t switch_api_router_mac_add(
     krnlmon_log_error(
         "router mac add: Failed to get rmac info on device %d, rmac "
         "handle 0x%lx: ,error: %s\n",
-        device,
-        rmac_handle,
-        switch_error_to_string(status));
+        device, rmac_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -361,14 +326,12 @@ switch_status_t switch_api_router_mac_add(
     krnlmon_log_error(
         "router mac add: Invalid mac on device %d, rmac handle 0x%lx: "
         ",error: %s\n",
-        device,
-        rmac_handle,
-        switch_error_to_string(status));
+        device, rmac_handle, switch_error_to_string(status));
     return status;
   }
 
   FOR_EACH_IN_LIST(rmac_info->rmac_list, node) {
-    rmac_entry = (switch_rmac_entry_t *)node->data;
+    rmac_entry = (switch_rmac_entry_t*)node->data;
     if (SWITCH_MEMCMP(&(rmac_entry->mac), mac, sizeof(switch_mac_addr_t)) ==
         0) {
       return SWITCH_STATUS_ITEM_ALREADY_EXISTS;
@@ -382,9 +345,7 @@ switch_status_t switch_api_router_mac_add(
     krnlmon_log_error(
         "router mac add: Failed to allocate memory for switch_rmac_entry_t "
         "on device %d rmac handle 0x%lx: ,error: %s\n",
-        device,
-        rmac_handle,
-        switch_error_to_string(status));
+        device, rmac_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -394,8 +355,9 @@ switch_status_t switch_api_router_mac_add(
 
   SWITCH_LIST_INSERT(&(rmac_info->rmac_list), &(rmac_entry->node), rmac_entry);
 
-  krnlmon_log_info("RMAC added on device %d, rmac handle 0x%lx, mac %s\n", device,
-             rmac_handle, switch_macaddress_to_string(&rmac_entry->mac));
+  krnlmon_log_info("RMAC added on device %d, rmac handle 0x%lx, mac %s\n",
+                   device, rmac_handle,
+                   switch_macaddress_to_string(&rmac_entry->mac));
 
   return status;
 }

--- a/switchapi/es2k/switch_table.c
+++ b/switchapi/es2k/switch_table.c
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-#include "switchapi/switch_internal.h"
 #include "switchapi/switch_table.h"
+
+#include "switchapi/switch_internal.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -24,7 +25,7 @@ extern "C" {
 
 #define __FILE_ID__ SWITCH_TABLE
 
-static char *switch_table_id_to_string(switch_table_id_t table_id) {
+static char* switch_table_id_to_string(switch_table_id_t table_id) {
   switch (table_id) {
     case SWITCH_TABLE_INGRESS_PORT_MAPPING:
       return "ingress port mapping";
@@ -101,33 +102,33 @@ static char *switch_table_id_to_string(switch_table_id_t table_id) {
     case SWITCH_TABLE_TUNNEL_MPLS:
       return "mpls";
     case SWITCH_TABLE_IPV4_VTEP:
-          return "ipv4 vtep";
+      return "ipv4 vtep";
     case SWITCH_TABLE_IPV6_VTEP:
-          return "ipv4 vtep";
+      return "ipv4 vtep";
     case SWITCH_TABLE_TUNNEL_TERM:
-          return "tunnel term";
+      return "tunnel term";
     case SWITCH_TABLE_EGRESS_IPV4_ACL:
-          return "egress ipv4 acl";
+      return "egress ipv4 acl";
     case SWITCH_TABLE_EGRESS_IPV6_ACL:
-          return "egress ipv6 acl";
+      return "egress ipv6 acl";
     case SWITCH_TABLE_ECN_ACL:
-          return "ecn acl";
+      return "ecn acl";
     case SWITCH_TABLE_PFC_ACL:
-          return "pfc acl";
+      return "pfc acl";
     case SWITCH_TABLE_EGRESS_PFC_ACL:
-          return "egress pfc acl";
+      return "egress pfc acl";
     case SWITCH_TABLE_MAX_ACL:
-          return "max acl";
+      return "max acl";
     case SWITCH_TABLE_INGRESS_QOS_MAP:
-          return "ingress qos map";
+      return "ingress qos map";
     case SWITCH_TABLE_WRED:
-          return "wred";
+      return "wred";
     case SWITCH_TABLE_NEIGHBOR:
-          return "neighbor";
+      return "neighbor";
     case SWITCH_TABLE_TUNNEL_SIP_REWRITE:
-          return "tunnel sip rewrite";
+      return "tunnel sip rewrite";
     case SWITCH_TABLE_MAX:
-          return "none";
+      return "none";
     /* BD */
     case SWITCH_TABLE_PORT_VLAN_TO_BD_MAPPING:
       return "port vlan bd mapping";
@@ -280,17 +281,16 @@ static char *switch_table_id_to_string(switch_table_id_t table_id) {
 }
 
 switch_status_t switch_table_init(switch_device_t device,
-                                  switch_size_t *table_sizes) {
-  switch_table_t *table_info = NULL;
+                                  switch_size_t* table_sizes) {
+  switch_table_t* table_info = NULL;
   switch_uint32_t index = 0;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
-  switch_char_t *table_str = NULL;
+  switch_char_t* table_str = NULL;
 
   status = switch_device_table_get(device, &table_info);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error("table init: Failed to get table info on device %d:%s",
-              device,
-              switch_error_to_string(status));
+                      device, switch_error_to_string(status));
     return status;
   }
 
@@ -301,8 +301,8 @@ switch_status_t switch_table_init(switch_device_t device,
     if (table_sizes[index]) {
       table_info[index].valid = TRUE;
       table_str = switch_table_id_to_string(index);
-      SWITCH_MEMCPY(
-          &table_info[index].table_name, table_str, strlen(table_str));
+      SWITCH_MEMCPY(&table_info[index].table_name, table_str,
+                    strlen(table_str));
     }
   }
 
@@ -310,14 +310,13 @@ switch_status_t switch_table_init(switch_device_t device,
 }
 
 switch_status_t switch_table_free(switch_device_t device) {
-  switch_table_t *table_info = NULL;
+  switch_table_t* table_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   status = switch_device_table_get(device, &table_info);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error("table free: Failed to get table info on device %d:%s",
-             device,
-             switch_error_to_string(status));
+                      device, switch_error_to_string(status));
     return status;
   }
 
@@ -327,8 +326,8 @@ switch_status_t switch_table_free(switch_device_t device) {
 
 switch_status_t switch_api_table_size_get_internal(switch_device_t device,
                                                    switch_table_id_t table_id,
-                                                   switch_size_t *table_size) {
-  switch_table_t *table_info = NULL;
+                                                   switch_size_t* table_size) {
+  switch_table_t* table_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(SWITCH_TABLE_ID_VALID(table_id));
@@ -336,9 +335,9 @@ switch_status_t switch_api_table_size_get_internal(switch_device_t device,
 
   status = switch_device_table_get(device, &table_info);
   if (status != SWITCH_STATUS_SUCCESS) {
-    krnlmon_log_error("get table size: Failed to get table info on device %d, error: %s",
-             device,
-             switch_error_to_string(status));
+    krnlmon_log_error(
+        "get table size: Failed to get table info on device %d, error: %s",
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -347,14 +346,14 @@ switch_status_t switch_api_table_size_get_internal(switch_device_t device,
   return status;
 }
 
-switch_status_t switch_table_default_sizes_get(switch_size_t *table_sizes) {
+switch_status_t switch_table_default_sizes_get(switch_size_t* table_sizes) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   switch_uint16_t index = 0;
 
   if (!table_sizes) {
     status = SWITCH_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("Failed to get table default size, error: %s",
-             switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -792,13 +791,12 @@ switch_status_t switch_table_default_sizes_get(switch_size_t *table_sizes) {
   return status;
 }
 
-
 #ifdef __cplusplus
 }
 #endif
 
 switch_status_t switch_api_table_size_get(switch_device_t device,
                                           switch_table_id_t table_id,
-                                          switch_size_t *table_size) {
-    return switch_api_table_size_get_internal(device, table_id, table_size);
+                                          switch_size_t* table_size) {
+  return switch_api_table_size_get_internal(device, table_id, table_size);
 }

--- a/switchapi/es2k/switch_table.c
+++ b/switchapi/es2k/switch_table.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/es2k/switch_tunnel.c
+++ b/switchapi/es2k/switch_tunnel.c
@@ -16,17 +16,15 @@
  */
 
 #include "switchapi/switch_tunnel.h"
-#include "switch_pd_tunnel.h"
 
+#include "switch_pd_tunnel.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_status.h"
 
-switch_status_t switch_api_tunnel_delete(
-    const switch_handle_t tunnel_handle) {
-
+switch_status_t switch_api_tunnel_delete(const switch_handle_t tunnel_handle) {
   switch_device_t device = 0;
-  switch_tunnel_info_t *tunnel_info = NULL;
+  switch_tunnel_info_t* tunnel_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(SWITCH_TUNNEL_HANDLE(tunnel_handle));
@@ -34,9 +32,7 @@ switch_status_t switch_api_tunnel_delete(
     krnlmon_log_error(
         "Failed to delete tunnel on device %d due to invalid, "
         "tunnel handle 0x%lx: ,error: %s",
-        device,
-        tunnel_handle,
-        switch_error_to_string(status));
+        device, tunnel_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -45,40 +41,36 @@ switch_status_t switch_api_tunnel_delete(
     krnlmon_log_error(
         "Failed to get tunnel info on device %d of tunnel handle 0x%lx: "
         "error: %s\n",
-        device,
-        tunnel_handle,
-        switch_error_to_string(status));
+        device, tunnel_handle, switch_error_to_string(status));
     return status;
   }
 
   status = switch_pd_tunnel_entry(device, &tunnel_info->api_tunnel_info, false);
   if (status != SWITCH_STATUS_SUCCESS) {
-      krnlmon_log_error(
-          "Failed to delete tunnel entry on device %d: ,"
-          "error: %s\n",
-          device,
-          switch_error_to_string(status));
-      return status;
+    krnlmon_log_error(
+        "Failed to delete tunnel entry on device %d: ,"
+        "error: %s\n",
+        device, switch_error_to_string(status));
+    return status;
   }
 
   status = switch_tunnel_handle_delete(device, tunnel_handle);
   if (status != SWITCH_STATUS_SUCCESS) {
-      krnlmon_log_error(
-          "Failed to delete tunnel handle on device %d: "
-          ",error: %s\n",
-          device,
-          switch_error_to_string(status));
-      return status;
+    krnlmon_log_error(
+        "Failed to delete tunnel handle on device %d: "
+        ",error: %s\n",
+        device, switch_error_to_string(status));
+    return status;
   }
 
   return status;
 }
 
 // Stubbed code to enabe compilation
-switch_status_t switch_api_tunnel_term_delete (
+switch_status_t switch_api_tunnel_term_delete(
     switch_handle_t tunnel_term_handle) {
-  switch_tunnel_term_info_t *tunnel_term_info = NULL;
-  switch_api_tunnel_term_info_t *api_tunnel_term_info = NULL;
+  switch_tunnel_term_info_t* tunnel_term_info = NULL;
+  switch_api_tunnel_term_info_t* api_tunnel_term_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   switch_device_t device = 0;
 
@@ -89,29 +81,26 @@ switch_status_t switch_api_tunnel_term_delete (
     krnlmon_log_error(
         "Failed to get tunnel term info on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
   api_tunnel_term_info = &tunnel_term_info->api_tunnel_term_info;
 
   status = switch_pd_tunnel_term_entry(device, api_tunnel_term_info, false);
   if (status != SWITCH_STATUS_SUCCESS) {
-      krnlmon_log_error(
-          "Failed to delete tunnel term entry on device %d: "
-          ",error: %s\n",
-          device,
-          switch_error_to_string(status));
-      return status;
+    krnlmon_log_error(
+        "Failed to delete tunnel term entry on device %d: "
+        ",error: %s\n",
+        device, switch_error_to_string(status));
+    return status;
   }
   status = switch_tunnel_term_handle_delete(device, tunnel_term_handle);
   if (status != SWITCH_STATUS_SUCCESS) {
-      krnlmon_log_error(
-          "Failed to delete tunnel term handle on device %d: "
-          ",error: %s\n",
-          device,
-          switch_error_to_string(status));
-      return status;
+    krnlmon_log_error(
+        "Failed to delete tunnel term handle on device %d: "
+        ",error: %s\n",
+        device, switch_error_to_string(status));
+    return status;
   }
 
   return status;
@@ -119,101 +108,94 @@ switch_status_t switch_api_tunnel_term_delete (
 
 switch_status_t switch_api_tunnel_create(
     const switch_device_t device,
-    const switch_api_tunnel_info_t *api_tunnel_info,
-    switch_handle_t *tunnel_handle) {
+    const switch_api_tunnel_info_t* api_tunnel_info,
+    switch_handle_t* tunnel_handle) {
+  switch_status_t status = SWITCH_STATUS_SUCCESS;
+  switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
+  switch_tunnel_info_t* tunnel_info = NULL;
 
-    switch_status_t status = SWITCH_STATUS_SUCCESS;
-    switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
-    switch_tunnel_info_t *tunnel_info = NULL;
+  handle = switch_tunnel_handle_create(device);
+  if (handle == SWITCH_API_INVALID_HANDLE) {
+    status = SWITCH_STATUS_NO_MEMORY;
+    krnlmon_log_error(
+        "Failed to create tunnel handle on device %d: "
+        ",error: %s\n",
+        device, switch_error_to_string(status));
+    return status;
+  }
 
-    handle = switch_tunnel_handle_create(device);
-    if (handle == SWITCH_API_INVALID_HANDLE) {
-        status = SWITCH_STATUS_NO_MEMORY;
-        krnlmon_log_error("Failed to create tunnel handle on device %d: "
-                 ",error: %s\n",
-                 device, switch_error_to_string(status));
-        return status;
-    }
+  status = switch_tunnel_get(device, handle, &tunnel_info);
+  if (status != SWITCH_STATUS_SUCCESS) {
+    krnlmon_log_error(
+        "Failed to get tunnel info on device %d: "
+        ",error: %s\n",
+        device, switch_error_to_string(status));
+    return status;
+  }
 
-    status = switch_tunnel_get(device, handle, &tunnel_info);
-    if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error(
-            "Failed to get tunnel info on device %d: "
-            ",error: %s\n",
-            device,
-            switch_error_to_string(status));
-        return status;
-    }
+  status = switch_pd_tunnel_entry(device, api_tunnel_info, true);
+  if (status != SWITCH_STATUS_SUCCESS) {
+    krnlmon_log_error(
+        "Failed to create tunnel entry on device %d: "
+        ",error: %s\n",
+        device, switch_error_to_string(status));
+    return status;
+  }
 
-    status = switch_pd_tunnel_entry(device, api_tunnel_info, true);
-    if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error(
-            "Failed to create tunnel entry on device %d: "
-            ",error: %s\n",
-            device,
-            switch_error_to_string(status));
-        return status;
-    }
-
-    SWITCH_MEMCPY(&tunnel_info->api_tunnel_info,
-                api_tunnel_info,
+  SWITCH_MEMCPY(&tunnel_info->api_tunnel_info, api_tunnel_info,
                 sizeof(switch_api_tunnel_info_t));
 
-    *tunnel_handle = handle;
-    return SWITCH_STATUS_SUCCESS;
+  *tunnel_handle = handle;
+  return SWITCH_STATUS_SUCCESS;
 }
 
 switch_status_t switch_api_tunnel_term_create(
     const switch_device_t device,
-    const switch_api_tunnel_term_info_t *api_tunnel_term_info,
-    switch_handle_t *tunnel_term_handle) {
-    switch_status_t status = SWITCH_STATUS_SUCCESS;
-    switch_tunnel_term_info_t *tunnel_term_info = NULL;
+    const switch_api_tunnel_term_info_t* api_tunnel_term_info,
+    switch_handle_t* tunnel_term_handle) {
+  switch_status_t status = SWITCH_STATUS_SUCCESS;
+  switch_tunnel_term_info_t* tunnel_term_info = NULL;
 
-    switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
+  switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
 
-    handle = switch_tunnel_term_handle_create(device);
-    if (handle == SWITCH_API_INVALID_HANDLE) {
-        status = SWITCH_STATUS_NO_MEMORY;
-        krnlmon_log_error(
-            "Failed to create tunnel term handle on device %d: "
-            ",error: %s\n",
-            device,
-            switch_error_to_string(status));
-        return status;
-    }
+  handle = switch_tunnel_term_handle_create(device);
+  if (handle == SWITCH_API_INVALID_HANDLE) {
+    status = SWITCH_STATUS_NO_MEMORY;
+    krnlmon_log_error(
+        "Failed to create tunnel term handle on device %d: "
+        ",error: %s\n",
+        device, switch_error_to_string(status));
+    return status;
+  }
 
-    status = switch_tunnel_term_get(device, handle, &tunnel_term_info);
-    if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error(
-            "Failed to get tunnel term info on device %d: "
-            ",error: %s\n",
-            device,
-            switch_error_to_string(status));
-        return status;
-    }
+  status = switch_tunnel_term_get(device, handle, &tunnel_term_info);
+  if (status != SWITCH_STATUS_SUCCESS) {
+    krnlmon_log_error(
+        "Failed to get tunnel term info on device %d: "
+        ",error: %s\n",
+        device, switch_error_to_string(status));
+    return status;
+  }
 
-    status = switch_pd_tunnel_term_entry(device, api_tunnel_term_info, true);
-    if (status != SWITCH_STATUS_SUCCESS) {
-        krnlmon_log_error(
-            "Failed to create tunnel term entry on device %d: "
-            ",error: %s\n",
-            device,
-            switch_error_to_string(status));
-        return status;
-    }
+  status = switch_pd_tunnel_term_entry(device, api_tunnel_term_info, true);
+  if (status != SWITCH_STATUS_SUCCESS) {
+    krnlmon_log_error(
+        "Failed to create tunnel term entry on device %d: "
+        ",error: %s\n",
+        device, switch_error_to_string(status));
+    return status;
+  }
 
-    SWITCH_MEMCPY(&tunnel_term_info->api_tunnel_term_info,
-                api_tunnel_term_info,
+  SWITCH_MEMCPY(&tunnel_term_info->api_tunnel_term_info, api_tunnel_term_info,
                 sizeof(switch_api_tunnel_term_info_t));
 
-    *tunnel_term_handle = handle;
+  *tunnel_term_handle = handle;
 
-    return SWITCH_STATUS_SUCCESS;
+  return SWITCH_STATUS_SUCCESS;
 }
 
 switch_status_t switch_tunnel_init(switch_device_t device) {
-  switch_tunnel_context_t *tunnel_ctx = NULL;
+  switch_tunnel_context_t* tunnel_ctx = NULL;
   switch_size_t tunnel_table_size = 0;
   switch_size_t tunnel_term_table_size = 0;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
@@ -225,30 +207,28 @@ switch_status_t switch_tunnel_init(switch_device_t device) {
     krnlmon_log_error(
         "Failed to allocate memory for switch_tunnel_context_t on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
   SWITCH_MEMSET(tunnel_ctx, 0x0, sizeof(switch_tunnel_context_t));
 
-  status = switch_device_api_context_set(
-      device, SWITCH_API_TYPE_TUNNEL, (void *)tunnel_ctx);
+  status = switch_device_api_context_set(device, SWITCH_API_TYPE_TUNNEL,
+                                         (void*)tunnel_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "Failed to set device api context on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
-  status = switch_api_table_size_get(
-      device, SWITCH_TABLE_TUNNEL, &tunnel_table_size);
+  status = switch_api_table_size_get(device, SWITCH_TABLE_TUNNEL,
+                                     &tunnel_table_size);
   SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
 
-  status = switch_api_table_size_get(
-      device, SWITCH_TABLE_TUNNEL_TERM, &tunnel_term_table_size);
+  status = switch_api_table_size_get(device, SWITCH_TABLE_TUNNEL_TERM,
+                                     &tunnel_term_table_size);
   SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
 
 #if 0
@@ -266,25 +246,23 @@ switch_status_t switch_tunnel_init(switch_device_t device) {
   }
 #endif
 
-  status = switch_handle_type_init(
-      device, SWITCH_HANDLE_TYPE_TUNNEL, tunnel_table_size);
+  status = switch_handle_type_init(device, SWITCH_HANDLE_TYPE_TUNNEL,
+                                   tunnel_table_size);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "Failed to init handle SWITCH_HANDLE_TYPE_TUNNEL on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     goto cleanup;
   }
 
-  status = switch_handle_type_init(
-      device, SWITCH_HANDLE_TYPE_TUNNEL_TERM, tunnel_term_table_size);
+  status = switch_handle_type_init(device, SWITCH_HANDLE_TYPE_TUNNEL_TERM,
+                                   tunnel_term_table_size);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "Failed to init handle SWITCH_HANDLE_TYPE_TUNNEL_TERM on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     goto cleanup;
   }
 
@@ -297,17 +275,16 @@ cleanup:
 }
 
 switch_status_t switch_tunnel_free(switch_device_t device) {
-  switch_tunnel_context_t *tunnel_ctx = NULL;
+  switch_tunnel_context_t* tunnel_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_TUNNEL, (void **)&tunnel_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_TUNNEL,
+                                         (void**)&tunnel_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "Failed to get device api context on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -316,8 +293,7 @@ switch_status_t switch_tunnel_free(switch_device_t device) {
     krnlmon_log_error(
         "Failed to free handle SWITCH_HANDLE_TYPE_TUNNEL on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
   }
 
   status = switch_handle_type_free(device, SWITCH_HANDLE_TYPE_TUNNEL_TERM);
@@ -325,8 +301,7 @@ switch_status_t switch_tunnel_free(switch_device_t device) {
     krnlmon_log_error(
         "Failed to free handle SWITCH_HANDLE_TYPE_TUNNEL_TERM on device %d: "
         ",error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
   }
 
   SWITCH_FREE(device, tunnel_ctx);

--- a/switchapi/es2k/switch_tunnel.c
+++ b/switchapi/es2k/switch_tunnel.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/es2k/switch_vrf.c
+++ b/switchapi/es2k/switch_vrf.c
@@ -15,13 +15,14 @@
  * limitations under the License.
  */
 
+#include "switchapi/switch_vrf.h"
+
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_status.h"
-#include "switchapi/switch_vrf.h"
 
 switch_status_t switch_vrf_init(switch_device_t device) {
-  switch_vrf_context_t *vrf_ctx = NULL;
+  switch_vrf_context_t* vrf_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   vrf_ctx = SWITCH_MALLOC(device, sizeof(switch_vrf_context_t), 0x1);
@@ -30,21 +31,19 @@ switch_status_t switch_vrf_init(switch_device_t device) {
     krnlmon_log_error(
         "vrf init: Failed to allocate memory switch_vrf_context_t on device %d:"
         " , error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
   SWITCH_MEMSET(vrf_ctx, 0x0, sizeof(switch_vrf_context_t));
 
-  status = switch_device_api_context_set(
-      device, SWITCH_API_TYPE_VRF, (void *)vrf_ctx);
+  status = switch_device_api_context_set(device, SWITCH_API_TYPE_VRF,
+                                         (void*)vrf_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "vrf init: Failed to get device context on device %d: "
         ", error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -54,8 +53,7 @@ switch_status_t switch_vrf_init(switch_device_t device) {
     krnlmon_log_error(
         "vrf init: Failed to init handle on device %d: "
         ", error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -65,17 +63,16 @@ switch_status_t switch_vrf_init(switch_device_t device) {
 }
 
 switch_status_t switch_vrf_free(switch_device_t device) {
-  switch_vrf_context_t *vrf_ctx = NULL;
+  switch_vrf_context_t* vrf_ctx = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_VRF, (void **)&vrf_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_VRF,
+                                         (void**)&vrf_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "vrf free: Failed to get device context on device %d: "
         ", error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
     return status;
   }
 
@@ -84,8 +81,7 @@ switch_status_t switch_vrf_free(switch_device_t device) {
     krnlmon_log_error(
         "vrf free: Failed to fre handle on device %d: "
         ", error: %s\n",
-        device,
-        switch_error_to_string(status));
+        device, switch_error_to_string(status));
   }
 
   SWITCH_FREE(device, vrf_ctx);
@@ -98,49 +94,42 @@ switch_status_t switch_vrf_free(switch_device_t device) {
 }
 
 switch_status_t switch_api_vrf_create(const switch_device_t device,
-                                               const switch_vrf_t vrf_id,
-                                               switch_handle_t *vrf_handle) {
-  switch_vrf_context_t *vrf_ctx = NULL;
-  switch_vrf_info_t *vrf_info = NULL;
+                                      const switch_vrf_t vrf_id,
+                                      switch_handle_t* vrf_handle) {
+  switch_vrf_context_t* vrf_ctx = NULL;
+  switch_vrf_info_t* vrf_info = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   switch_handle_t handle = SWITCH_API_INVALID_HANDLE;
-  switch_handle_t *tmp_vrf_handle = NULL;
+  switch_handle_t* tmp_vrf_handle = NULL;
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_VRF, (void **)&vrf_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_VRF,
+                                         (void**)&vrf_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "vrf create:: Failed to get device context on device %d, vrf id %d: "
         ", error: %s\n",
-        device,
-        vrf_id,
-        switch_error_to_string(status));
+        device, vrf_id, switch_error_to_string(status));
     return status;
   }
 
   *vrf_handle = SWITCH_API_INVALID_HANDLE;
-  
-  if(vrf_id)
-  {
-    status = SWITCH_ARRAY_GET(
-        &vrf_ctx->vrf_id_array, vrf_id, (void **)&tmp_vrf_handle);
+
+  if (vrf_id) {
+    status = SWITCH_ARRAY_GET(&vrf_ctx->vrf_id_array, vrf_id,
+                              (void**)&tmp_vrf_handle);
     if (status != SWITCH_STATUS_ITEM_NOT_FOUND &&
         status != SWITCH_STATUS_SUCCESS) {
       krnlmon_log_error(
           "vrf create Failed to get vrf handle on device %d, vrf id %d: "
           ", error: %s\n",
-          device,
-          vrf_id,
-          switch_error_to_string(status));
+          device, vrf_id, switch_error_to_string(status));
       return status;
     }
 
     if (status == SWITCH_STATUS_SUCCESS) {
       *vrf_handle = *tmp_vrf_handle;
       krnlmon_log_info("vrf id %x, (handle: 0x%lx) already exists on device %d",
-                vrf_id,
-                *vrf_handle,
-                device);
+                       vrf_id, *vrf_handle, device);
       return status;
     }
   }
@@ -151,24 +140,20 @@ switch_status_t switch_api_vrf_create(const switch_device_t device,
     krnlmon_log_error(
         "vrf create: Failed to create handle on device %d, vrf id %d: "
         ", error: %s\n",
-        device,
-        vrf_id,
-        switch_error_to_string(status));
+        device, vrf_id, switch_error_to_string(status));
     return status;
   }
 
   *vrf_handle = handle;
 
-  status = SWITCH_ARRAY_INSERT(
-        &vrf_ctx->vrf_id_array, vrf_id, (void *)(vrf_handle));
+  status =
+      SWITCH_ARRAY_INSERT(&vrf_ctx->vrf_id_array, vrf_id, (void*)(vrf_handle));
 
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "vrf create Failed to get vrf handle on device %d, vrf id %d: "
         ", error: %s\n",
-        device,
-        vrf_id,
-        switch_error_to_string(status));
+        device, vrf_id, switch_error_to_string(status));
     status = switch_vrf_handle_delete(device, handle);
     SWITCH_ASSERT(status == SWITCH_STATUS_SUCCESS);
     return status;
@@ -179,29 +164,24 @@ switch_status_t switch_api_vrf_create(const switch_device_t device,
     krnlmon_log_error(
         "vrf create: Failed to get vrf info on device %d, vrf id %d: "
         ", error: %s\n",
-        device,
-        vrf_id,
-        switch_error_to_string(status));
+        device, vrf_id, switch_error_to_string(status));
     status = switch_vrf_handle_delete(device, handle);
     return status;
   }
 
   vrf_info->vrf_id = vrf_id;
 
-  krnlmon_log_info(
-      "vrf created on device %d vrf id %d handle 0x%lx ",
-      device,
-      vrf_id,
-      handle);
+  krnlmon_log_info("vrf created on device %d vrf id %d handle 0x%lx ", device,
+                   vrf_id, handle);
 
   return status;
 }
 
-switch_status_t switch_api_vrf_delete(
-    const switch_device_t device, const switch_handle_t vrf_handle) {
-  switch_vrf_context_t *vrf_ctx = NULL;
-  switch_vrf_info_t *vrf_info = NULL;
-  switch_handle_t *tmp_vrf_handle = NULL;
+switch_status_t switch_api_vrf_delete(const switch_device_t device,
+                                      const switch_handle_t vrf_handle) {
+  switch_vrf_context_t* vrf_ctx = NULL;
+  switch_vrf_info_t* vrf_info = NULL;
+  switch_handle_t* tmp_vrf_handle = NULL;
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!SWITCH_VRF_HANDLE(vrf_handle)) {
@@ -209,21 +189,17 @@ switch_status_t switch_api_vrf_delete(
     krnlmon_log_error(
         "vrf delete failed on device %d, vrf handle 0x%lx: "
         ", error: %s\n",
-        device,
-        vrf_handle,
-        switch_error_to_string(status));
+        device, vrf_handle, switch_error_to_string(status));
     return status;
   }
 
-  status = switch_device_api_context_get(
-      device, SWITCH_API_TYPE_VRF, (void **)&vrf_ctx);
+  status = switch_device_api_context_get(device, SWITCH_API_TYPE_VRF,
+                                         (void**)&vrf_ctx);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error(
         "vrf delete: Failed to get device context on device %d, vrf "
         "handle 0x%lx: , error: %s\n",
-        device,
-        vrf_handle,
-        switch_error_to_string(status));
+        device, vrf_handle, switch_error_to_string(status));
     return status;
   }
 
@@ -232,24 +208,19 @@ switch_status_t switch_api_vrf_delete(
     krnlmon_log_error(
         "vrf delete: Failed to get vrf info on device %d, vrf handle 0x%lx: "
         ", error: %s\n",
-        device,
-        vrf_handle,
-        switch_error_to_string(status));
+        device, vrf_handle, switch_error_to_string(status));
     return status;
   }
 
   if (vrf_info->vrf_id) {
-    SWITCH_ARRAY_GET(
-        &vrf_ctx->vrf_id_array, vrf_info->vrf_id, (void **)&tmp_vrf_handle);
+    SWITCH_ARRAY_GET(&vrf_ctx->vrf_id_array, vrf_info->vrf_id,
+                     (void**)&tmp_vrf_handle);
     status = SWITCH_ARRAY_DELETE(&vrf_ctx->vrf_id_array, vrf_info->vrf_id);
     if (status != SWITCH_STATUS_SUCCESS) {
       krnlmon_log_error(
           "vrf delete: Failed to get vrf info for vrf handle 0x%lx vrf id %d: "
           "on device %d, error: %s\n",
-          vrf_handle,
-          vrf_info->vrf_id,
-          device,
-          switch_error_to_string(status));
+          vrf_handle, vrf_info->vrf_id, device, switch_error_to_string(status));
       return status;
     }
 
@@ -263,14 +234,12 @@ switch_status_t switch_api_vrf_delete(
     krnlmon_log_error(
         "vrf delete: Failed to delete vrf handle 0x%lx: on device %d "
         ", error: %s\n",
-        vrf_handle,
-        device,
-        switch_error_to_string(status));
+        vrf_handle, device, switch_error_to_string(status));
     return status;
   }
 
-  krnlmon_log_info(
-      "vrf deleted on device %d, vrf handle 0x%lx\n", device, vrf_handle);
+  krnlmon_log_info("vrf deleted on device %d, vrf handle 0x%lx\n", device,
+                   vrf_handle);
 
   return status;
 }

--- a/switchapi/es2k/switch_vrf.c
+++ b/switchapi/es2k/switch_vrf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/es2k/switchapi_utils.c
+++ b/switchapi/es2k/switchapi_utils.c
@@ -23,9 +23,8 @@ extern "C" {
 
 #define __FILE_ID__ SWITCHAPI_UTILS
 
-static switch_uint32_t MurmurHash(const void *key,
-                           switch_uint32_t length,
-                           switch_uint32_t seed) {
+static switch_uint32_t MurmurHash(const void* key, switch_uint32_t length,
+                                  switch_uint32_t seed) {
 // 'm' and 'r' are mixing constants generated offline.
 // They're not really 'magic', they just happen to work well.
 #define m 0x5bd1e995
@@ -35,10 +34,10 @@ static switch_uint32_t MurmurHash(const void *key,
   switch_uint32_t h = seed ^ (switch_uint32_t)length;
 
   // Mix 4 bytes at a time into the hash
-  const unsigned char *data = (const unsigned char *)key;
+  const unsigned char* data = (const unsigned char*)key;
 
   while (length >= 4) {
-    uint32_t k = *(uint32_t *)data;
+    uint32_t k = *(uint32_t*)data;
 
     k *= m;
     k ^= k >> r;
@@ -74,25 +73,24 @@ static switch_uint32_t MurmurHash(const void *key,
   return h;
 }
 
-switch_status_t SWITCH_ARRAY_INIT(switch_array_t *array) {
+switch_status_t SWITCH_ARRAY_INIT(switch_array_t* array) {
   SWITCH_ASSERT(array != NULL);
   array->array = NULL;
   array->num_entries = 0;
   return SWITCH_STATUS_SUCCESS;
 }
 
-switch_uint32_t SWITCH_ARRAY_COUNT(switch_array_t *array) {
+switch_uint32_t SWITCH_ARRAY_COUNT(switch_array_t* array) {
   SWITCH_ASSERT(array != NULL);
   return array->num_entries;
 }
 
-switch_status_t SWITCH_ARRAY_INSERT(switch_array_t *array,
-                                    switch_uint64_t index,
-                                    void *data) {
+switch_status_t SWITCH_ARRAY_INSERT(switch_array_t* array,
+                                    switch_uint64_t index, void* data) {
   SWITCH_ASSERT(array != NULL);
   SWITCH_ASSERT(data != NULL);
 
-  Word_t *p = NULL;
+  Word_t* p = NULL;
   JLI(p, array->array, (switch_uint64_t)index);
   if (p) {
     *p = (Word_t)data;
@@ -103,38 +101,36 @@ switch_status_t SWITCH_ARRAY_INSERT(switch_array_t *array,
   }
 }
 
-switch_status_t SWITCH_ARRAY_GET(switch_array_t *array,
-                                 switch_uint64_t index,
-                                 void **data) {
+switch_status_t SWITCH_ARRAY_GET(switch_array_t* array, switch_uint64_t index,
+                                 void** data) {
   SWITCH_ASSERT(array != NULL);
   SWITCH_ASSERT(data != NULL);
 
-  Word_t *p = NULL;
+  Word_t* p = NULL;
   JLG(p, array->array, (switch_uint64_t)index);
   if (p) {
-    *(Word_t *)data = *(Word_t *)p;
+    *(Word_t*)data = *(Word_t*)p;
     return SWITCH_STATUS_SUCCESS;
   } else {
     return SWITCH_STATUS_ITEM_NOT_FOUND;
   }
 }
 
-switch_status_t SWITCH_ARRAY_NEXT(switch_array_t *array,
-                                  switch_uint64_t *index,
-                                  void **data) {
+switch_status_t SWITCH_ARRAY_NEXT(switch_array_t* array, switch_uint64_t* index,
+                                  void** data) {
   Word_t tmp_index = (Word_t)*index;
 
   SWITCH_ASSERT(array != NULL);
   SWITCH_ASSERT(data != NULL);
 
-  Word_t *p = NULL;
+  Word_t* p = NULL;
   if (tmp_index == 0) {
     JLF(p, array->array, tmp_index);
   } else {
     JLN(p, array->array, tmp_index);
   }
   if (p) {
-    *(Word_t *)data = *(Word_t *)p;
+    *(Word_t*)data = *(Word_t*)p;
     *index = (switch_uint64_t)tmp_index;
     return SWITCH_STATUS_SUCCESS;
   } else {
@@ -142,7 +138,7 @@ switch_status_t SWITCH_ARRAY_NEXT(switch_array_t *array,
   }
 }
 
-switch_status_t SWITCH_ARRAY_DELETE(switch_array_t *array,
+switch_status_t SWITCH_ARRAY_DELETE(switch_array_t* array,
                                     switch_uint64_t index) {
   SWITCH_ASSERT(array != NULL);
 
@@ -156,7 +152,7 @@ switch_status_t SWITCH_ARRAY_DELETE(switch_array_t *array,
   }
 }
 
-switch_status_t SWITCH_LIST_INIT(switch_list_t *list) {
+switch_status_t SWITCH_LIST_INIT(switch_list_t* list) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(list != NULL);
@@ -166,7 +162,7 @@ switch_status_t SWITCH_LIST_INIT(switch_list_t *list) {
   return SWITCH_STATUS_SUCCESS;
 }
 
-switch_status_t SWITCH_LIST_SORT(switch_list_t *list,
+switch_status_t SWITCH_LIST_SORT(switch_list_t* list,
                                  switch_list_compare_func_t compare_func) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
@@ -176,7 +172,7 @@ switch_status_t SWITCH_LIST_SORT(switch_list_t *list,
   return SWITCH_STATUS_SUCCESS;
 }
 
-bool SWITCH_LIST_EMPTY(switch_list_t *list) {
+bool SWITCH_LIST_EMPTY(switch_list_t* list) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   bool is_empty = false;
 
@@ -186,15 +182,14 @@ bool SWITCH_LIST_EMPTY(switch_list_t *list) {
   return is_empty;
 }
 
-switch_size_t SWITCH_LIST_COUNT(switch_list_t *list) {
+switch_size_t SWITCH_LIST_COUNT(switch_list_t* list) {
   SWITCH_ASSERT(list != NULL);
 
   return list->num_entries;
 }
 
-switch_status_t SWITCH_LIST_INSERT(switch_list_t *list,
-                                   switch_node_t *node,
-                                   void *data) {
+switch_status_t SWITCH_LIST_INSERT(switch_list_t* list, switch_node_t* node,
+                                   void* data) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(list != NULL);
@@ -206,7 +201,7 @@ switch_status_t SWITCH_LIST_INSERT(switch_list_t *list,
   return SWITCH_STATUS_SUCCESS;
 }
 
-switch_status_t SWITCH_LIST_DELETE(switch_list_t *list, switch_node_t *node) {
+switch_status_t SWITCH_LIST_DELETE(switch_list_t* list, switch_node_t* node) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(list != NULL);
@@ -217,7 +212,7 @@ switch_status_t SWITCH_LIST_DELETE(switch_list_t *list, switch_node_t *node) {
   return SWITCH_STATUS_SUCCESS;
 }
 
-switch_status_t SWITCH_HASHTABLE_INIT(switch_hashtable_t *hashtable) {
+switch_status_t SWITCH_HASHTABLE_INIT(switch_hashtable_t* hashtable) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(hashtable != NULL);
@@ -228,16 +223,15 @@ switch_status_t SWITCH_HASHTABLE_INIT(switch_hashtable_t *hashtable) {
   return SWITCH_STATUS_SUCCESS;
 }
 
-switch_size_t SWITCH_HASHTABLE_COUNT(switch_hashtable_t *hashtable) {
+switch_size_t SWITCH_HASHTABLE_COUNT(switch_hashtable_t* hashtable) {
   SWITCH_ASSERT(hashtable != NULL);
 
   return hashtable->num_entries;
 }
 
-switch_status_t SWITCH_HASHTABLE_INSERT(switch_hashtable_t *hashtable,
-                                        switch_hashnode_t *node,
-                                        void *key,
-                                        void *data) {
+switch_status_t SWITCH_HASHTABLE_INSERT(switch_hashtable_t* hashtable,
+                                        switch_hashnode_t* node, void* key,
+                                        void* data) {
   switch_uint8_t hash_key[SWITCH_API_BUFFER_SIZE];
   switch_uint32_t hash_length = 0;
   switch_uint32_t hash = 0;
@@ -253,7 +247,7 @@ switch_status_t SWITCH_HASHTABLE_INSERT(switch_hashtable_t *hashtable,
   status = hashtable->key_func(key, hash_key, &hash_length);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error("hashtable insert failed, error: %s\n",
-             switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -263,9 +257,8 @@ switch_status_t SWITCH_HASHTABLE_INSERT(switch_hashtable_t *hashtable,
   return SWITCH_STATUS_SUCCESS;
 }
 
-switch_status_t SWITCH_HASHTABLE_DELETE(switch_hashtable_t *hashtable,
-                                        void *key,
-                                        void **data) {
+switch_status_t SWITCH_HASHTABLE_DELETE(switch_hashtable_t* hashtable,
+                                        void* key, void** data) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   switch_uint8_t hash_key[SWITCH_API_BUFFER_SIZE];
   switch_uint32_t hash_length = 0;
@@ -280,17 +273,17 @@ switch_status_t SWITCH_HASHTABLE_DELETE(switch_hashtable_t *hashtable,
   status = hashtable->key_func(key, hash_key, &hash_length);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error("hashtable delete failed, error: %s\n",
-             switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
   hash = MurmurHash(hash_key, hash_length, hashtable->hash_seed);
-  *data = (void *)tommy_hashtable_remove(
+  *data = (void*)tommy_hashtable_remove(
       &hashtable->table, hashtable->compare_func, hash_key, hash);
   if (!(*data)) {
     status = SWITCH_STATUS_ITEM_NOT_FOUND;
     krnlmon_log_error("hashtable delete failed, error: %s\n",
-              switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
@@ -298,8 +291,8 @@ switch_status_t SWITCH_HASHTABLE_DELETE(switch_hashtable_t *hashtable,
   return SWITCH_STATUS_SUCCESS;
 }
 
-switch_status_t SWITCH_HASHTABLE_DELETE_NODE(switch_hashtable_t *hashtable,
-                                             switch_hashnode_t *node) {
+switch_status_t SWITCH_HASHTABLE_DELETE_NODE(switch_hashtable_t* hashtable,
+                                             switch_hashnode_t* node) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(hashtable != NULL);
@@ -310,9 +303,8 @@ switch_status_t SWITCH_HASHTABLE_DELETE_NODE(switch_hashtable_t *hashtable,
   return SWITCH_STATUS_SUCCESS;
 }
 
-switch_status_t SWITCH_HASHTABLE_SEARCH(switch_hashtable_t *hashtable,
-                                        void *key,
-                                        void **data) {
+switch_status_t SWITCH_HASHTABLE_SEARCH(switch_hashtable_t* hashtable,
+                                        void* key, void** data) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
   switch_uint8_t hash_key[SWITCH_API_BUFFER_SIZE] = {0};
   switch_uint32_t hash_length = 0;
@@ -325,26 +317,25 @@ switch_status_t SWITCH_HASHTABLE_SEARCH(switch_hashtable_t *hashtable,
   status = hashtable->key_func(key, hash_key, &hash_length);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_debug("hashtable search failed, error: %s\n",
-              switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
   hash = MurmurHash(hash_key, hash_length, hashtable->hash_seed);
-  *data = (void *)tommy_hashtable_search(
+  *data = (void*)tommy_hashtable_search(
       &hashtable->table, hashtable->compare_func, hash_key, hash);
   if (!(*data)) {
     status = SWITCH_STATUS_ITEM_NOT_FOUND;
     krnlmon_log_debug("hashtable search failed, error: %s\n",
-              switch_error_to_string(status));
+                      switch_error_to_string(status));
     return status;
   }
 
   return status;
 }
 
-switch_status_t SWITCH_HASHTABLE_FOREACH_ARG(switch_hashtable_t *hashtable,
-                                             void *func,
-                                             void *arg) {
+switch_status_t SWITCH_HASHTABLE_FOREACH_ARG(switch_hashtable_t* hashtable,
+                                             void* func, void* arg) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(hashtable != NULL);
@@ -356,7 +347,7 @@ switch_status_t SWITCH_HASHTABLE_FOREACH_ARG(switch_hashtable_t *hashtable,
   return SWITCH_STATUS_SUCCESS;
 }
 
-switch_status_t SWITCH_HASHTABLE_DONE(switch_hashtable_t *hashtable) {
+switch_status_t SWITCH_HASHTABLE_DONE(switch_hashtable_t* hashtable) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   SWITCH_ASSERT(hashtable != NULL);
@@ -365,7 +356,7 @@ switch_status_t SWITCH_HASHTABLE_DONE(switch_hashtable_t *hashtable) {
   return SWITCH_STATUS_SUCCESS;
 }
 
-char *switch_error_to_string(switch_status_t status) {
+char* switch_error_to_string(switch_status_t status) {
   switch (status) {
     case SWITCH_STATUS_ITEM_NOT_FOUND:
       return "err: entry not found";
@@ -408,7 +399,7 @@ char *switch_error_to_string(switch_status_t status) {
   }
 }
 
-char *switch_handle_type_to_string(switch_handle_type_t handle_type) {
+char* switch_handle_type_to_string(switch_handle_type_t handle_type) {
   switch (handle_type) {
     case SWITCH_HANDLE_TYPE_NONE:
       return "none";
@@ -510,7 +501,7 @@ char *switch_handle_type_to_string(switch_handle_type_t handle_type) {
       return "pktdriver rx filter";
     case SWITCH_HANDLE_TYPE_PKTDRIVER_TX_FILTER:
       return "pktdriver tx filter";
-   case SWITCH_HANDLE_TYPE_ROUTE:
+    case SWITCH_HANDLE_TYPE_ROUTE:
       return "route";
     case SWITCH_HANDLE_TYPE_DEVICE:
       return "device";
@@ -664,8 +655,7 @@ switch_status_t switch_pd_tdi_status_to_status(tdi_status_t pd_status) {
   return status;
 }
 
-
-static bool switch_l3_host_entry(const switch_ip_addr_t *ip_addr) {
+static bool switch_l3_host_entry(const switch_ip_addr_t* ip_addr) {
   SWITCH_ASSERT(ip_addr != NULL);
 
   if (ip_addr->type == SWITCH_API_IP_ADDR_V4) {
@@ -677,10 +667,9 @@ static bool switch_l3_host_entry(const switch_ip_addr_t *ip_addr) {
   }
 }
 
-switch_status_t switch_ipv4_to_string(switch_ip4_t ip4,
-                                      char *buffer,
+switch_status_t switch_ipv4_to_string(switch_ip4_t ip4, char* buffer,
                                       switch_int32_t buffer_size,
-                                      switch_int32_t *length) {
+                                      switch_int32_t* length) {
   SWITCH_ASSERT(buffer != NULL);
 
   char tmp_buffer[SWITCH_API_BUFFER_SIZE];
@@ -691,10 +680,9 @@ switch_status_t switch_ipv4_to_string(switch_ip4_t ip4,
   return SWITCH_STATUS_SUCCESS;
 }
 
-switch_status_t switch_ipv6_to_string(switch_ip6_t ip6,
-                                      char *buffer,
+switch_status_t switch_ipv6_to_string(switch_ip6_t ip6, char* buffer,
                                       switch_int32_t buffer_size,
-                                      switch_int32_t *length) {
+                                      switch_int32_t* length) {
   SWITCH_ASSERT(buffer != NULL);
 
   char tmp_buffer[SWITCH_API_BUFFER_SIZE];
@@ -704,22 +692,16 @@ switch_status_t switch_ipv6_to_string(switch_ip6_t ip6,
   return SWITCH_STATUS_SUCCESS;
 }
 
-switch_status_t switch_mac_to_string(switch_mac_addr_t *mac,
-                                     char *buffer,
+switch_status_t switch_mac_to_string(switch_mac_addr_t* mac, char* buffer,
                                      switch_int32_t buffer_size,
-                                     switch_int32_t *length_out) {
+                                     switch_int32_t* length_out) {
   SWITCH_ASSERT(buffer != NULL);
   SWITCH_ASSERT(mac != NULL);
 
-  switch_int32_t length = snprintf(buffer,
-                                   buffer_size,
-                                   "%02x:%02x:%02x:%02x:%02x:%02x",
-                                   mac->mac_addr[0],
-                                   mac->mac_addr[1],
-                                   mac->mac_addr[2],
-                                   mac->mac_addr[3],
-                                   mac->mac_addr[4],
-                                   mac->mac_addr[5]);
+  switch_int32_t length =
+      snprintf(buffer, buffer_size, "%02x:%02x:%02x:%02x:%02x:%02x",
+               mac->mac_addr[0], mac->mac_addr[1], mac->mac_addr[2],
+               mac->mac_addr[3], mac->mac_addr[4], mac->mac_addr[5]);
   if (length_out) {
     *length_out = length;
   }
@@ -727,7 +709,7 @@ switch_status_t switch_mac_to_string(switch_mac_addr_t *mac,
 }
 
 static switch_status_t switch_ipv4_prefix_to_mask(switch_uint32_t prefix,
-                                           switch_uint32_t *mask) {
+                                                  switch_uint32_t* mask) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   if (!mask) {
@@ -744,7 +726,7 @@ static switch_status_t switch_ipv4_prefix_to_mask(switch_uint32_t prefix,
 }
 
 static switch_status_t switch_ipv6_prefix_to_mask(switch_uint32_t prefix,
-                                           switch_uint8_t *mask) {
+                                                  switch_uint8_t* mask) {
   switch_uint32_t prefix_bytes = 0;
   switch_uint32_t index = 0;
 
@@ -884,7 +866,7 @@ switch_direction_t switch_table_id_to_direction(switch_table_id_t table_id) {
   }
 }
 
-char *switch_api_type_to_string(switch_api_type_t api_type) {
+char* switch_api_type_to_string(switch_api_type_t api_type) {
   switch (api_type) {
     case SWITCH_API_TYPE_PORT:
       return "port";
@@ -966,7 +948,7 @@ char *switch_api_type_to_string(switch_api_type_t api_type) {
   }
 }
 
-static char *switch_packet_type_to_string(switch_packet_type_t packet_type) {
+static char* switch_packet_type_to_string(switch_packet_type_t packet_type) {
   switch (packet_type) {
     case SWITCH_PACKET_TYPE_UNICAST:
       return "unicast";
@@ -980,8 +962,8 @@ static char *switch_packet_type_to_string(switch_packet_type_t packet_type) {
   }
 }
 
-switch_int32_t switch_convert_string_to_ipv4(const char *v4_string,
-                                             switch_ip4_t *ip) {
+switch_int32_t switch_convert_string_to_ipv4(const char* v4_string,
+                                             switch_ip4_t* ip) {
   switch_int32_t ret_val;
 
   if (!v4_string || !ip) {
@@ -997,8 +979,8 @@ switch_int32_t switch_convert_string_to_ipv4(const char *v4_string,
   return 1;
 }
 
-switch_int32_t switch_convert_string_to_ipv6(const char *v6_string,
-                                             switch_ip6_t *ip) {
+switch_int32_t switch_convert_string_to_ipv6(const char* v6_string,
+                                             switch_ip6_t* ip) {
   switch_int32_t ret_val;
 
   if (!v6_string || !ip) {

--- a/switchapi/es2k/switchapi_utils.c
+++ b/switchapi/es2k/switchapi_utils.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_base_types.h
+++ b/switchapi/switch_base_types.h
@@ -21,11 +21,11 @@
 /**
  * Third party includes
  */
+#include "bf_sal/bf_sys_mem.h"
+#include "bf_sal/bf_sys_timer.h"
 #include "judy-1.0.5/src/Judy.h"
 #include "tommyds/tommyhashtbl.h"
 #include "tommyds/tommylist.h"
-#include "bf_sal/bf_sys_mem.h"
-#include "bf_sal/bf_sys_timer.h"
 #ifdef STATIC_LINK_LIB
 #include "bf_switchd/bf_switchd.h"
 #endif  // STATIC_LINK_LIB
@@ -33,9 +33,9 @@
 /**
  * standard includes
  */
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdbool.h>
 #include <string.h>
 
 #ifdef __cplusplus
@@ -81,7 +81,7 @@ extern "C" {
 #define SWITCH_MEMCPY memcpy
 #define SWITCH_MEMCMP memcmp
 
-#define UNUSED(x) (void) x;
+#define UNUSED(x) (void)x;
 
 #define __MODULE__ SWITCH_API_TYPE_NONE
 
@@ -331,7 +331,7 @@ typedef switch_int32_t switch_dev_port_t;
  */
 typedef struct switch_handle_list_s {
   /** handle array */
-  switch_handle_t *handles;
+  switch_handle_t* handles;
 
   /** number of handles */
   switch_size_t num_handles;
@@ -353,7 +353,7 @@ typedef switch_uint128_t switch_ip6_t;
 /** List of signed 32 bit integer values */
 typedef struct switch_s32_list_s {
   /** integer array */
-  switch_int32_t *value;
+  switch_int32_t* value;
 
   /** number of entries */
   switch_uint16_t num_entries;
@@ -363,7 +363,7 @@ typedef struct switch_s32_list_s {
 /** List of unsigned 32 bit integer values */
 typedef struct switch_u32_list_s {
   /** integer array */
-  switch_int32_t *value;
+  switch_int32_t* value;
 
   /** number of entries */
   switch_uint16_t num_entries;

--- a/switchapi/switch_base_types.h
+++ b/switchapi/switch_base_types.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_config.h
+++ b/switchapi/switch_config.h
@@ -45,7 +45,7 @@ typedef struct switch_config_s {
 
 } switch_config_t;
 
-switch_status_t switch_config_init(switch_config_t *switch_config);
+switch_status_t switch_config_init(switch_config_t* switch_config);
 
 switch_status_t switch_config_free(void);
 

--- a/switchapi/switch_config.h
+++ b/switchapi/switch_config.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_config_int.h
+++ b/switchapi/switch_config_int.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022-2023 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_config_int.h
+++ b/switchapi/switch_config_int.h
@@ -59,7 +59,7 @@ typedef struct switch_config_info_s {
 
   bool device_inited[SWITCH_MAX_DEVICE];
 
-  switch_device_context_t *device_ctx[SWITCH_MAX_DEVICE];
+  switch_device_context_t* device_ctx[SWITCH_MAX_DEVICE];
 
   switch_config_params_t config_params;
 
@@ -90,7 +90,7 @@ extern switch_config_info_t config_info;
 
 #define SWITCH_CONFIG_CPU_ETH_INTF() config_info.api_switch_config.cpu_interface
 
-#define SWITCH_CONFIG_CPU_ETH_INTF_LEN() \
+#define SWITCH_CONFIG_CPU_ETH_INTF_LEN()               \
   strnlen(config_info.api_switch_config.cpu_interface, \
           sizeof(config_info.api_switch_config.cpu_interface))
 
@@ -106,12 +106,12 @@ extern switch_config_info_t config_info;
 #define switch_cfg_mc_sess_hdl config_info.mc_sess_hdl
 
 switch_status_t switch_config_table_sizes_get(switch_device_t device,
-                                              switch_size_t *table_sizes);
+                                              switch_size_t* table_sizes);
 
 switch_status_t switch_config_device_context_set(
-    switch_device_t device, switch_device_context_t *device_ctx);
+    switch_device_t device, switch_device_context_t* device_ctx);
 
 switch_status_t switch_config_device_context_get(
-    switch_device_t device, switch_device_context_t **device_ctx);
+    switch_device_t device, switch_device_context_t** device_ctx);
 
 #endif /* __SWITCH_CONFIG_INT_H__ */

--- a/switchapi/switch_device.h
+++ b/switchapi/switch_device.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_device.h
+++ b/switchapi/switch_device.h
@@ -26,13 +26,13 @@ extern "C" {
 
 typedef struct switch_api_device_info_s {
   /** default vrf id */
-//  switch_vrf_t default_vrf;
+  //  switch_vrf_t default_vrf;
 
   /** vrf handle */
   switch_handle_t vrf_handle;
 
   /** default vlan id */
-//  switch_vlan_t default_vlan;
+  //  switch_vlan_t default_vlan;
 
   /** vlan handle */
   switch_handle_t vlan_handle;
@@ -68,10 +68,10 @@ typedef struct switch_api_device_info_s {
   switch_handle_list_t port_list;
 
   /** ethernet cpu port */
-//  switch_port_t eth_cpu_port;
+  //  switch_port_t eth_cpu_port;
 
   /** pcie cpu port */
-//  switch_port_t pcie_cpu_port;
+  //  switch_port_t pcie_cpu_port;
 
   /** counter refresh interval */
   switch_uint32_t refresh_interval;
@@ -101,13 +101,13 @@ switch_status_t switch_api_device_add(switch_device_t device);
 switch_status_t switch_api_device_remove(switch_device_t device);
 
 switch_status_t switch_api_device_default_rmac_handle_get(
-    switch_device_t device, switch_handle_t *rmac_handle);
+    switch_device_t device, switch_handle_t* rmac_handle);
 
 switch_status_t switch_api_get_default_nhop_group(
-    switch_device_t device, switch_handle_t *nhop_group_handle);
+    switch_device_t device, switch_handle_t* nhop_group_handle);
 
-switch_status_t switch_api_device_tunnel_dmac_get(
-    switch_device_t device, switch_mac_addr_t *mac_addr);
+switch_status_t switch_api_device_tunnel_dmac_get(switch_device_t device,
+                                                  switch_mac_addr_t* mac_addr);
 #ifdef __cplusplus
 }
 #endif

--- a/switchapi/switch_device_int.h
+++ b/switchapi/switch_device_int.h
@@ -17,10 +17,10 @@
 
 #ifndef __SWITCH_DEVICE_INT_H__
 #define __SWITCH_DEVICE_INT_H__
-#include "switch_id.h"
-#include "switch_types_int.h"
-#include "switch_table.h"
 #include "switch_device.h"
+#include "switch_id.h"
+#include "switch_table.h"
+#include "switch_types_int.h"
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
@@ -33,7 +33,7 @@ extern "C" {
 
 #define SWITCH_MAX_DEVICE 256
 
-typedef void *switch_api_mutex_t;
+typedef void* switch_api_mutex_t;
 
 typedef switch_status_t (*switch_device_stats_poll_interval_set_fn)(
     switch_device_t device, switch_uint32_t interval);
@@ -58,13 +58,13 @@ typedef struct switch_device_context_s {
   switch_api_device_info_t device_info;
 
   /** device context for every module */
-  void *context[SWITCH_API_TYPE_MAX];
+  void* context[SWITCH_API_TYPE_MAX];
 
   /** flag to indicate if module is initialized */
   bool api_inited[SWITCH_API_TYPE_MAX];
 
   /** ifindex allocator */
-  switch_id_allocator_t *ifindex_allocator;
+  switch_id_allocator_t* ifindex_allocator;
 
   /** maximum pipes */
   switch_uint32_t max_pipes;
@@ -78,7 +78,7 @@ typedef struct switch_device_context_s {
 } switch_device_context_t;
 
 switch_status_t switch_device_init(switch_device_t device,
-                                   switch_size_t *table_sizes);
+                                   switch_size_t* table_sizes);
 switch_status_t switch_device_deinit(switch_device_t device);
 
 switch_status_t switch_device_free(switch_device_t device);
@@ -88,30 +88,30 @@ switch_status_t switch_device_api_init(switch_device_t device);
 switch_status_t switch_device_api_free(switch_device_t device);
 
 switch_status_t switch_device_table_get(switch_device_t device,
-                                        switch_table_t **table_info);
+                                        switch_table_t** table_info);
 
 switch_status_t switch_device_api_context_get(switch_device_t device,
                                               switch_api_type_t api_type,
-                                              void **context);
+                                              void** context);
 
 switch_status_t switch_device_api_context_set(switch_device_t device,
                                               switch_api_type_t api_type,
-                                              void *context);
+                                              void* context);
 
 switch_status_t switch_device_context_get(
-    switch_device_t device, switch_device_context_t **context_get);
+    switch_device_t device, switch_device_context_t** context_get);
 
 switch_status_t switch_device_ifindex_allocate(switch_device_t device,
-                                               switch_ifindex_t *ifindex);
+                                               switch_ifindex_t* ifindex);
 
 switch_status_t switch_device_ifindex_deallocate(switch_device_t device,
                                                  switch_ifindex_t ifindex);
 
 switch_status_t switch_api_device_vrf_max_get(switch_device_t device,
-                                              switch_uint16_t *max_vrf);
+                                              switch_uint16_t* max_vrf);
 
 switch_status_t switch_device_max_pipes_get(switch_device_t device,
-                                            switch_int32_t *max_pipes);
+                                            switch_int32_t* max_pipes);
 
 #ifdef __cplusplus
 }

--- a/switchapi/switch_device_int.h
+++ b/switchapi/switch_device_int.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_fdb.h
+++ b/switchapi/switch_fdb.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_fdb.h
+++ b/switchapi/switch_fdb.h
@@ -30,22 +30,21 @@ extern "C" {
 
 #define SWITCH_L2_HASH_KEY_SIZE sizeof(switch_mac_addr_t)
 
-#define SWITCH_L2_KEY_GET(_api_l2_info, _l2_key)                         \
-  {                                                                      \
-  do {                                                                   \
-       SWITCH_MEMSET(&_l2_key, 0x0, sizeof(switch_l2_key_t));            \
-       SWITCH_ASSERT(SWITCH_RIF_HANDLE(_api_l2_info->rif_handle));       \
-       _l2_key.rif_handle = _api_l2_info->rif_handle;                    \
-       SWITCH_MEMCPY(&_l2_key.mac,                                       \
-                  &_api_l2_info->dst_mac,                                \
-                  sizeof(switch_mac_addr_t));                            \
-     } while(0);                                                         \
-} 
+#define SWITCH_L2_KEY_GET(_api_l2_info, _l2_key)                  \
+  {                                                               \
+    do {                                                          \
+      SWITCH_MEMSET(&_l2_key, 0x0, sizeof(switch_l2_key_t));      \
+      SWITCH_ASSERT(SWITCH_RIF_HANDLE(_api_l2_info->rif_handle)); \
+      _l2_key.rif_handle = _api_l2_info->rif_handle;              \
+      SWITCH_MEMCPY(&_l2_key.mac, &_api_l2_info->dst_mac,         \
+                    sizeof(switch_mac_addr_t));                   \
+    } while (0);                                                  \
+  }
 
-  /** l2 info handle wrappers */
-#define switch_l2_tx_handle_create(_device) \
-  switch_handle_create(                      \
-      _device, SWITCH_HANDLE_TYPE_L2_FWD_TX, sizeof(switch_l2_info_t))
+/** l2 info handle wrappers */
+#define switch_l2_tx_handle_create(_device)                   \
+  switch_handle_create(_device, SWITCH_HANDLE_TYPE_L2_FWD_TX, \
+                       sizeof(switch_l2_info_t))
 
 #define switch_l2_tx_handle_delete(_device, _handle, _count) \
   switch_handle_delete(_device, SWITCH_HANDLE_TYPE_L2_FWD_TX, _handle)
@@ -53,77 +52,72 @@ extern "C" {
 #define switch_l2_rx_handle_delete(_device, _handle, _count) \
   switch_handle_delete(_device, SWITCH_HANDLE_TYPE_L2_FWD_RX, _handle)
 
-#define switch_l2_rx_handle_create(_device) \
-  switch_handle_create(                      \
-      _device, SWITCH_HANDLE_TYPE_L2_FWD_RX, sizeof(switch_l2_info_t))
+#define switch_l2_rx_handle_create(_device)                   \
+  switch_handle_create(_device, SWITCH_HANDLE_TYPE_L2_FWD_RX, \
+                       sizeof(switch_l2_info_t))
 
-#define switch_l2_tx_get(_device, _handle, _info)                        \
-  ({                                                                     \
-    switch_l2_info_t *_tmp_l2_info = NULL;                               \
-    (void)(_tmp_l2_info == *_info);                                      \
-    switch_handle_get(                                                   \
-        _device, SWITCH_HANDLE_TYPE_L2_FWD_TX, _handle, (void **)_info); \
+#define switch_l2_tx_get(_device, _handle, _info)                     \
+  ({                                                                  \
+    switch_l2_info_t* _tmp_l2_info = NULL;                            \
+    (void)(_tmp_l2_info == *_info);                                   \
+    switch_handle_get(_device, SWITCH_HANDLE_TYPE_L2_FWD_TX, _handle, \
+                      (void**)_info);                                 \
   })
 
-#define switch_l2_rx_get(_device, _handle, _info)                        \
-  ({                                                                     \
-    switch_l2_info_t *_tmp_l2_info = NULL;                               \
-    (void)(_tmp_l2_info == *_info);                                      \
-    switch_handle_get(                                                   \
-        _device, SWITCH_HANDLE_TYPE_L2_FWD_RX, _handle, (void **)_info); \
+#define switch_l2_rx_get(_device, _handle, _info)                     \
+  ({                                                                  \
+    switch_l2_info_t* _tmp_l2_info = NULL;                            \
+    (void)(_tmp_l2_info == *_info);                                   \
+    switch_handle_get(_device, SWITCH_HANDLE_TYPE_L2_FWD_RX, _handle, \
+                      (void**)_info);                                 \
   })
 
-#define SWITCH_L2_TX_HANDLE(handle)                            \
-    SWITCH_HANDLE_VALID(handle, SWITCH_HANDLE_TYPE_L2_FWD_TX)
+#define SWITCH_L2_TX_HANDLE(handle) \
+  SWITCH_HANDLE_VALID(handle, SWITCH_HANDLE_TYPE_L2_FWD_TX)
 
-#define SWITCH_L2_RX_HANDLE(handle)                            \
-    SWITCH_HANDLE_VALID(handle, SWITCH_HANDLE_TYPE_L2_FWD_RX)
+#define SWITCH_L2_RX_HANDLE(handle) \
+  SWITCH_HANDLE_VALID(handle, SWITCH_HANDLE_TYPE_L2_FWD_RX)
 
-typedef enum switch_l2_info_type_s
-{
-    SWITCH_L2_FWD_NONE,
-    SWITCH_L2_FWD_TX,
-    SWITCH_L2_FWD_RX,
-    SWITCH_L2_FWD_MAX
-}switch_l2_info_type_t;
+typedef enum switch_l2_info_type_s {
+  SWITCH_L2_FWD_NONE,
+  SWITCH_L2_FWD_TX,
+  SWITCH_L2_FWD_RX,
+  SWITCH_L2_FWD_MAX
+} switch_l2_info_type_t;
 
-typedef enum switch_l2_learn_from_t
-{
-    SWITCH_L2_FWD_LEARN_NONE,
-    SWITCH_L2_FWD_LEARN_TUNNEL_INTERFACE,
-    SWITCH_L2_FWD_LEARN_VLAN_INTERFACE,
-    SWITCH_L2_FWD_LEARN_PHYSICAL_INTERFACE,
-    SWITCH_L2_FWD_LEARN_MAX
-}switch_l2_learn_from_t;
+typedef enum switch_l2_learn_from_t {
+  SWITCH_L2_FWD_LEARN_NONE,
+  SWITCH_L2_FWD_LEARN_TUNNEL_INTERFACE,
+  SWITCH_L2_FWD_LEARN_VLAN_INTERFACE,
+  SWITCH_L2_FWD_LEARN_PHYSICAL_INTERFACE,
+  SWITCH_L2_FWD_LEARN_MAX
+} switch_l2_learn_from_t;
 
 typedef struct switch_api_l2_info_s {
+  switch_mac_addr_t dst_mac;
 
-    switch_mac_addr_t dst_mac; 
+  switch_handle_t rif_handle;
 
-    switch_handle_t rif_handle;
+  switch_l2_info_type_t type;
 
-    switch_l2_info_type_t type;
+  uint8_t port_id;
 
-    uint8_t port_id;
+  switch_l2_learn_from_t learn_from;
 
-    switch_l2_learn_from_t learn_from;
-
-    switch_handle_t l2_handle;
+  switch_handle_t l2_handle;
 
 } switch_api_l2_info_t;
 
-typedef struct switch_l2_info_s
-{
-    /** hashtable node */
-    switch_hashnode_t node;
-    
-    switch_api_l2_info_t api_l2_info;
+typedef struct switch_l2_info_s {
+  /** hashtable node */
+  switch_hashnode_t node;
 
-}switch_l2_info_t;
+  switch_api_l2_info_t api_l2_info;
 
-typedef struct switch_l2_context_s
-{
-    switch_hashtable_t l2_hashtable;
+} switch_l2_info_t;
+
+typedef struct switch_l2_context_s {
+  switch_hashtable_t l2_hashtable;
 
 } switch_l2_context_t;
 
@@ -131,29 +125,24 @@ switch_status_t switch_l2_init(switch_device_t device);
 
 switch_status_t switch_l2_free(switch_device_t device);
 
-switch_status_t switch_api_l2_forward_create(
-    const switch_device_t device,
-    switch_api_l2_info_t *api_l2_info,
-    switch_handle_t *l2_handle);
+switch_status_t switch_api_l2_forward_create(const switch_device_t device,
+                                             switch_api_l2_info_t* api_l2_info,
+                                             switch_handle_t* l2_handle);
 
-switch_status_t switch_api_l2_forward_delete (
-    const switch_device_t device,
-    const switch_api_l2_info_t *api_l2_info);
+switch_status_t switch_api_l2_forward_delete(
+    const switch_device_t device, const switch_api_l2_info_t* api_l2_info);
 
-switch_status_t switch_l2_hash_key_init(void *args,
-                                          switch_uint8_t *key,
-                                          switch_uint32_t *len);
+switch_status_t switch_l2_hash_key_init(void* args, switch_uint8_t* key,
+                                        switch_uint32_t* len);
 
-switch_int32_t switch_l2_hash_compare(const void *key1, const void *key2);
+switch_int32_t switch_l2_hash_compare(const void* key1, const void* key2);
 
-switch_status_t switch_api_l2_handle_get(
-    const switch_device_t device,
-    const switch_mac_addr_t *l2_key,
-    switch_handle_t *l2_handle);
+switch_status_t switch_api_l2_handle_get(const switch_device_t device,
+                                         const switch_mac_addr_t* l2_key,
+                                         switch_handle_t* l2_handle);
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* __SWITCH_FDB_H__ */
-

--- a/switchapi/switch_handle.h
+++ b/switchapi/switch_handle.h
@@ -19,8 +19,8 @@
 #define __SWITCH_HANDLE_H__
 
 #include "switch_base_types.h"
-#include "switch_status.h"
 #include "switch_id.h"
+#include "switch_status.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/switchapi/switch_handle.h
+++ b/switchapi/switch_handle.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_handle_int.h
+++ b/switchapi/switch_handle_int.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_handle_int.h
+++ b/switchapi/switch_handle_int.h
@@ -18,8 +18,8 @@
 #ifndef __SWITCH_HANDLE_INT_H__
 #define __SWITCH_HANDLE_INT_H__
 
-#include "switch_internal.h"
 #include "id/id.h"
+#include "switch_internal.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -43,7 +43,7 @@ typedef struct switch_handle_info_s {
   switch_handle_type_t type;
 
   /** handle id allocator */
-  switch_id_allocator_t *allocator;
+  switch_id_allocator_t* allocator;
 
   /** number of handles allocated */
   switch_uint32_t num_in_use;
@@ -98,8 +98,7 @@ switch_handle_t switch_handle_create_and_set(switch_device_t device,
 
 switch_status_t switch_handle_get(switch_device_t device,
                                   switch_handle_type_t type,
-                                  switch_handle_t handle,
-                                  void **i_info);
+                                  switch_handle_t handle, void** i_info);
 
 switch_status_t switch_handle_delete(switch_device_t device,
                                      switch_handle_type_t type,
@@ -118,11 +117,11 @@ switch_status_t switch_handle_delete_special(switch_device_t device,
 switch_status_t switch_api_handle_iterate_internal(switch_device_t device,
                                                    switch_handle_type_t type,
                                                    switch_handle_t old_handle,
-                                                   switch_handle_t *new_handle);
+                                                   switch_handle_t* new_handle);
 
 switch_status_t switch_api_handle_count_get(switch_device_t device,
                                             switch_handle_type_t type,
-                                            switch_size_t *num_entries);
+                                            switch_size_t* num_entries);
 
 #define SWITCH_HANDLE_VALID(handle, type) \
   (switch_handle_type_get(handle) == type)
@@ -317,16 +316,16 @@ switch_status_t switch_api_handle_count_get(switch_device_t device,
 #define SWITCH_MPLS_LABEL_STACK_HANDLE(_handle) \
   SWITCH_HANDLE_VALID(_handle, SWITCH_HANDLE_TYPE_MPLS_LABEL_STACK)
 
-#define FOR_EACH_HANDLE_BEGIN(__device, __type, __handle)   \
-  {                                                         \
-    switch_status_t __status = SWITCH_STATUS_SUCCESS;       \
-    switch_handle_t __o_handle = SWITCH_API_INVALID_HANDLE; \
-    switch_handle_t __n_handle = SWITCH_API_INVALID_HANDLE; \
-    do {                                                    \
-      __status = switch_api_handle_iterate_internal(        \
-          __device, __type, __o_handle, &__n_handle);       \
-      SWITCH_ASSERT(__status == SWITCH_STATUS_SUCCESS);     \
-      __handle = __n_handle;                                \
+#define FOR_EACH_HANDLE_BEGIN(__device, __type, __handle)                     \
+  {                                                                           \
+    switch_status_t __status = SWITCH_STATUS_SUCCESS;                         \
+    switch_handle_t __o_handle = SWITCH_API_INVALID_HANDLE;                   \
+    switch_handle_t __n_handle = SWITCH_API_INVALID_HANDLE;                   \
+    do {                                                                      \
+      __status = switch_api_handle_iterate_internal(__device, __type,         \
+                                                    __o_handle, &__n_handle); \
+      SWITCH_ASSERT(__status == SWITCH_STATUS_SUCCESS);                       \
+      __handle = __n_handle;                                                  \
       __o_handle = __n_handle;
 
 #define FOR_EACH_HANDLE_END()                     \

--- a/switchapi/switch_id.h
+++ b/switchapi/switch_id.h
@@ -27,7 +27,7 @@ extern "C" {
 /** ID allocator */
 typedef struct switch_id_allocator_t_ {
   switch_uint32_t n_words; /**< number fo 32 bit words in allocator */
-  switch_uint32_t *data;   /**< bitmap of allocator */
+  switch_uint32_t* data;   /**< bitmap of allocator */
   bool zero_based;         /**< allocate index from zero if set */
   bool expandable; /**< if set, expand bitmap when needed. zero_based must be
                       FALSE */
@@ -41,14 +41,14 @@ typedef struct switch_id_allocator_t_ {
 switch_status_t switch_api_id_allocator_new(switch_device_t device,
                                             switch_uint32_t initial_size,
                                             bool zero_based,
-                                            switch_id_allocator_t **allocator);
+                                            switch_id_allocator_t** allocator);
 
 /**
  Delete the allocator
  @param allocator allocator allocated with create
 */
 switch_status_t switch_api_id_allocator_destroy(
-    switch_device_t device, switch_id_allocator_t *allocator);
+    switch_device_t device, switch_id_allocator_t* allocator);
 
 /**
  Allocate one id from the allocator
@@ -56,7 +56,7 @@ switch_status_t switch_api_id_allocator_destroy(
  @param allocator allocator created with create
 */
 switch_status_t switch_api_id_allocator_allocate(
-    switch_device_t device, switch_id_allocator_t *allocator, switch_id_t *id);
+    switch_device_t device, switch_id_allocator_t* allocator, switch_id_t* id);
 
 /**
  Allocate count consecutive ids from the allocator
@@ -65,10 +65,8 @@ switch_status_t switch_api_id_allocator_allocate(
  @param count number of consecutive ids to allocate
 */
 switch_status_t switch_api_id_allocator_allocate_contiguous(
-    switch_device_t device,
-    switch_id_allocator_t *allocator,
-    switch_uint8_t count,
-    switch_id_t *id);
+    switch_device_t device, switch_id_allocator_t* allocator,
+    switch_uint8_t count, switch_id_t* id);
 
 /**
  Free up id in allocator
@@ -76,7 +74,7 @@ switch_status_t switch_api_id_allocator_allocate_contiguous(
  @param id id to free in allocator
 */
 switch_status_t switch_api_id_allocator_release(
-    switch_device_t device, switch_id_allocator_t *allocator, switch_id_t id);
+    switch_device_t device, switch_id_allocator_t* allocator, switch_id_t id);
 
 /**
  Set a bit in allocator
@@ -84,7 +82,7 @@ switch_status_t switch_api_id_allocator_release(
  @param id - bit to be set in allocator
 */
 switch_status_t switch_api_id_allocator_set(switch_device_t device,
-                                            switch_id_allocator_t *allocator,
+                                            switch_id_allocator_t* allocator,
                                             switch_id_t id);
 /**
  Check if a bit is set in allocator
@@ -92,7 +90,7 @@ switch_status_t switch_api_id_allocator_set(switch_device_t device,
  @param id - bit to be checked in allocator
 */
 bool switch_api_id_allocator_is_set(switch_device_t device,
-                                    switch_id_allocator_t *allocator,
+                                    switch_id_allocator_t* allocator,
                                     switch_id_t id);
 
 #ifdef __cplusplus

--- a/switchapi/switch_id.h
+++ b/switchapi/switch_id.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_interface.h
+++ b/switchapi/switch_interface.h
@@ -97,9 +97,8 @@ typedef struct switch_api_interface_info_s {
  @param intf_info - interface information specific to type
  */
 switch_status_t switch_api_interface_create(
-    switch_device_t device,
-    switch_api_interface_info_t *intf_info,
-    switch_handle_t *intf_handle);
+    switch_device_t device, switch_api_interface_info_t* intf_info,
+    switch_handle_t* intf_handle);
 
 /**
  Interface delete
@@ -111,77 +110,61 @@ switch_status_t switch_api_interface_delete(switch_device_t device,
 
 switch_status_t switch_api_interface_handle_get(switch_device_t device,
                                                 switch_handle_t intf_handle,
-                                                switch_handle_t *port_handle);
+                                                switch_handle_t* port_handle);
 
 switch_status_t switch_api_interface_by_type_get(
-    switch_device_t device,
-    switch_handle_t handle,
-    switch_interface_type_t intf_type,
-    switch_handle_t *intf_handle);
+    switch_device_t device, switch_handle_t handle,
+    switch_interface_type_t intf_type, switch_handle_t* intf_handle);
 
 switch_status_t switch_api_interface_native_vlan_set(
-    switch_device_t device,
-    switch_handle_t intf_handle,
-    switch_handle_t vlan_handle,
-    switch_handle_t *member_handle);
+    switch_device_t device, switch_handle_t intf_handle,
+    switch_handle_t vlan_handle, switch_handle_t* member_handle);
 
 switch_status_t switch_api_interface_native_vlan_get(
-    switch_device_t device,
-    switch_handle_t intf_handle,
-    switch_handle_t *vlan_handle);
+    switch_device_t device, switch_handle_t intf_handle,
+    switch_handle_t* vlan_handle);
 
 switch_status_t switch_api_interface_native_vlan_id_set(
-    switch_device_t device,
-    switch_handle_t intf_handle,
-    switch_vlan_t vlan_id,
-    switch_handle_t *member_handle);
+    switch_device_t device, switch_handle_t intf_handle, switch_vlan_t vlan_id,
+    switch_handle_t* member_handle);
 
 switch_status_t switch_api_interface_native_vlan_id_get(
-    switch_device_t device,
-    switch_handle_t intf_handle,
-    switch_vlan_t *vlan_id);
+    switch_device_t device, switch_handle_t intf_handle,
+    switch_vlan_t* vlan_id);
 
 switch_status_t switch_api_interface_attribute_set(
-    const switch_device_t device,
-    const switch_handle_t intf_handle,
+    const switch_device_t device, const switch_handle_t intf_handle,
     const switch_uint64_t intf_flags,
-    const switch_api_interface_info_t *api_intf_info);
+    const switch_api_interface_info_t* api_intf_info);
 
 switch_status_t switch_api_interface_attribute_get(
-    const switch_device_t device,
-    const switch_handle_t intf_handle,
+    const switch_device_t device, const switch_handle_t intf_handle,
     const switch_uint64_t intf_flags,
-    switch_api_interface_info_t *api_intf_info);
+    switch_api_interface_info_t* api_intf_info);
 
 switch_status_t switch_api_interface_handle_dump(
-    const switch_device_t device,
-    const switch_handle_t intf_handle,
-    const void *cli_ctx);
+    const switch_device_t device, const switch_handle_t intf_handle,
+    const void* cli_ctx);
 
 switch_status_t switch_api_interface_ifindex_get(
-    switch_device_t device,
-    switch_handle_t interface_handle,
-    switch_ifindex_t *ifindex);
+    switch_device_t device, switch_handle_t interface_handle,
+    switch_ifindex_t* ifindex);
 
 switch_status_t switch_api_interface_handle_from_handle_get(
-    switch_device_t device,
-    switch_handle_t handle,
-    switch_handle_t *intf_handle);
+    switch_device_t device, switch_handle_t handle,
+    switch_handle_t* intf_handle);
 
 switch_status_t switch_api_interface_ln_handle_get(switch_device_t device,
                                                    switch_handle_t intf_handle,
-                                                   switch_handle_t *ln_handle);
+                                                   switch_handle_t* ln_handle);
 switch_status_t switch_api_interface_stats_get(
-    switch_device_t device,
-    switch_handle_t intf_handle,
-    switch_uint16_t num_entries,
-    switch_interface_counter_id_t *counter_id,
-    switch_counter_t *counters);
+    switch_device_t device, switch_handle_t intf_handle,
+    switch_uint16_t num_entries, switch_interface_counter_id_t* counter_id,
+    switch_counter_t* counters);
 
 switch_status_t switch_api_interface_port_lag_ifindex_get(
-    const switch_device_t device,
-    const switch_handle_t handle,
-    switch_ifindex_t *ifindex);
+    const switch_device_t device, const switch_handle_t handle,
+    switch_ifindex_t* ifindex);
 
 /** @} */  // end of interface
 

--- a/switchapi/switch_interface.h
+++ b/switchapi/switch_interface.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_internal.h
+++ b/switchapi/switch_internal.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_internal.h
+++ b/switchapi/switch_internal.h
@@ -19,12 +19,13 @@
 #define _switch_internal_h_
 
 #include <stdio.h>
-#include "switchapi/switch_status.h"
+
 #include "switchapi/switch_device_int.h"
 #include "switchapi/switch_handle_int.h"
+#include "switchapi/switch_status.h"
 //#include "bf_types.h"
-#include "tdi/common/tdi_defs.h"
 #include "switchutils/switch_utils.h"
+#include "tdi/common/tdi_defs.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,111 +33,100 @@ extern "C" {
 
 #define SWITCH_API_BUFFER_SIZE 512
 
-char *switch_error_to_string(switch_status_t status);
+char* switch_error_to_string(switch_status_t status);
 
-switch_status_t SWITCH_ARRAY_INIT(switch_array_t *array);
+switch_status_t SWITCH_ARRAY_INIT(switch_array_t* array);
 
-switch_uint32_t SWITCH_ARRAY_COUNT(switch_array_t *array);
+switch_uint32_t SWITCH_ARRAY_COUNT(switch_array_t* array);
 
-switch_status_t SWITCH_ARRAY_INSERT(switch_array_t *array,
-                                    switch_uint64_t index,
-                                    void *ptr);
+switch_status_t SWITCH_ARRAY_INSERT(switch_array_t* array,
+                                    switch_uint64_t index, void* ptr);
 
-switch_status_t SWITCH_ARRAY_GET(switch_array_t *array,
-                                 switch_uint64_t index,
-                                 void **ptr);
-switch_status_t SWITCH_ARRAY_NEXT(switch_array_t *array,
-                                  switch_uint64_t *index,
-                                  void **ptr);
+switch_status_t SWITCH_ARRAY_GET(switch_array_t* array, switch_uint64_t index,
+                                 void** ptr);
+switch_status_t SWITCH_ARRAY_NEXT(switch_array_t* array, switch_uint64_t* index,
+                                  void** ptr);
 
-switch_status_t SWITCH_ARRAY_DELETE(switch_array_t *array,
+switch_status_t SWITCH_ARRAY_DELETE(switch_array_t* array,
                                     switch_uint64_t index);
 
-switch_status_t SWITCH_LIST_INIT(switch_list_t *list);
+switch_status_t SWITCH_LIST_INIT(switch_list_t* list);
 
-switch_size_t SWITCH_LIST_COUNT(switch_list_t *list);
+switch_size_t SWITCH_LIST_COUNT(switch_list_t* list);
 
-bool SWITCH_LIST_EMPTY(switch_list_t *list);
+bool SWITCH_LIST_EMPTY(switch_list_t* list);
 
-switch_status_t SWITCH_LIST_SORT(switch_list_t *list,
+switch_status_t SWITCH_LIST_SORT(switch_list_t* list,
                                  switch_list_compare_func_t compare_func);
 
-switch_status_t SWITCH_LIST_INSERT(switch_list_t *list,
-                                   switch_node_t *node,
-                                   void *ptr);
+switch_status_t SWITCH_LIST_INSERT(switch_list_t* list, switch_node_t* node,
+                                   void* ptr);
 
-switch_status_t SWITCH_LIST_DELETE(switch_list_t *list, switch_node_t *node);
+switch_status_t SWITCH_LIST_DELETE(switch_list_t* list, switch_node_t* node);
 
-switch_status_t SWITCH_HASHTABLE_INIT(switch_hashtable_t *hashtable);
+switch_status_t SWITCH_HASHTABLE_INIT(switch_hashtable_t* hashtable);
 
-switch_size_t SWITCH_HASHTABLE_COUNT(switch_hashtable_t *hashtable);
+switch_size_t SWITCH_HASHTABLE_COUNT(switch_hashtable_t* hashtable);
 
-switch_status_t SWITCH_HASHTABLE_INSERT(switch_hashtable_t *hashtable,
-                                        switch_hashnode_t *node,
-                                        void *key,
-                                        void *data);
+switch_status_t SWITCH_HASHTABLE_INSERT(switch_hashtable_t* hashtable,
+                                        switch_hashnode_t* node, void* key,
+                                        void* data);
 
-switch_status_t SWITCH_HASHTABLE_DELETE(switch_hashtable_t *hashtable,
-                                        void *key,
-                                        void **data);
+switch_status_t SWITCH_HASHTABLE_DELETE(switch_hashtable_t* hashtable,
+                                        void* key, void** data);
 
-switch_status_t SWITCH_HASHTABLE_DELETE_NODE(switch_hashtable_t *hashtable,
-                                             switch_hashnode_t *node);
+switch_status_t SWITCH_HASHTABLE_DELETE_NODE(switch_hashtable_t* hashtable,
+                                             switch_hashnode_t* node);
 
-switch_status_t SWITCH_HASHTABLE_SEARCH(switch_hashtable_t *hashtable,
-                                        void *key,
-                                        void **data);
+switch_status_t SWITCH_HASHTABLE_SEARCH(switch_hashtable_t* hashtable,
+                                        void* key, void** data);
 
-switch_status_t SWITCH_HASHTABLE_FOREACH_ARG(switch_hashtable_t *hashtable,
-                                             void *func,
-                                             void *arg);
+switch_status_t SWITCH_HASHTABLE_FOREACH_ARG(switch_hashtable_t* hashtable,
+                                             void* func, void* arg);
 
-switch_status_t SWITCH_HASHTABLE_DONE(switch_hashtable_t *hashtable);
+switch_status_t SWITCH_HASHTABLE_DONE(switch_hashtable_t* hashtable);
 
-char *switch_error_to_string(switch_status_t status);
+char* switch_error_to_string(switch_status_t status);
 
-//char *switch_table_id_to_string(switch_table_id_t table_id);
+// char *switch_table_id_to_string(switch_table_id_t table_id);
 
 switch_direction_t switch_table_id_to_direction(switch_table_id_t table_id);
 
-char *switch_api_type_to_string(switch_api_type_t api_type);
+char* switch_api_type_to_string(switch_api_type_t api_type);
 
-switch_int32_t switch_convert_string_to_ipv4(const char *v4_string,
-                                             switch_ip4_t *ip);
+switch_int32_t switch_convert_string_to_ipv4(const char* v4_string,
+                                             switch_ip4_t* ip);
 
-switch_int32_t switch_convert_string_to_ipv6(const char *v6_string,
-                                             switch_ip6_t *ip);
+switch_int32_t switch_convert_string_to_ipv6(const char* v6_string,
+                                             switch_ip6_t* ip);
 
-switch_status_t switch_mac_to_string(switch_mac_addr_t *mac,
-                                     char *buffer,
+switch_status_t switch_mac_to_string(switch_mac_addr_t* mac, char* buffer,
                                      switch_int32_t buffer_size,
-                                     switch_int32_t *length);
+                                     switch_int32_t* length);
 
-switch_status_t switch_ipv6_to_string(switch_ip6_t ip6,
-                                      char *buffer,
+switch_status_t switch_ipv6_to_string(switch_ip6_t ip6, char* buffer,
                                       switch_int32_t buffer_size,
-                                      switch_int32_t *length);
+                                      switch_int32_t* length);
 
-switch_status_t switch_ipv4_to_string(switch_ip4_t ip4,
-                                      char *buffer,
+switch_status_t switch_ipv4_to_string(switch_ip4_t ip4, char* buffer,
                                       switch_int32_t buffer_size,
-                                      switch_int32_t *length);
+                                      switch_int32_t* length);
 
-char *switch_handle_type_to_string(switch_handle_type_t handle_type);
+char* switch_handle_type_to_string(switch_handle_type_t handle_type);
 
-#define SWITCH_LIST_GET_HEAD(__list, __node)    \
-    node = tommy_list_head(&__list.list);
+#define SWITCH_LIST_GET_HEAD(__list, __node) \
+  node = tommy_list_head(&__list.list);
 
 #define SWITCH_ARRAY_FIRST_GET(__array, __index, __type, __entry) \
   Word_t __index_tmp = 0;                                         \
-  Word_t *__pvalue = NULL;                                        \
+  Word_t* __pvalue = NULL;                                        \
   __entry = NULL;                                                 \
   if (__array.array) {                                            \
     JLF(__pvalue, __array.array, __index_tmp);                    \
     status = SWITCH_STATUS_ITEM_NOT_FOUND;                        \
     if (__pvalue) {                                               \
       __index = __index_tmp;                                      \
-      __entry = (__type *)__pvalue;                               \
+      __entry = (__type*)__pvalue;                                \
       status = SWITCH_STATUS_SUCCESS;                             \
     }                                                             \
   } else {                                                        \
@@ -145,11 +135,11 @@ char *switch_handle_type_to_string(switch_handle_type_t handle_type);
 
 #define SWITCH_ARRAY_NEXT_GET(__array, __o_index, __n_index, __type, __entry) \
   Word_t __index_tmp = (Word_t)__o_index;                                     \
-  Word_t *__pvalue = NULL;                                                    \
+  Word_t* __pvalue = NULL;                                                    \
   __entry = NULL;                                                             \
   JLN(__pvalue, __array.array, __index_tmp);                                  \
   if (__pvalue) {                                                             \
-    __entry = (__type *)__pvalue;                                             \
+    __entry = (__type*)__pvalue;                                              \
     __n_index = __index_tmp;                                                  \
   } else {                                                                    \
     __n_index = SWITCH_API_INVALID_HANDLE;                                    \
@@ -158,14 +148,14 @@ char *switch_handle_type_to_string(switch_handle_type_t handle_type);
 
 #define FOR_EACH_IN_ARRAY(__index, __array, __type, __entry)            \
   {                                                                     \
-    Word_t *__pvalue = NULL;                                            \
-    Word_t *__pvalue_next = NULL;                                       \
+    Word_t* __pvalue = NULL;                                            \
+    Word_t* __pvalue_next = NULL;                                       \
     Word_t __index_tmp = __index;                                       \
     JLF(__pvalue, __array.array, __index_tmp);                          \
     __index = __index_tmp;                                              \
     for (; __pvalue; __pvalue = __pvalue_next, __index = __index_tmp) { \
       JLN(__pvalue_next, __array.array, __index_tmp);                   \
-      __entry = (__type *)(*__pvalue);
+      __entry = (__type*)(*__pvalue);
 
 #define FOR_EACH_IN_ARRAY_END() \
   }                             \
@@ -173,8 +163,8 @@ char *switch_handle_type_to_string(switch_handle_type_t handle_type);
 
 #define FOR_EACH_IN_ARRAY_VALUE(__index, __array, __type, __entry)      \
   {                                                                     \
-    Word_t *__pvalue = NULL;                                            \
-    Word_t *__pvalue_next = NULL;                                       \
+    Word_t* __pvalue = NULL;                                            \
+    Word_t* __pvalue_next = NULL;                                       \
     Word_t __index_tmp = __index;                                       \
     JLF(__pvalue, __array.array, __index_tmp);                          \
     __index = __index_tmp;                                              \
@@ -189,7 +179,7 @@ char *switch_handle_type_to_string(switch_handle_type_t handle_type);
 #define FOR_EACH_IN_LIST(__list, __node)   \
   {                                        \
     node = tommy_list_head(&__list.list);  \
-    switch_node_t *__next_node = NULL;     \
+    switch_node_t* __next_node = NULL;     \
     for (; __node; __node = __next_node) { \
       __next_node = node->next;
 
@@ -197,7 +187,7 @@ char *switch_handle_type_to_string(switch_handle_type_t handle_type);
   }                            \
   }
 
-#define SWITCH_HW_FLAG_ISSET(_info, _pd_entry) _info->hw_flags &_pd_entry
+#define SWITCH_HW_FLAG_ISSET(_info, _pd_entry) _info->hw_flags& _pd_entry
 
 #define SWITCH_HW_FLAG_SET(_info, _pd_entry) _info->hw_flags |= _pd_entry
 
@@ -206,16 +196,15 @@ char *switch_handle_type_to_string(switch_handle_type_t handle_type);
 #define SWITCH_HASHTABLE_ITERATOR(_hashtable, _func, _arg) \
   tommy_hashtable_foreach_arg(_hashtable, _func, _arg)
 
-#define CHECK_RET(x, ret)                                                      \
-  do {                                                                         \
-    if (x) {                                                                   \
+#define CHECK_RET(x, ret)                                            \
+  do {                                                               \
+    if (x) {                                                         \
       printf("ERROR %s at (%s)\n", switch_error_to_string(ret), #x); \
-      return ret;                                                              \
-    }                                                                          \
+      return ret;                                                    \
+    }                                                                \
   } while (0)
 
-#define SWITCH_ASSERT(x)                              \
-    CHECK_RET(!(x), SWITCH_STATUS_INVALID_PARAMETER); \
+#define SWITCH_ASSERT(x) CHECK_RET(!(x), SWITCH_STATUS_INVALID_PARAMETER);
 
 // TODO, get this info from p4 table
 #define TUNNEL_TABLE_SIZE 128

--- a/switchapi/switch_l3.h
+++ b/switchapi/switch_l3.h
@@ -38,7 +38,6 @@ extern "C" {
  *  @{
  */
 
-
 /** route type */
 typedef enum switch_route_type_s {
   SWITCH_ROUTE_TYPE_HOST = 0,
@@ -98,7 +97,6 @@ typedef struct switch_route_info_s {
 
 } switch_route_info_t;
 
-
 /**
  Get the handle of the interface that route lookup returns for a host addr
  @param device device
@@ -108,8 +106,8 @@ typedef struct switch_route_info_s {
 */
 switch_status_t switch_api_l3_route_nhop_get(switch_device_t device,
                                              switch_handle_t vrf_handle,
-                                             switch_ip_addr_t *ip_addr,
-                                             switch_handle_t *intf_handle);
+                                             switch_ip_addr_t* ip_addr,
+                                             switch_handle_t* intf_handle);
 
 /**
  * @brief route add - add an entry to host or lpm table to match based on
@@ -122,7 +120,7 @@ switch_status_t switch_api_l3_route_nhop_get(switch_device_t device,
  * returned.
  */
 switch_status_t switch_api_l3_route_add(
-    switch_device_t device, switch_api_route_entry_t *api_route_entry);
+    switch_device_t device, switch_api_route_entry_t* api_route_entry);
 
 /**
  * @brief route update - update an entry to host or lpm table to match based on
@@ -135,7 +133,7 @@ switch_status_t switch_api_l3_route_add(
  * returned.
  */
 switch_status_t switch_api_l3_route_update(
-    switch_device_t device, switch_api_route_entry_t *api_route_entry);
+    switch_device_t device, switch_api_route_entry_t* api_route_entry);
 
 /**
  * @brief route delete - delete an entry to host or lpm table to match based on
@@ -147,8 +145,8 @@ switch_status_t switch_api_l3_route_update(
  * @return #SWITCH_STATUS_SUCCESS if success otherwise error code is
  * returned.
  */
-switch_status_t switch_api_l3_delete_route(switch_device_t device,
-    switch_api_route_entry_t *api_route_entry);
+switch_status_t switch_api_l3_delete_route(
+    switch_device_t device, switch_api_route_entry_t* api_route_entry);
 /**
  Lookup FIB table (host or LPM) for a given host address
  Return nexthop handle (single path or ECMP group)
@@ -159,9 +157,8 @@ switch_status_t switch_api_l3_delete_route(switch_device_t device,
  @param nhop_handle pointer to return Nexthop  Handle
 */
 switch_status_t switch_api_l3_route_lookup(
-    switch_device_t device,
-    switch_api_route_entry_t *api_route_entry,
-    switch_handle_t *nhop_handle);
+    switch_device_t device, switch_api_route_entry_t* api_route_entry,
+    switch_handle_t* nhop_handle);
 
 switch_status_t switch_api_rif_ipv4_unicast_enabled_set(
     switch_device_t device, switch_handle_t intf_handle, bool set);
@@ -171,19 +168,18 @@ switch_status_t switch_api_rif_ipv6_unicast_enabled_set(
 
 switch_status_t switch_api_l3_route_handle_lookup(
     const switch_device_t device,
-    const switch_api_route_entry_t *api_route_entry,
-    switch_handle_t *route_handle);
+    const switch_api_route_entry_t* api_route_entry,
+    switch_handle_t* route_handle);
 
 switch_status_t switch_api_route_table_size_get(switch_device_t device,
-                                                switch_size_t *tbl_size);
+                                                switch_size_t* tbl_size);
 
 switch_status_t switch_route_hashtable_insert(switch_device_t device,
                                               switch_handle_t route_handle);
 
 switch_status_t switch_route_table_hash_lookup(
-    switch_device_t device,
-    switch_route_entry_t *route_entry,
-    switch_handle_t *route_handle);
+    switch_device_t device, switch_route_entry_t* route_entry,
+    switch_handle_t* route_handle);
 
 switch_status_t switch_route_hashtable_remove(switch_device_t device,
                                               switch_handle_t route_handle);

--- a/switchapi/switch_l3.h
+++ b/switchapi/switch_l3.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_l3_int.h
+++ b/switchapi/switch_l3_int.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_l3_int.h
+++ b/switchapi/switch_l3_int.h
@@ -34,19 +34,19 @@ extern "C" {
 #define SWITCH_IP_TYPE_IPv6 2
 
 /** route handle wrappers */
-#define switch_route_handle_create(_device) \
-  switch_handle_create(                     \
-      _device, SWITCH_HANDLE_TYPE_ROUTE, sizeof(switch_route_info_t))
+#define switch_route_handle_create(_device)               \
+  switch_handle_create(_device, SWITCH_HANDLE_TYPE_ROUTE, \
+                       sizeof(switch_route_info_t))
 
 #define switch_route_handle_delete(_device, _handle) \
   switch_handle_delete(_device, SWITCH_HANDLE_TYPE_ROUTE, _handle)
 
-#define switch_route_get(_device, _handle, _info)                    \
-  ({                                                                 \
-    switch_route_info_t *_tmp_route_info = NULL;                     \
-    (void)(_tmp_route_info == *_info);                               \
-    switch_handle_get(                                               \
-        _device, SWITCH_HANDLE_TYPE_ROUTE, _handle, (void **)_info); \
+#define switch_route_get(_device, _handle, _info)                 \
+  ({                                                              \
+    switch_route_info_t* _tmp_route_info = NULL;                  \
+    (void)(_tmp_route_info == *_info);                            \
+    switch_handle_get(_device, SWITCH_HANDLE_TYPE_ROUTE, _handle, \
+                      (void**)_info);                             \
   })
 
 /** stores route information */
@@ -74,21 +74,20 @@ typedef struct switch_l3_context_s {
 
 #define SWITCH_L3_IP_IPV6_ADDRESS(ip_info) ip_info->ip.v6addr
 
-switch_status_t switch_route_table_entry_key_init(void *args,
-                                                  switch_uint8_t *key,
-                                                  switch_uint32_t *len);
+switch_status_t switch_route_table_entry_key_init(void* args,
+                                                  switch_uint8_t* key,
+                                                  switch_uint32_t* len);
 
-switch_int32_t switch_route_entry_hash_compare(const void *key1,
-                                               const void *key2);
+switch_int32_t switch_route_entry_hash_compare(const void* key1,
+                                               const void* key2);
 
 switch_status_t switch_l3_init(switch_device_t device);
 
 switch_status_t switch_l3_free(switch_device_t device);
 
 switch_status_t switch_route_table_hash_lookup(
-    switch_device_t device,
-    switch_route_entry_t *route_entry,
-    switch_handle_t *route_handle);
+    switch_device_t device, switch_route_entry_t* route_entry,
+    switch_handle_t* route_handle);
 
 #ifdef __cplusplus
 }

--- a/switchapi/switch_lag.h
+++ b/switchapi/switch_lag.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Intel Corporation.
+ * Copyright 2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_neighbor.h
+++ b/switchapi/switch_neighbor.h
@@ -78,19 +78,17 @@ typedef struct switch_neighbor_info_s {
 } switch_neighbor_info_t;
 
 switch_status_t switch_api_neighbor_attribute_get(
-    const switch_device_t device,
-    const switch_handle_t neighbor_handle,
+    const switch_device_t device, const switch_handle_t neighbor_handle,
     const switch_uint64_t neighbor_flags,
-    switch_api_neighbor_info_t *api_neighbor_info);
+    switch_api_neighbor_info_t* api_neighbor_info);
 /**
 ARP entry add
 @param device device
 @param neighbor - ARP information used to set egress table
 */
 switch_status_t switch_api_neighbor_create(
-    switch_device_t device,
-    switch_api_neighbor_info_t *api_neighbor,
-    switch_handle_t *neighbor_handle);
+    switch_device_t device, switch_api_neighbor_info_t* api_neighbor,
+    switch_handle_t* neighbor_handle);
 
 /**
 ARP entry delete

--- a/switchapi/switch_neighbor.h
+++ b/switchapi/switch_neighbor.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_neighbor_int.h
+++ b/switchapi/switch_neighbor_int.h
@@ -17,45 +17,44 @@
 #ifndef __SWITCH_NEIGHBOR_INT_H__
 #define __SWITCH_NEIGHBOR_INT_H__
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
 
-#include "switch_types_int.h"
 #include "switch_rif.h"
+#include "switch_types_int.h"
 
 #if defined(DPDK_TARGET)
-  #include "dpdk/switch_pd_routing.h"
+#include "dpdk/switch_pd_routing.h"
 #elif defined(ES2K_TARGET)
-  #include "es2k/switch_pd_routing.h"
+#include "es2k/switch_pd_routing.h"
 #endif
 
-#define switch_neighbor_handle_create(_device) \
-  switch_handle_create(                        \
-      _device, SWITCH_HANDLE_TYPE_NEIGHBOR, sizeof(switch_neighbor_info_t))
+#define switch_neighbor_handle_create(_device)               \
+  switch_handle_create(_device, SWITCH_HANDLE_TYPE_NEIGHBOR, \
+                       sizeof(switch_neighbor_info_t))
 
 #define switch_neighbor_handle_delete(_device, _handle) \
   switch_handle_delete(_device, SWITCH_HANDLE_TYPE_NEIGHBOR, _handle)
 
-#define switch_neighbor_get(_device, _handle, _info)                    \
-  ({                                                                    \
-    switch_neighbor_info_t *_tmp_neighbor_info = NULL;                  \
-    (void)(_tmp_neighbor_info == *_info);                               \
-    switch_handle_get(                                                  \
-        _device, SWITCH_HANDLE_TYPE_NEIGHBOR, _handle, (void **)_info); \
+#define switch_neighbor_get(_device, _handle, _info)                 \
+  ({                                                                 \
+    switch_neighbor_info_t* _tmp_neighbor_info = NULL;               \
+    (void)(_tmp_neighbor_info == *_info);                            \
+    switch_handle_get(_device, SWITCH_HANDLE_TYPE_NEIGHBOR, _handle, \
+                      (void**)_info);                                \
   })
 
 /** neighbor device context */
 typedef struct switch_neighbor_context_s {
   /** tunnel dmac rewrite hashtable */
-//  switch_hashtable_t tunnel_dmac_rewrite_hashtable;
+  //  switch_hashtable_t tunnel_dmac_rewrite_hashtable;
 
   /** dmac rewrite hashtable */
-//  switch_hashtable_t neighbor_dmac_hashtable;
+  //  switch_hashtable_t neighbor_dmac_hashtable;
 
   /** tunnel dmac rewrite index allocator */
-  switch_id_allocator_t *dmac_rewrite_index;
+  switch_id_allocator_t* dmac_rewrite_index;
 
 } switch_neighbor_context_t;
 

--- a/switchapi/switch_neighbor_int.h
+++ b/switchapi/switch_neighbor_int.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_nhop.h
+++ b/switchapi/switch_nhop.h
@@ -108,8 +108,7 @@ typedef struct switch_api_nhop_info_s {
 } switch_api_nhop_info_t;
 
 /** nhop_group info struct */
-typedef struct switch_nhop_group_info_s
-{
+typedef struct switch_nhop_group_info_s {
   switch_handle_t nhop_group_handle;
 
   switch_list_t members;
@@ -121,8 +120,6 @@ typedef struct switch_nhop_group_info_s
   bool pd_nhop_group_deleted;
 
 } switch_nhop_group_info_t;
-
-
 
 typedef struct switch_nhop_member_s {
   /** nhop member handle */
@@ -156,10 +153,8 @@ switch_status_t switch_nhop_member_handle_init(switch_device_t device);
  @param nhop_key- Interface to be associated with the nexthop and nexthop ip
 */
 switch_status_t switch_api_nhop_create(
-    const switch_device_t device,
-    const switch_api_nhop_info_t *api_nhop_info,
-    switch_handle_t *nhop_handle);
-
+    const switch_device_t device, const switch_api_nhop_info_t* api_nhop_info,
+    switch_handle_t* nhop_handle);
 
 /**
  Update a Nexthop
@@ -170,7 +165,7 @@ switch_status_t switch_api_nhop_create(
 switch_status_t switch_api_nhop_update(switch_device_t device,
                                        switch_handle_t nhop_handle,
                                        switch_uint64_t flags,
-                                       switch_api_nhop_info_t *api_nhop_info);
+                                       switch_api_nhop_info_t* api_nhop_info);
 
 /**
  Get attributes of a Nexthop
@@ -180,7 +175,7 @@ switch_status_t switch_api_nhop_update(switch_device_t device,
 */
 switch_status_t switch_api_nhop_get(switch_device_t device,
                                     switch_handle_t nhop_handle,
-                                    switch_api_nhop_info_t *api_nhop_info);
+                                    switch_api_nhop_info_t* api_nhop_info);
 
 /**
  Delete a Nexthop
@@ -195,15 +190,15 @@ switch_status_t switch_api_nhop_delete(const switch_device_t device,
  @param device - device to create the nhop_group group
  @param nhop_handle - Handle that identifies nexthop uniquely
 */
-switch_status_t switch_api_create_nhop_group(const switch_device_t device,
-                                            switch_handle_t *nhop_group_handle);
+switch_status_t switch_api_create_nhop_group(
+    const switch_device_t device, switch_handle_t* nhop_group_handle);
 
 /**
  Delete a nhop Group
  @param nhop_group_handle - Handle that identifies nhop group uniquely
 */
-switch_status_t switch_api_delete_nhop_group(const switch_device_t device,
-                                      const switch_handle_t nhop_group_handle);
+switch_status_t switch_api_delete_nhop_group(
+    const switch_device_t device, const switch_handle_t nhop_group_handle);
 
 /**
  Add nexthop member to nhop group
@@ -213,11 +208,9 @@ switch_status_t switch_api_delete_nhop_group(const switch_device_t device,
  @param nhop_handle_list - List of nexthops to be added to the nhop Group
 */
 switch_status_t switch_api_add_nhop_member(
-    const switch_device_t device,
-    const switch_handle_t nhop_group_handle,
-    const switch_uint32_t num_nhops,
-    const switch_handle_t *nhop_handles,
-    switch_handle_t *member_handle);
+    const switch_device_t device, const switch_handle_t nhop_group_handle,
+    const switch_uint32_t num_nhops, const switch_handle_t* nhop_handles,
+    switch_handle_t* member_handle);
 
 /**
  Delete nexthop member from nhop group
@@ -227,27 +220,24 @@ switch_status_t switch_api_add_nhop_member(
  @param nhop_handle_list - List of nexthops to be added to the nhop Group
 */
 switch_status_t switch_api_delete_nhop_member(
-    const switch_device_t device,
-    const switch_handle_t nhop_group_handle,
-    const switch_uint32_t num_nhops,
-    const switch_handle_t *nhop_handles);
+    const switch_device_t device, const switch_handle_t nhop_group_handle,
+    const switch_uint32_t num_nhops, const switch_handle_t* nhop_handles);
 
 /*
  Return nexthop handle from (intf_handle, ip address)
  @param nhop_key- Interface to be associated with the nexthop and nexthop ip
  */
 switch_status_t switch_api_nhop_handle_get(const switch_device_t device,
-                                           const switch_nhop_key_t *nhop_key,
-                                           switch_handle_t *nhop_handle);
+                                           const switch_nhop_key_t* nhop_key,
+                                           switch_handle_t* nhop_handle);
 
 /*
  Get neighbor handle from nexthop handle
  @param nhop_handle nexthop handle
  */
 switch_status_t switch_api_neighbor_handle_get(
-    const switch_device_t device,
-    const switch_handle_t nhop_handle,
-    switch_handle_t *neighbor_handle);
+    const switch_device_t device, const switch_handle_t nhop_handle,
+    switch_handle_t* neighbor_handle);
 
 /*
  Get to know whether nhop is single path or ecmp
@@ -255,50 +245,43 @@ switch_status_t switch_api_neighbor_handle_get(
 */
 switch_status_t switch_api_nhop_id_type_get(const switch_device_t device,
                                             const switch_handle_t nhop_handle,
-                                            switch_nhop_id_type_t *nhop_type);
+                                            switch_nhop_id_type_t* nhop_type);
 
-switch_status_t switch_api_delete_nhop_members(switch_device_t device,
-                                               switch_handle_t nhop_group_handle);
+switch_status_t switch_api_delete_nhop_members(
+    switch_device_t device, switch_handle_t nhop_group_handle);
 
-switch_status_t switch_api_nhop_members_get(const switch_device_t device,
-                                            const switch_handle_t nhop_group_handle,
-                                            switch_uint16_t *num_nhops,
-                                            switch_handle_t **nhop_handles);
+switch_status_t switch_api_nhop_members_get(
+    const switch_device_t device, const switch_handle_t nhop_group_handle,
+    switch_uint16_t* num_nhops, switch_handle_t** nhop_handles);
 
 switch_status_t switch_api_nhop_handle_dump(const switch_device_t device,
                                             const switch_handle_t nhop_handle,
-                                            const void *cli_ctx);
+                                            const void* cli_ctx);
 switch_status_t switch_api_nhop_table_size_get(switch_device_t device,
-                                               switch_size_t *tbl_size);
+                                               switch_size_t* tbl_size);
 
 switch_status_t switch_api_nhop_group_get_by_nhop_member(
-    const switch_device_t device,
-    const switch_handle_t nhop_member_handle,
-    switch_handle_t *nhop_group_handle,
-    switch_handle_t *nhop_handle);
+    const switch_device_t device, const switch_handle_t nhop_member_handle,
+    switch_handle_t* nhop_group_handle, switch_handle_t* nhop_handle);
 
 switch_status_t switch_api_rif_nhop_get(switch_device_t device,
                                         switch_handle_t vrf_handle,
-                                        switch_handle_t *nhop_handle);
-
+                                        switch_handle_t* nhop_handle);
 
 /**
  * function to initialize nhop key
- * */ 
-switch_status_t switch_nhop_hash_key_init(void *args,
-                                          switch_uint8_t *key,
-                                          switch_uint32_t *len);
+ * */
+switch_status_t switch_nhop_hash_key_init(void* args, switch_uint8_t* key,
+                                          switch_uint32_t* len);
 
 /**
  * function to compare 2 nhop keys
  * */
-switch_int32_t switch_nhop_hash_compare(const void *key1, const void *key2);
+switch_int32_t switch_nhop_hash_compare(const void* key1, const void* key2);
 
 switch_status_t nhop_member_get_from_nhop(
-    const switch_device_t device,
-    const switch_handle_t nhop_group_handle,
-    const switch_handle_t nhop_handle,
-    switch_nhop_member_t **nhop_member);
+    const switch_device_t device, const switch_handle_t nhop_group_handle,
+    const switch_handle_t nhop_handle, switch_nhop_member_t** nhop_member);
 #ifdef __cplusplus
 }
 #endif

--- a/switchapi/switch_nhop.h
+++ b/switchapi/switch_nhop.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_nhop_int.h
+++ b/switchapi/switch_nhop_int.h
@@ -15,13 +15,13 @@
  * limitations under the License.
  */
 
-#include "switch_types_int.h"
 #include "switch_nhop.h"
+#include "switch_types_int.h"
 
 #if defined(DPDK_TARGET)
-  #include "dpdk/switch_pd_routing.h"
+#include "dpdk/switch_pd_routing.h"
 #elif defined(ES2K_TARGET)
-  #include "es2k/switch_pd_routing.h"
+#include "es2k/switch_pd_routing.h"
 #endif
 
 #ifndef __SWITCH_NHOP_INT_H__
@@ -43,45 +43,44 @@ extern "C" {
 #define MAX_NEIGHBOR_NODES 0
 #endif
 
-
 // note - have relevant functions now in switch_nhop.c
-#define switch_nhop_handle_create(_device, _count) \
-  switch_handle_create(                    \
-      _device, SWITCH_HANDLE_TYPE_NHOP, sizeof(switch_nhop_info_t))
+#define switch_nhop_handle_create(_device, _count)       \
+  switch_handle_create(_device, SWITCH_HANDLE_TYPE_NHOP, \
+                       sizeof(switch_nhop_info_t))
 
-#define switch_nhop_group_create_handle(_device, _count) \
-  switch_handle_create(                    \
-      _device, SWITCH_HANDLE_TYPE_NHOP_GROUP, sizeof(switch_nhop_group_info_t))
+#define switch_nhop_group_create_handle(_device, _count)       \
+  switch_handle_create(_device, SWITCH_HANDLE_TYPE_NHOP_GROUP, \
+                       sizeof(switch_nhop_group_info_t))
 
 #define switch_nhop_handle_delete(_device, _handle, _count) \
   switch_handle_delete(_device, SWITCH_HANDLE_TYPE_NHOP, _handle)
 
-#define switch_nhop_get(_device, _handle, _info)                    \
-  ({                                                                \
-    switch_nhop_info_t *_tmp_nhop_info = NULL;                      \
-    (void)(_tmp_nhop_info == *_info);                               \
-    switch_handle_get(                                              \
-        _device, SWITCH_HANDLE_TYPE_NHOP, _handle, (void **)_info); \
+#define switch_nhop_get(_device, _handle, _info)                 \
+  ({                                                             \
+    switch_nhop_info_t* _tmp_nhop_info = NULL;                   \
+    (void)(_tmp_nhop_info == *_info);                            \
+    switch_handle_get(_device, SWITCH_HANDLE_TYPE_NHOP, _handle, \
+                      (void**)_info);                            \
   })
 
-#define switch_nhop_member_create_handle(_device) \
-  switch_handle_create(                           \
-      _device, SWITCH_HANDLE_TYPE_NHOP_MEMBER, sizeof(switch_nhop_member_t))
+#define switch_nhop_member_create_handle(_device)               \
+  switch_handle_create(_device, SWITCH_HANDLE_TYPE_NHOP_MEMBER, \
+                       sizeof(switch_nhop_member_t))
 
 #define switch_nhop_delete_member_handle(_device, _handle) \
   switch_handle_delete(_device, SWITCH_HANDLE_TYPE_NHOP_MEMBER, _handle)
 
-#define switch_nhop_get_member(_device, _handle, _info)                    \
-  ({                                                                       \
-    switch_nhop_member_t *_tmp_nhop_member_info = NULL;                    \
-    (void)(_tmp_nhop_member_info == *_info);                               \
-    switch_handle_get(                                                     \
-        _device, SWITCH_HANDLE_TYPE_NHOP_MEMBER, _handle, (void **)_info); \
+#define switch_nhop_get_member(_device, _handle, _info)                 \
+  ({                                                                    \
+    switch_nhop_member_t* _tmp_nhop_member_info = NULL;                 \
+    (void)(_tmp_nhop_member_info == *_info);                            \
+    switch_handle_get(_device, SWITCH_HANDLE_TYPE_NHOP_MEMBER, _handle, \
+                      (void**)_info);                                   \
   })
 
-#define switch_nhop_get_group(_device, _handle, _info)                    \
-    switch_handle_get(                                              \
-        _device, SWITCH_HANDLE_TYPE_NHOP_GROUP, _handle, (void **)_info)
+#define switch_nhop_get_group(_device, _handle, _info)               \
+  switch_handle_get(_device, SWITCH_HANDLE_TYPE_NHOP_GROUP, _handle, \
+                    (void**)_info)
 
 #define switch_nhop_group_delete_handle(_device, _handle) \
   switch_handle_delete(_device, SWITCH_HANDLE_TYPE_NHOP_GROUP, _handle)
@@ -101,7 +100,7 @@ extern "C" {
     SWITCH_MEMSET(&_nhop_key, 0x0, sizeof(switch_nhop_key_t));            \
     if (_api_nhop_info->nhop_type == SWITCH_NHOP_TYPE_IP) {               \
       SWITCH_ASSERT(SWITCH_RIF_HANDLE(_api_nhop_info->rif_handle) ||      \
-		    SWITCH_LAG_HANDLE(_api_nhop_info->rif_handle));       \
+                    SWITCH_LAG_HANDLE(_api_nhop_info->rif_handle));       \
       _nhop_key.handle = _api_nhop_info->rif_handle;                      \
     } else if (_api_nhop_info->nhop_type == SWITCH_NHOP_TYPE_TUNNEL) {    \
       SWITCH_ASSERT(SWITCH_TUNNEL_HANDLE(_api_nhop_info->tunnel_handle)); \
@@ -116,12 +115,11 @@ extern "C" {
     } else {                                                              \
       _nhop_key.handle = _api_nhop_info->intf_handle;                     \
     }                                                                     \
-    SWITCH_MEMCPY(&_nhop_key.ip_addr,                                     \
-                  &api_nhop_info->ip_addr,                                \
+    SWITCH_MEMCPY(&_nhop_key.ip_addr, &api_nhop_info->ip_addr,            \
                   sizeof(switch_ip_addr_t));                              \
   } while (0);
 
-static inline char *switch_nhop_type_to_string(switch_nhop_type_t nhop_type) {
+static inline char* switch_nhop_type_to_string(switch_nhop_type_t nhop_type) {
   switch (nhop_type) {
     case SWITCH_NHOP_TYPE_NONE:
       return "punt";
@@ -185,7 +183,7 @@ typedef struct switch_nhop_info_s {
 
   /** nhop type is single path */
   switch_spath_info_t spath;
-  
+
   /** number of nhop group references */
   switch_uint32_t nhop_group_ref_count;
 
@@ -235,15 +233,12 @@ switch_status_t switch_nhop_default_entries_delete(switch_device_t device);
  * maintained by nhop and increases ref count by 1
  */
 switch_status_t switch_nhop_add_to_group_member_list(
-    switch_device_t device,
-    switch_nhop_info_t *nhop_info,
+    switch_device_t device, switch_nhop_info_t* nhop_info,
     switch_handle_t nhop_mem_handle);
 
 switch_status_t switch_nhop_member_get_from_nhop(
-    const switch_device_t device,
-    const switch_handle_t nhop_group_handle,
-    const switch_handle_t nhop_handle,
-    switch_nhop_member_t **nhop_member);
+    const switch_device_t device, const switch_handle_t nhop_group_handle,
+    const switch_handle_t nhop_handle, switch_nhop_member_t** nhop_member);
 
 #ifdef __cplusplus
 }

--- a/switchapi/switch_nhop_int.h
+++ b/switchapi/switch_nhop_int.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_port_int.h
+++ b/switchapi/switch_port_int.h
@@ -92,41 +92,40 @@ typedef enum switch_port_vlan_xlate_entry_type_s {
 #define SWITCH_PORT_FREE(_d, _p) SWITCH_FREE(_d, _p)
 
 /** port handle wrappers */
-#define switch_port_handle_create(_device) \
-  switch_handle_create(                    \
-      _device, SWITCH_HANDLE_TYPE_PORT, sizeof(switch_port_info_t))
+#define switch_port_handle_create(_device)               \
+  switch_handle_create(_device, SWITCH_HANDLE_TYPE_PORT, \
+                       sizeof(switch_port_info_t))
 
 #define switch_port_handle_delete(_device, _handle) \
   switch_handle_delete(_device, SWITCH_HANDLE_TYPE_PORT, _handle)
 
-#define switch_port_get(_device, _handle, _info)                    \
-  ({                                                                \
-    switch_port_info_t *_tmp_port_info = NULL;                      \
-    (void)(_tmp_port_info == *_info);                               \
-    switch_handle_get(                                              \
-        _device, SWITCH_HANDLE_TYPE_PORT, _handle, (void **)_info); \
+#define switch_port_get(_device, _handle, _info)                 \
+  ({                                                             \
+    switch_port_info_t* _tmp_port_info = NULL;                   \
+    (void)(_tmp_port_info == *_info);                            \
+    switch_handle_get(_device, SWITCH_HANDLE_TYPE_PORT, _handle, \
+                      (void**)_info);                            \
   })
 
 /** port priority group handle wrappers */
-#define switch_ppg_handle_create(_device)                 \
-  switch_handle_create(_device,                           \
-                       SWITCH_HANDLE_TYPE_PRIORITY_GROUP, \
+#define switch_ppg_handle_create(_device)                          \
+  switch_handle_create(_device, SWITCH_HANDLE_TYPE_PRIORITY_GROUP, \
                        sizeof(switch_port_priority_group_t))
 
 #define switch_ppg_handle_delete(_device, _handle) \
   switch_handle_delete(_device, SWITCH_HANDLE_TYPE_PRIORITY_GROUP, _handle)
 
-#define switch_ppg_get(_device, _handle, _info)                               \
-  ({                                                                          \
-    switch_port_priority_group_t *_tmp_port_priority_group = NULL;            \
-    (void)(_tmp_port_priority_group == *_info);                               \
-    switch_handle_get(                                                        \
-        _device, SWITCH_HANDLE_TYPE_PRIORITY_GROUP, _handle, (void **)_info); \
+#define switch_ppg_get(_device, _handle, _info)                            \
+  ({                                                                       \
+    switch_port_priority_group_t* _tmp_port_priority_group = NULL;         \
+    (void)(_tmp_port_priority_group == *_info);                            \
+    switch_handle_get(_device, SWITCH_HANDLE_TYPE_PRIORITY_GROUP, _handle, \
+                      (void**)_info);                                      \
   })
 
 #define SWITCH_PORT_DEV_PORT_GET(_device, _port_handle, _dev_port, _status) \
   do {                                                                      \
-    switch_port_info_t *_port_info = NULL;                                  \
+    switch_port_info_t* _port_info = NULL;                                  \
     _status = SWITCH_STATUS_INVALID_HANDLE;                                 \
     _status = switch_port_get(_device, _port_handle, &_port_info);          \
     if (_port_info) {                                                       \
@@ -134,8 +133,7 @@ typedef enum switch_port_vlan_xlate_entry_type_s {
     }                                                                       \
   } while (0);
 
-
-static inline char *switch_port_speed_to_string(
+static inline char* switch_port_speed_to_string(
     switch_port_speed_t port_speed) {
   switch (port_speed) {
     case SWITCH_PORT_SPEED_10G:
@@ -155,7 +153,7 @@ static inline char *switch_port_speed_to_string(
   }
 }
 
-static inline char *switch_port_type_to_string(switch_port_type_t port_type) {
+static inline char* switch_port_type_to_string(switch_port_type_t port_type) {
   switch (port_type) {
     case SWITCH_PORT_TYPE_NORMAL:
       return "NORMAL";
@@ -170,7 +168,7 @@ static inline char *switch_port_type_to_string(switch_port_type_t port_type) {
   }
 }
 
-static inline char *switch_port_oper_status_to_string(
+static inline char* switch_port_oper_status_to_string(
     switch_port_oper_status_t oper_status) {
   switch (oper_status) {
     case SWITCH_PORT_OPER_STATUS_UNKNOWN:
@@ -186,7 +184,7 @@ static inline char *switch_port_oper_status_to_string(
   }
 }
 
-static inline char *switch_port_auto_neg_mode_to_string(
+static inline char* switch_port_auto_neg_mode_to_string(
     switch_port_auto_neg_mode_t an_mode) {
   switch (an_mode) {
     case SWITCH_PORT_AUTO_NEG_MODE_DEFAULT:
@@ -200,7 +198,7 @@ static inline char *switch_port_auto_neg_mode_to_string(
   }
 }
 
-static inline char *switch_port_lb_mode_to_string(
+static inline char* switch_port_lb_mode_to_string(
     switch_port_loopback_mode_t lb_mode) {
   switch (lb_mode) {
     case SWITCH_PORT_LOOPBACK_MODE_NONE:
@@ -353,8 +351,8 @@ typedef enum switch_port_num_lanes_s {
     }                                                                     \
   } while (0);
 
-#define SWITCH_PORT_SC_STATS_HW_FLAG_ISSET(                                   \
-    _port_info, _pkt_type, _color, _hw_set)                                   \
+#define SWITCH_PORT_SC_STATS_HW_FLAG_ISSET(_port_info, _pkt_type, _color,     \
+                                           _hw_set)                           \
   do {                                                                        \
     if (_pkt_type == SWITCH_PACKET_TYPE_UNICAST) {                            \
       if (_color == SWITCH_COLOR_GREEN) {                                     \

--- a/switchapi/switch_port_int.h
+++ b/switchapi/switch_port_int.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_rif.h
+++ b/switchapi/switch_rif.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_rif.h
+++ b/switchapi/switch_rif.h
@@ -44,25 +44,22 @@ typedef struct switch_api_rif_info_s {
   switch_handle_t rmac_handle; /**< rmac group id */
   switch_handle_t nh_handle;   /**< shared nexthop if a route points to RIF */
 
-  switch_port_t port_id; /** target dp index used when packet need to tx */
+  switch_port_t port_id;     /** target dp index used when packet need to tx */
   switch_port_t phy_port_id; /** target dp index used when packet need to rx */
 
 } switch_api_rif_info_t;
 
 switch_status_t switch_rif_init(switch_device_t device);
 
-
 switch_status_t switch_rif_free(switch_device_t device);
 
 switch_status_t switch_api_rif_attribute_get(
-    const switch_device_t device,
-    const switch_handle_t rif_handle,
-    const switch_uint64_t rif_flags,
-    switch_api_rif_info_t *api_rif_info);
+    const switch_device_t device, const switch_handle_t rif_handle,
+    const switch_uint64_t rif_flags, switch_api_rif_info_t* api_rif_info);
 
 switch_status_t switch_api_rif_create(switch_device_t device,
-                                      switch_api_rif_info_t *api_rif_info,
-                                      switch_handle_t *rif_handle);
+                                      switch_api_rif_info_t* api_rif_info,
+                                      switch_handle_t* rif_handle);
 switch_status_t switch_api_rif_delete(switch_device_t device,
                                       switch_handle_t rif_handle);
 

--- a/switchapi/switch_rif_int.h
+++ b/switchapi/switch_rif_int.h
@@ -39,18 +39,19 @@ typedef struct switch_rif_info_s {
 
 } switch_rif_info_t;
 
-#define switch_rif_handle_create(_device) \
-  switch_handle_create(                   \
-      _device, SWITCH_HANDLE_TYPE_RIF, sizeof(switch_rif_info_t))
+#define switch_rif_handle_create(_device)               \
+  switch_handle_create(_device, SWITCH_HANDLE_TYPE_RIF, \
+                       sizeof(switch_rif_info_t))
 
 #define switch_rif_handle_delete(_device, _handle) \
   switch_handle_delete(_device, SWITCH_HANDLE_TYPE_RIF, _handle)
 
-#define switch_rif_get(_device, _handle, _info)                                  \
-  ({                                                                             \
-    switch_rif_info_t *_tmp_rif_info = NULL;                                     \
-    (void)(_tmp_rif_info == *_info);                                             \
-    switch_handle_get(_device, SWITCH_HANDLE_TYPE_RIF, _handle, (void **)_info); \
+#define switch_rif_get(_device, _handle, _info)                 \
+  ({                                                            \
+    switch_rif_info_t* _tmp_rif_info = NULL;                    \
+    (void)(_tmp_rif_info == *_info);                            \
+    switch_handle_get(_device, SWITCH_HANDLE_TYPE_RIF, _handle, \
+                      (void**)_info);                           \
   })
 
 #define SWITCH_RIF_TYPE(_rif_info) _rif_info->api_rif_info.rif_type

--- a/switchapi/switch_rif_int.h
+++ b/switchapi/switch_rif_int.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_rmac.h
+++ b/switchapi/switch_rmac.h
@@ -63,9 +63,8 @@ typedef enum switch_rmac_type_s {
  * returned.
  */
 switch_status_t switch_api_router_mac_group_create(
-    const switch_device_t device,
-    const switch_rmac_type_t rmac_type,
-    switch_handle_t *rmac_handle);
+    const switch_device_t device, const switch_rmac_type_t rmac_type,
+    switch_handle_t* rmac_handle);
 
 /**
  * @brief Delete a router mac group
@@ -93,10 +92,8 @@ switch_status_t switch_api_router_mac_group_delete(
  * returned.
  */
 switch_status_t switch_api_router_mac_group_create_with_macs(
-    const switch_device_t device,
-    const switch_size_t num_macs,
-    const switch_mac_addr_t *mac,
-    switch_handle_t *rmac_handle);
+    const switch_device_t device, const switch_size_t num_macs,
+    const switch_mac_addr_t* mac, switch_handle_t* rmac_handle);
 
 /**
  * @brief Add a router mac to rmac group
@@ -115,7 +112,7 @@ switch_status_t switch_api_router_mac_group_create_with_macs(
 */
 switch_status_t switch_api_vrrp_rmac_add(const switch_device_t device,
                                          const switch_handle_t rmac_handle,
-                                         const switch_mac_addr_t *vrrp_mac);
+                                         const switch_mac_addr_t* vrrp_mac);
 
 /**
  * @brief Delete a router mac from rmac group
@@ -130,11 +127,11 @@ switch_status_t switch_api_vrrp_rmac_add(const switch_device_t device,
 switch_status_t switch_api_router_mac_delete(const switch_device_t device,
                                              const switch_handle_t rif_handle,
                                              const switch_handle_t rmac_handle,
-                                             const switch_mac_addr_t *mac);
+                                             const switch_mac_addr_t* mac);
 
 switch_status_t switch_api_vrrp_rmac_delete(const switch_device_t device,
                                             const switch_handle_t rmac_handle,
-                                            const switch_mac_addr_t *vrrp_mac);
+                                            const switch_mac_addr_t* vrrp_mac);
 
 /**
  * @brief Returns all router macs belonging to a router mac group
@@ -149,8 +146,8 @@ switch_status_t switch_api_vrrp_rmac_delete(const switch_device_t device,
  */
 switch_status_t switch_api_rmac_macs_get(const switch_device_t device,
                                          const switch_handle_t rmac_handle,
-                                         switch_uint16_t *num_entries,
-                                         switch_mac_addr_t **macs);
+                                         switch_uint16_t* num_entries,
+                                         switch_mac_addr_t** macs);
 
 /**
  * @brief Dumps router mac info using clish context
@@ -164,7 +161,7 @@ switch_status_t switch_api_rmac_macs_get(const switch_device_t device,
  */
 switch_status_t switch_api_rmac_handle_dump(const switch_device_t device,
                                             const switch_handle_t rmac_handle,
-                                            const void *cli_ctx);
+                                            const void* cli_ctx);
 
 /**
  * @brief Add a tunnel dmac to rmac group
@@ -176,10 +173,9 @@ switch_status_t switch_api_rmac_handle_dump(const switch_device_t device,
  * @return #SWITCH_STATUS_SUCCESS if success otherwise error code is
  * returned.
  */
-switch_status_t switch_api_router_mac_add(
-    const switch_device_t device,
-    const switch_handle_t rmac_handle,
-    const switch_mac_addr_t *mac);
+switch_status_t switch_api_router_mac_add(const switch_device_t device,
+                                          const switch_handle_t rmac_handle,
+                                          const switch_mac_addr_t* mac);
 
 /** @} */  // end of Router MAC API
 

--- a/switchapi/switch_rmac.h
+++ b/switchapi/switch_rmac.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_rmac_int.h
+++ b/switchapi/switch_rmac_int.h
@@ -26,19 +26,19 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#define switch_rmac_handle_create(_device) \
-  switch_handle_create(                    \
-      _device, SWITCH_HANDLE_TYPE_RMAC, sizeof(switch_rmac_info_t))
+#define switch_rmac_handle_create(_device)               \
+  switch_handle_create(_device, SWITCH_HANDLE_TYPE_RMAC, \
+                       sizeof(switch_rmac_info_t))
 
 #define switch_rmac_handle_delete(_device, _handle) \
   switch_handle_delete(_device, SWITCH_HANDLE_TYPE_RMAC, _handle)
 
-#define switch_rmac_get(_device, _handle, _info)                    \
-  ({                                                                \
-    switch_rmac_info_t *_tmp_rmac_info = NULL;                      \
-    (void)(_tmp_rmac_info == *_info);                               \
-    switch_handle_get(                                              \
-        _device, SWITCH_HANDLE_TYPE_RMAC, _handle, (void **)_info); \
+#define switch_rmac_get(_device, _handle, _info)                 \
+  ({                                                             \
+    switch_rmac_info_t* _tmp_rmac_info = NULL;                   \
+    (void)(_tmp_rmac_info == *_info);                            \
+    switch_handle_get(_device, SWITCH_HANDLE_TYPE_RMAC, _handle, \
+                      (void**)_info);                            \
   })
 
 /** rmac entry */
@@ -83,10 +83,10 @@ typedef struct switch_smac_entry_s {
 /** router mac device context */
 typedef struct switch_rmac_context_s {
   /** smac index allocator */
-  switch_id_allocator_t *smac_allocator;
+  switch_id_allocator_t* smac_allocator;
 
   /** tunnel smac index allocator */
-  switch_id_allocator_t *tunnel_smac_allocator;
+  switch_id_allocator_t* tunnel_smac_allocator;
 
 } switch_rmac_context_t;
 

--- a/switchapi/switch_rmac_int.h
+++ b/switchapi/switch_rmac_int.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_status.h
+++ b/switchapi/switch_status.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_status.h
+++ b/switchapi/switch_status.h
@@ -150,8 +150,8 @@ extern "C" {
 #define SWITCH_STATUS_INVALID_HANDLE 0x000000018L
 
 /*
-*  RESOURCE is in use
-*/
+ *  RESOURCE is in use
+ */
 #define SWITCH_STATUS_RESOURCE_IN_USE 0x00000019L
 
 /*

--- a/switchapi/switch_table.h
+++ b/switchapi/switch_table.h
@@ -27,8 +27,7 @@ extern "C" {
 #endif
 
 #define SWITCH_TABLE_ID_VALID(_table_id) \
-        _table_id > SWITCH_TABLE_NONE &&_table_id < SWITCH_TABLE_MAX
-
+  _table_id > SWITCH_TABLE_NONE&& _table_id < SWITCH_TABLE_MAX
 
 typedef enum switch_table_id_ {
 
@@ -194,26 +193,26 @@ typedef struct switch_table_s {
 
 switch_status_t switch_api_table_size_get(switch_device_t device,
                                           switch_table_id_t table_id,
-                                          switch_size_t *table_size);
+                                          switch_size_t* table_size);
 
 switch_status_t switch_api_table_all_get(switch_device_t device,
-                                         switch_size_t *num_entries,
-                                         switch_table_t *api_table_info);
+                                         switch_size_t* num_entries,
+                                         switch_table_t* api_table_info);
 
 switch_status_t switch_api_table_entry_count_get(switch_device_t device,
                                                  switch_table_id_t table_id,
-                                                 switch_uint32_t *num_entries);
+                                                 switch_uint32_t* num_entries);
 
 switch_status_t switch_table_init(switch_device_t device,
-                                  switch_size_t *table_sizes);
+                                  switch_size_t* table_sizes);
 
 switch_status_t switch_table_free(switch_device_t device);
 
 switch_status_t switch_api_table_size_get_internal(switch_device_t device,
                                                    switch_table_id_t table_id,
-                                                   switch_size_t *table_size);
+                                                   switch_size_t* table_size);
 
-switch_status_t switch_table_default_sizes_get(switch_size_t *table_sizes);
+switch_status_t switch_table_default_sizes_get(switch_size_t* table_sizes);
 
 #ifdef __cplusplus
 }

--- a/switchapi/switch_tunnel.h
+++ b/switchapi/switch_tunnel.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_tunnel.h
+++ b/switchapi/switch_tunnel.h
@@ -39,41 +39,39 @@ extern "C" {
 #define SWITCH_SRV6_SID_LENGTH 16
 
 /** tunnel handle wrappers */
-#define switch_tunnel_handle_create(_device) \
-  switch_handle_create(                      \
-      _device, SWITCH_HANDLE_TYPE_TUNNEL, sizeof(switch_tunnel_info_t))
+#define switch_tunnel_handle_create(_device)               \
+  switch_handle_create(_device, SWITCH_HANDLE_TYPE_TUNNEL, \
+                       sizeof(switch_tunnel_info_t))
 
 #define switch_tunnel_handle_delete(_device, _handle) \
   switch_handle_delete(_device, SWITCH_HANDLE_TYPE_TUNNEL, _handle)
 
-#define switch_tunnel_get(_device, _handle, _info)                    \
-  ({                                                                  \
-    switch_tunnel_info_t *_tmp_tunnel_info = NULL;                    \
-    (void)(_tmp_tunnel_info == *_info);                               \
-    switch_handle_get(                                                \
-        _device, SWITCH_HANDLE_TYPE_TUNNEL, _handle, (void **)_info); \
+#define switch_tunnel_get(_device, _handle, _info)                 \
+  ({                                                               \
+    switch_tunnel_info_t* _tmp_tunnel_info = NULL;                 \
+    (void)(_tmp_tunnel_info == *_info);                            \
+    switch_handle_get(_device, SWITCH_HANDLE_TYPE_TUNNEL, _handle, \
+                      (void**)_info);                              \
   })
 
 /** tunnel term handle wrappers */
-#define switch_tunnel_term_handle_create(_device)      \
-  switch_handle_create(_device,                        \
-                       SWITCH_HANDLE_TYPE_TUNNEL_TERM, \
+#define switch_tunnel_term_handle_create(_device)               \
+  switch_handle_create(_device, SWITCH_HANDLE_TYPE_TUNNEL_TERM, \
                        sizeof(switch_tunnel_term_info_t))
 
 #define switch_tunnel_term_handle_delete(_device, _handle) \
   switch_handle_delete(_device, SWITCH_HANDLE_TYPE_TUNNEL_TERM, _handle)
 
-#define switch_tunnel_term_get(_device, _handle, _info)                    \
-  ({                                                                       \
-    switch_tunnel_term_info_t *_tmp_tunnel_term_info = NULL;               \
-    (void)(_tmp_tunnel_term_info == *_info);                               \
-    switch_handle_get(                                                     \
-        _device, SWITCH_HANDLE_TYPE_TUNNEL_TERM, _handle, (void **)_info); \
+#define switch_tunnel_term_get(_device, _handle, _info)                 \
+  ({                                                                    \
+    switch_tunnel_term_info_t* _tmp_tunnel_term_info = NULL;            \
+    (void)(_tmp_tunnel_term_info == *_info);                            \
+    switch_handle_get(_device, SWITCH_HANDLE_TYPE_TUNNEL_TERM, _handle, \
+                      (void**)_info);                                   \
   })
 
 /** vxlan default port */
 #define SWITCH_VXLAN_DEFAULT_PORT 4789
-
 
 #define SWITCH_TUNNEL_VNI_SIZE 24
 
@@ -114,16 +112,16 @@ typedef struct switch_tunnel_context_s {
   switch_hashtable_t dst_vtep_hashtable;
 
   /** source ip rewrite index allocator */
-  switch_id_allocator_t *src_ip_id_allocator;
+  switch_id_allocator_t* src_ip_id_allocator;
 
   /** destination ip rewrite index allocator */
-  switch_id_allocator_t *dst_ip_id_allocator;
+  switch_id_allocator_t* dst_ip_id_allocator;
 
   /** tunnel vni allocator */
-  switch_id_allocator_t *tunnel_vni_allocator;
+  switch_id_allocator_t* tunnel_vni_allocator;
 
   /** mpls transit array indexed by label */
-  switch_array_t *mpls_transit_array;
+  switch_array_t* mpls_transit_array;
 
   /** data structure to store tunnel destination IPs */
   Pvoid_t PJLarr_tunnel_dest;
@@ -371,22 +369,20 @@ typedef struct switch_api_tunnel_mapper_entry_s {
 
 switch_status_t switch_api_tunnel_mapper_create(
     const switch_device_t device,
-    const switch_api_tunnel_mapper_t *tunnel_mapper,
-    switch_handle_t *tunnel_mapper_handle);
+    const switch_api_tunnel_mapper_t* tunnel_mapper,
+    switch_handle_t* tunnel_mapper_handle);
 
 switch_status_t switch_api_tunnel_mapper_delete(
     const switch_device_t device, const switch_handle_t tunnel_mapper_handle);
 
 switch_status_t switch_api_tunnel_mapper_entries_get(
-    const switch_device_t device,
-    const switch_handle_t tunnel_mapper_handle,
-    switch_uint16_t *num_entries,
-    switch_handle_t *tunnel_mapper_entry_handles);
+    const switch_device_t device, const switch_handle_t tunnel_mapper_handle,
+    switch_uint16_t* num_entries, switch_handle_t* tunnel_mapper_entry_handles);
 
 switch_status_t switch_api_tunnel_mapper_entry_create(
     const switch_device_t device,
-    const switch_api_tunnel_mapper_entry_t *tunnel_mapper_entry,
-    switch_handle_t *tunnel_mapper_entry_handle);
+    const switch_api_tunnel_mapper_entry_t* tunnel_mapper_entry,
+    switch_handle_t* tunnel_mapper_entry_handle);
 
 switch_status_t switch_api_tunnel_mapper_entry_delete(
     const switch_device_t device,
@@ -395,44 +391,37 @@ switch_status_t switch_api_tunnel_mapper_entry_delete(
 switch_status_t switch_api_tunnel_mapper_entry_get(
     const switch_device_t device,
     const switch_handle_t tunnel_mapper_entry_handle,
-    switch_api_tunnel_mapper_entry_t *tunnel_mapper_entry);
+    switch_api_tunnel_mapper_entry_t* tunnel_mapper_entry);
 
 switch_status_t switch_api_tunnel_create(
-    const switch_device_t device,
-    const switch_api_tunnel_info_t *tunnel_info,
-    switch_handle_t *tunnel_handle);
+    const switch_device_t device, const switch_api_tunnel_info_t* tunnel_info,
+    switch_handle_t* tunnel_handle);
 
-switch_status_t switch_api_tunnel_delete(
-    const switch_handle_t tunnel_handle);
+switch_status_t switch_api_tunnel_delete(const switch_handle_t tunnel_handle);
 
 switch_status_t switch_api_tunnel_info_get(
-    const switch_device_t device,
-    const switch_handle_t tunnel_handle,
-    switch_api_tunnel_info_t *api_tunnel_info);
+    const switch_device_t device, const switch_handle_t tunnel_handle,
+    switch_api_tunnel_info_t* api_tunnel_info);
 
 switch_status_t switch_api_tunnel_interface_get(
-    const switch_device_t device,
-    const switch_handle_t tunnel_handle,
-    switch_handle_t *intf_handle);
+    const switch_device_t device, const switch_handle_t tunnel_handle,
+    switch_handle_t* intf_handle);
 
 switch_status_t switch_api_tunnel_term_entries_get(
-    const switch_device_t device,
-    const switch_handle_t tunnel_handle,
-    switch_uint16_t *num_entries,
-    switch_handle_t *tunnel_term_handles);
+    const switch_device_t device, const switch_handle_t tunnel_handle,
+    switch_uint16_t* num_entries, switch_handle_t* tunnel_term_handles);
 
 switch_status_t switch_api_tunnel_term_create(
     const switch_device_t device,
-    const switch_api_tunnel_term_info_t *tunnel_term_info,
-    switch_handle_t *tunnel_handle);
+    const switch_api_tunnel_term_info_t* tunnel_term_info,
+    switch_handle_t* tunnel_handle);
 
 switch_status_t switch_api_tunnel_term_delete(
     const switch_handle_t tunnel_term_handle);
 
 switch_status_t switch_api_tunnel_term_get(
-    const switch_device_t device,
-    const switch_handle_t tunnel_term_handle,
-    switch_api_tunnel_term_info_t *api_term_info);
+    const switch_device_t device, const switch_handle_t tunnel_term_handle,
+    switch_api_tunnel_term_info_t* api_term_info);
 
 switch_status_t switch_tunnel_init(switch_device_t device);
 

--- a/switchapi/switch_types_int.h
+++ b/switchapi/switch_types_int.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022-2023 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/switch_types_int.h
+++ b/switchapi/switch_types_int.h
@@ -20,8 +20,9 @@
 
 #include <arpa/inet.h>
 #include <netinet/in.h>
-#include "switchapi/switch_handle.h"
+
 #include "switchapi/switch_base_types.h"
+#include "switchapi/switch_handle.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -48,18 +49,17 @@ typedef tommy_hashtable_node switch_hashnode_t;
 #define switch_select select
 #define switch_snprintf snprintf
 
-typedef switch_status_t (*switch_key_func_t)(void *args,
-                                             switch_uint8_t *key,
-                                             switch_uint32_t *len);
+typedef switch_status_t (*switch_key_func_t)(void* args, switch_uint8_t* key,
+                                             switch_uint32_t* len);
 
-typedef switch_int32_t (*switch_hash_compare_func_t)(const void *key1,
-                                                     const void *key2);
+typedef switch_int32_t (*switch_hash_compare_func_t)(const void* key1,
+                                                     const void* key2);
 
-typedef switch_int32_t (*switch_list_compare_func_t)(const void *key1,
-                                                     const void *key2);
+typedef switch_int32_t (*switch_list_compare_func_t)(const void* key1,
+                                                     const void* key2);
 
 typedef struct switch_array_ {
-  void *array;
+  void* array;
   switch_size_t num_entries;
 } switch_array_t;
 
@@ -77,23 +77,17 @@ typedef struct switch_list_ {
   switch_size_t num_entries;
 } switch_list_t;
 
-static inline const char *switch_macaddress_to_string(
-    const switch_mac_addr_t *mac) {
+static inline const char* switch_macaddress_to_string(
+    const switch_mac_addr_t* mac) {
   static char mac_str[18];
-  snprintf(mac_str,
-           sizeof(mac_str),
-           "%02x:%02x:%02x:%02x:%02x:%02x",
-           mac->mac_addr[0],
-           mac->mac_addr[1],
-           mac->mac_addr[2],
-           mac->mac_addr[3],
-           mac->mac_addr[4],
-           mac->mac_addr[5]);
+  snprintf(mac_str, sizeof(mac_str), "%02x:%02x:%02x:%02x:%02x:%02x",
+           mac->mac_addr[0], mac->mac_addr[1], mac->mac_addr[2],
+           mac->mac_addr[3], mac->mac_addr[4], mac->mac_addr[5]);
   return mac_str;
 }
 
-static inline const char *switch_ipaddress_to_string(
-    const switch_ip_addr_t *ip_addr) {
+static inline const char* switch_ipaddress_to_string(
+    const switch_ip_addr_t* ip_addr) {
   static char ipv4_str[INET_ADDRSTRLEN + 10];
   static char ipv6_str[INET6_ADDRSTRLEN + 10];
   int len = 0;

--- a/switchapi/switch_vrf.h
+++ b/switchapi/switch_vrf.h
@@ -28,22 +28,22 @@ extern "C" {
 
 #define MAX_VRF 1024
 
-#define switch_vrf_handle_create(_device) \
-  switch_handle_create(                   \
-      _device, SWITCH_HANDLE_TYPE_VRF, sizeof(switch_vrf_info_t))
+#define switch_vrf_handle_create(_device)               \
+  switch_handle_create(_device, SWITCH_HANDLE_TYPE_VRF, \
+                       sizeof(switch_vrf_info_t))
 
 #define switch_vrf_handle_delete(_device, _handle) \
   switch_handle_delete(_device, SWITCH_HANDLE_TYPE_VRF, _handle)
 
-#define switch_vrf_get(_device, _handle, _info, _status)                   \
-  do {                                                                     \
-    switch_vrf_context_t *_vrf_ctx = NULL;                                 \
-    _status = switch_device_api_context_get(                               \
-        _device, SWITCH_API_TYPE_VRF, (void **)&_vrf_ctx);                 \
-    if (_status == SWITCH_STATUS_SUCCESS) {                                \
-      switch_handle_get(                                                   \
-          _device, SWITCH_HANDLE_TYPE_VRF, _handle, (void **)_info);       \
-    }                                                                      \
+#define switch_vrf_get(_device, _handle, _info, _status)                  \
+  do {                                                                    \
+    switch_vrf_context_t* _vrf_ctx = NULL;                                \
+    _status = switch_device_api_context_get(_device, SWITCH_API_TYPE_VRF, \
+                                            (void**)&_vrf_ctx);           \
+    if (_status == SWITCH_STATUS_SUCCESS) {                               \
+      switch_handle_get(_device, SWITCH_HANDLE_TYPE_VRF, _handle,         \
+                        (void**)_info);                                   \
+    }                                                                     \
   } while (0);
 
 typedef struct switch_vrf_context_s {
@@ -54,7 +54,6 @@ typedef struct switch_vrf_context_s {
   switch_array_t vrf_array;
 
 } switch_vrf_context_t;
-
 
 /** stores vrf info and its associated hardware handles */
 typedef struct switch_vrf_info_s {
@@ -78,15 +77,13 @@ switch_status_t switch_vrf_free(switch_device_t device);
 
 switch_status_t switch_api_vrf_create(const switch_device_t device,
                                       const switch_vrf_t vrf_id,
-                                      switch_handle_t *vrf_handle);
+                                      switch_handle_t* vrf_handle);
 
 switch_status_t switch_api_vrf_delete(const switch_device_t device,
                                       const switch_handle_t vrf_handle);
-
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* __SWITCH_VRF_H__ */
-

--- a/switchapi/switch_vrf.h
+++ b/switchapi/switch_vrf.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchlink/sai/switchlink_handle_ecmp.c
+++ b/switchlink/sai/switchlink_handle_ecmp.c
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-#include "switchlink_init_sai.h"
 #include "switchlink/switchlink_handle.h"
+#include "switchlink_init_sai.h"
 
-static sai_next_hop_group_api_t *sai_nhop_group_api = NULL;
+static sai_next_hop_group_api_t* sai_nhop_group_api = NULL;
 
 /*
  * Routine Description:
@@ -30,14 +30,13 @@ static sai_next_hop_group_api_t *sai_nhop_group_api = NULL;
  */
 
 sai_status_t sai_init_nhop_group_api() {
-   sai_status_t status = SAI_STATUS_SUCCESS;
+  sai_status_t status = SAI_STATUS_SUCCESS;
 
-   status = sai_api_query(SAI_API_NEXT_HOP_GROUP, (void **)&sai_nhop_group_api);
-   krnlmon_assert(status == SAI_STATUS_SUCCESS);
+  status = sai_api_query(SAI_API_NEXT_HOP_GROUP, (void**)&sai_nhop_group_api);
+  krnlmon_assert(status == SAI_STATUS_SUCCESS);
 
   return status;
 }
-
 
 /*
  * Routine Description:
@@ -51,7 +50,7 @@ sai_status_t sai_init_nhop_group_api() {
  *   -1 in case of error
  */
 
-static int delete_ecmp(switchlink_db_ecmp_info_t *ecmp_info) {
+static int delete_ecmp(switchlink_db_ecmp_info_t* ecmp_info) {
   sai_status_t retval = SAI_STATUS_SUCCESS;
   sai_status_t status;
 
@@ -59,7 +58,7 @@ static int delete_ecmp(switchlink_db_ecmp_info_t *ecmp_info) {
   uint8_t index = 0;
   for (index = 0; index < ecmp_info->num_nhops; index++) {
     status = sai_nhop_group_api->remove_next_hop_group_member(
-      ecmp_info->nhop_member_handles[index]);
+        ecmp_info->nhop_member_handles[index]);
     if (!retval) retval = status;
   }
 #endif
@@ -110,20 +109,22 @@ void switchlink_delete_ecmp(switchlink_handle_t ecmp_h) {
 
     for (index = 0; index < num_nhops; index++) {
       memset(&nexthop_info, 0, sizeof(switchlink_db_nexthop_info_t));
-      status = switchlink_db_get_nexthop_handle_info(nhops[index],
-                                                     &nexthop_info);
+      status =
+          switchlink_db_get_nexthop_handle_info(nhops[index], &nexthop_info);
       if (status != SWITCHLINK_DB_STATUS_SUCCESS) {
-        krnlmon_log_error("Cannot get nhop info for nhop handle 0x%lx", nhops[index]);
+        krnlmon_log_error("Cannot get nhop info for nhop handle 0x%lx",
+                          nhops[index]);
         continue;
       }
 
       if (validate_delete_nexthop(nexthop_info.using_by,
                                   SWITCHLINK_NHOP_FROM_ROUTE)) {
-        krnlmon_log_debug("Deleting nhop 0x%lx, from delete_ecmp", nexthop_info.nhop_h);
+        krnlmon_log_debug("Deleting nhop 0x%lx, from delete_ecmp",
+                          nexthop_info.nhop_h);
         switchlink_delete_nexthop(nexthop_info.nhop_h);
         switchlink_db_delete_nexthop(&nexthop_info);
       } else {
-          krnlmon_log_debug("Removing Route learn from nhop");
+        krnlmon_log_debug("Removing Route learn from nhop");
         nexthop_info.using_by &= ~SWITCHLINK_NHOP_FROM_ROUTE;
         switchlink_db_update_nexthop_using_by(&nexthop_info);
       }
@@ -143,7 +144,7 @@ void switchlink_delete_ecmp(switchlink_handle_t ecmp_h) {
  *   -1 in case of error
  */
 
-int switchlink_create_ecmp(switchlink_db_ecmp_info_t *ecmp_info) {
+int switchlink_create_ecmp(switchlink_db_ecmp_info_t* ecmp_info) {
   sai_status_t status = SAI_STATUS_SUCCESS;
   uint8_t index = 0;
   sai_attribute_t attr_list[1];
@@ -153,8 +154,8 @@ int switchlink_create_ecmp(switchlink_db_ecmp_info_t *ecmp_info) {
   attr_list[0].id = SAI_NEXT_HOP_GROUP_ATTR_TYPE;
   attr_list[0].value.s32 = SAI_NEXT_HOP_GROUP_TYPE_ECMP;
 
-  status = sai_nhop_group_api->create_next_hop_group(
-      &(ecmp_info->ecmp_h), 0, 0x1, attr_list);
+  status = sai_nhop_group_api->create_next_hop_group(&(ecmp_info->ecmp_h), 0,
+                                                     0x1, attr_list);
   if (status != SAI_STATUS_SUCCESS) {
     krnlmon_log_error("Unable to create nexthop group for ECMP");
     return -1;
@@ -169,10 +170,10 @@ int switchlink_create_ecmp(switchlink_db_ecmp_info_t *ecmp_info) {
     status = sai_nhop_group_api->create_next_hop_group_member(
         &ecmp_info->nhop_member_handles[index], 0, 0x2, attr_member_list);
     if (status != SAI_STATUS_SUCCESS) {
-        krnlmon_log_error("Unable to add members to nexthop group for ECMP");
-        return -1;
+      krnlmon_log_error("Unable to add members to nexthop group for ECMP");
+      return -1;
     }
   }
 
-  return status; 
+  return status;
 }

--- a/switchlink/sai/switchlink_handle_lag.c
+++ b/switchlink/sai/switchlink_handle_lag.c
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
+#include <linux/if.h>
+
 #include "bf_pal/bf_pal_port_intf.h"
 #include "bf_rt/bf_rt_common.h"
 #include "bf_types.h"
 #include "port_mgr/dpdk/bf_dpdk_port_if.h"
 #include "switchlink_init_sai.h"
-#include <linux/if.h>
 
 #define SWITCH_PD_MAC_STR_LENGTH 18
 #define SWITCH_PD_TARGET_VPORT_OFFSET 16
@@ -329,7 +330,8 @@ void switchlink_create_lag_member(
 
   status = switchlink_db_get_lag_member_info(&lag_member_info);
   if (status == SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND) {
-    status = switchlink_db_get_mac_lag_handle(lag_member_intf->mac_addr, &lag_h);
+    status =
+        switchlink_db_get_mac_lag_handle(lag_member_intf->mac_addr, &lag_h);
     if (status == SWITCHLINK_DB_STATUS_SUCCESS) {
       lag_member_intf->lag_h = lag_h;
       krnlmon_log_debug("Parent LAG handle is: 0x%lx", lag_h);

--- a/switchlink/sai/switchlink_handle_lag.c
+++ b/switchlink/sai/switchlink_handle_lag.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Intel Corporation.
+ * Copyright 2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchlink/sai/switchlink_handle_link.c
+++ b/switchlink/sai/switchlink_handle_link.c
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-#include "switchlink_init_sai.h"
 #include "switchlink/switchlink_handle.h"
+#include "switchlink_init_sai.h"
 
-static sai_virtual_router_api_t *sai_vrf_api = NULL;
-static sai_router_interface_api_t *sai_rintf_api = NULL;
+static sai_virtual_router_api_t* sai_vrf_api = NULL;
+static sai_router_interface_api_t* sai_rintf_api = NULL;
 /*
  * Routine Description:
  *    Initialize Router Interface SAI API
@@ -30,10 +30,10 @@ static sai_router_interface_api_t *sai_rintf_api = NULL;
  */
 
 sai_status_t sai_init_rintf_api() {
-   sai_status_t status = SAI_STATUS_SUCCESS;
+  sai_status_t status = SAI_STATUS_SUCCESS;
 
-   status = sai_api_query(SAI_API_ROUTER_INTERFACE, (void **)&sai_rintf_api);
-   krnlmon_assert(status == SAI_STATUS_SUCCESS);
+  status = sai_api_query(SAI_API_ROUTER_INTERFACE, (void**)&sai_rintf_api);
+  krnlmon_assert(status == SAI_STATUS_SUCCESS);
 
   return status;
 }
@@ -48,10 +48,10 @@ sai_status_t sai_init_rintf_api() {
  */
 
 sai_status_t sai_init_vrf_api() {
-   sai_status_t status = SAI_STATUS_SUCCESS;
+  sai_status_t status = SAI_STATUS_SUCCESS;
 
-   status = sai_api_query(SAI_API_VIRTUAL_ROUTER, (void **)&sai_vrf_api);
-   krnlmon_assert(status == SAI_STATUS_SUCCESS);
+  status = sai_api_query(SAI_API_VIRTUAL_ROUTER, (void**)&sai_vrf_api);
+  krnlmon_assert(status == SAI_STATUS_SUCCESS);
 
   return status;
 }
@@ -68,7 +68,7 @@ sai_status_t sai_init_vrf_api() {
  *    Failure status code on error
  */
 
-int switchlink_create_vrf(switchlink_handle_t *vrf_h) {
+int switchlink_create_vrf(switchlink_handle_t* vrf_h) {
   sai_status_t status = SAI_STATUS_SUCCESS;
   sai_attribute_t attr_list[2];
 
@@ -95,9 +95,8 @@ int switchlink_create_vrf(switchlink_handle_t *vrf_h) {
  *   -1 in case of error
  */
 
-static int create_interface(
-                        const switchlink_db_interface_info_t *intf,
-                        switchlink_handle_t *intf_h) {
+static int create_interface(const switchlink_db_interface_info_t* intf,
+                            switchlink_handle_t* intf_h) {
   sai_status_t status = SAI_STATUS_SUCCESS;
 
   if (intf->intf_type == SWITCHLINK_INTF_TYPE_L3) {
@@ -110,10 +109,10 @@ static int create_interface(
     attr_list[ac].id = SAI_ROUTER_INTERFACE_ATTR_TYPE;
     attr_list[ac].value.oid = 0;
     if (!(intf_h)) {
-	krnlmon_log_error("Interface handle is NULL");
-	return -1;
-    } else {	
-        attr_list[ac].value.oid = *intf_h;
+      krnlmon_log_error("Interface handle is NULL");
+      return -1;
+    } else {
+      attr_list[ac].value.oid = *intf_h;
     }
     ac++;
     attr_list[ac].id = SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS;
@@ -123,8 +122,7 @@ static int create_interface(
     attr_list[ac].value.u32 = intf->ifindex;
     ac++;
 
-    status =
-        sai_rintf_api->create_router_interface(intf_h, 0, ac++, attr_list);
+    status = sai_rintf_api->create_router_interface(intf_h, 0, ac++, attr_list);
   }
   return ((status == SAI_STATUS_SUCCESS) ? 0 : -1);
 }
@@ -142,8 +140,8 @@ static int create_interface(
  *   -1 in case of error
  */
 
-static int delete_interface(const switchlink_db_interface_info_t *intf,
-                                switchlink_handle_t intf_h) {
+static int delete_interface(const switchlink_db_interface_info_t* intf,
+                            switchlink_handle_t intf_h) {
   sai_status_t status = SAI_STATUS_SUCCESS;
   if (intf->intf_type == SWITCHLINK_INTF_TYPE_L3) {
     status = sai_rintf_api->remove_router_interface(intf_h);
@@ -162,7 +160,7 @@ static int delete_interface(const switchlink_db_interface_info_t *intf,
  *    void
  */
 
-void switchlink_create_interface(switchlink_db_interface_info_t *intf) {
+void switchlink_create_interface(switchlink_db_interface_info_t* intf) {
   switchlink_db_status_t status;
   switchlink_db_interface_info_t ifinfo;
 
@@ -173,8 +171,9 @@ void switchlink_create_interface(switchlink_db_interface_info_t *intf) {
 
     status = create_interface(intf, &(intf->intf_h));
     if (status) {
-      krnlmon_log_error("newlink: Failed to create switchlink interface, error: %d\n",
-               status);
+      krnlmon_log_error(
+          "newlink: Failed to create switchlink interface, error: %d\n",
+          status);
       return;
     }
 
@@ -182,18 +181,18 @@ void switchlink_create_interface(switchlink_db_interface_info_t *intf) {
     switchlink_db_add_interface(intf->ifindex, intf);
   } else {
     // interface has already been created
-    if (memcmp(&(ifinfo.mac_addr),
-               &(intf->mac_addr),
+    if (memcmp(&(ifinfo.mac_addr), &(intf->mac_addr),
                sizeof(switchlink_mac_addr_t))) {
-       memcpy(&(ifinfo.mac_addr), &(intf->mac_addr),
-              sizeof(switchlink_mac_addr_t));
+      memcpy(&(ifinfo.mac_addr), &(intf->mac_addr),
+             sizeof(switchlink_mac_addr_t));
 
       // Delete if RMAC is configured previously, and create this new RMAC.
       status = create_interface(&ifinfo, &ifinfo.intf_h);
       if (status) {
-        krnlmon_log_error("newlink: Failed to create switchlink interface,"
-                    " error: %d\n",
-                    status);
+        krnlmon_log_error(
+            "newlink: Failed to create switchlink interface,"
+            " error: %d\n",
+            status);
         return;
       }
 
@@ -225,4 +224,3 @@ void switchlink_delete_interface(uint32_t ifindex) {
   delete_interface(&intf, intf.intf_h);
   switchlink_db_delete_interface(intf.ifindex);
 }
-

--- a/switchlink/sai/switchlink_handle_link.c
+++ b/switchlink/sai/switchlink_handle_link.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchlink/sai/switchlink_handle_neigh.c
+++ b/switchlink/sai/switchlink_handle_neigh.c
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-#include "switchlink_init_sai.h"
 #include "switchlink/switchlink_handle.h"
+#include "switchlink_init_sai.h"
 
-static sai_neighbor_api_t *sai_neigh_api = NULL;
-static sai_fdb_api_t *sai_fdb_api = NULL;
+static sai_neighbor_api_t* sai_neigh_api = NULL;
+static sai_fdb_api_t* sai_fdb_api = NULL;
 /*
  * Routine Description:
  *    Initialize Neighbor SAI API
@@ -30,10 +30,10 @@ static sai_fdb_api_t *sai_fdb_api = NULL;
  */
 
 sai_status_t sai_init_neigh_api() {
-   sai_status_t status = SAI_STATUS_SUCCESS;
+  sai_status_t status = SAI_STATUS_SUCCESS;
 
-   status = sai_api_query(SAI_API_NEIGHBOR, (void **)&sai_neigh_api);
-   krnlmon_assert(status == SAI_STATUS_SUCCESS);
+  status = sai_api_query(SAI_API_NEIGHBOR, (void**)&sai_neigh_api);
+  krnlmon_assert(status == SAI_STATUS_SUCCESS);
 
   return status;
 }
@@ -48,10 +48,10 @@ sai_status_t sai_init_neigh_api() {
  */
 
 sai_status_t sai_init_fdb_api() {
-   sai_status_t status = SAI_STATUS_SUCCESS;
+  sai_status_t status = SAI_STATUS_SUCCESS;
 
-   status = sai_api_query(SAI_API_FDB, (void **)&sai_fdb_api);
-   krnlmon_assert(status == SAI_STATUS_SUCCESS);
+  status = sai_api_query(SAI_API_FDB, (void**)&sai_fdb_api);
+  krnlmon_assert(status == SAI_STATUS_SUCCESS);
 
   return status;
 }
@@ -70,9 +70,8 @@ sai_status_t sai_init_fdb_api() {
  *    false: if this NHOP is referred by other features.
  */
 
-bool
-validate_delete_nexthop(uint32_t using_by,
-                        switchlink_nhop_using_by_e type) {
+bool validate_delete_nexthop(uint32_t using_by,
+                             switchlink_nhop_using_by_e type) {
   return (using_by & ~(type)) ? false : true;
 }
 
@@ -150,7 +149,7 @@ static int delete_mac(switchlink_mac_addr_t mac_addr,
  *   -1 in case of error
  */
 
-static int create_neighbor(const switchlink_db_neigh_info_t *neigh_info) {
+static int create_neighbor(const switchlink_db_neigh_info_t* neigh_info) {
   sai_status_t status = SAI_STATUS_SUCCESS;
 
   sai_attribute_t attr_list[1];
@@ -166,18 +165,17 @@ static int create_neighbor(const switchlink_db_neigh_info_t *neigh_info) {
     neighbor_entry.ip_address.addr.ip4 =
         htonl(neigh_info->ip_addr.ip.v4addr.s_addr);
     krnlmon_log_info("Create a neighbor entry: 0x%x",
-		      neigh_info->ip_addr.ip.v4addr.s_addr);
+                     neigh_info->ip_addr.ip.v4addr.s_addr);
   } else {
     krnlmon_assert(neigh_info->ip_addr.family == AF_INET6);
     neighbor_entry.ip_address.addr_family = SAI_IP_ADDR_FAMILY_IPV6;
-    memcpy(neighbor_entry.ip_address.addr.ip6,
-           &(neigh_info->ip_addr.ip.v6addr),
+    memcpy(neighbor_entry.ip_address.addr.ip6, &(neigh_info->ip_addr.ip.v6addr),
            sizeof(sai_ip6_t));
     krnlmon_log_info("Create a neighbor entry: 0x%x:0x%x:0x%x:0x%x",
-		      neigh_info->ip_addr.ip.v6addr.__in6_u.__u6_addr32[0],
-		      neigh_info->ip_addr.ip.v6addr.__in6_u.__u6_addr32[1],
-		      neigh_info->ip_addr.ip.v6addr.__in6_u.__u6_addr32[2],
-		      neigh_info->ip_addr.ip.v6addr.__in6_u.__u6_addr32[3]);
+                     neigh_info->ip_addr.ip.v6addr.__in6_u.__u6_addr32[0],
+                     neigh_info->ip_addr.ip.v6addr.__in6_u.__u6_addr32[1],
+                     neigh_info->ip_addr.ip.v6addr.__in6_u.__u6_addr32[2],
+                     neigh_info->ip_addr.ip.v6addr.__in6_u.__u6_addr32[3]);
   }
 
   status = sai_neigh_api->create_neighbor_entry(&neighbor_entry, 1, attr_list);
@@ -196,7 +194,7 @@ static int create_neighbor(const switchlink_db_neigh_info_t *neigh_info) {
  *   -1 in case of error
  */
 
-static int delete_neighbor(const switchlink_db_neigh_info_t *neigh_info) {
+static int delete_neighbor(const switchlink_db_neigh_info_t* neigh_info) {
   sai_status_t status = SAI_STATUS_SUCCESS;
 
   sai_neighbor_entry_t neighbor_entry;
@@ -230,9 +228,9 @@ void switchlink_delete_mac(switchlink_mac_addr_t mac_addr,
   if (status != SWITCHLINK_DB_STATUS_SUCCESS) {
     return;
   }
-  krnlmon_log_info("Delete a FDB entry: %x:%x:%x:%x:%x:%x", mac_addr[0], mac_addr[1],
-                                                     mac_addr[2], mac_addr[3],
-                                                     mac_addr[4], mac_addr[5]);
+  krnlmon_log_info("Delete a FDB entry: %x:%x:%x:%x:%x:%x", mac_addr[0],
+                   mac_addr[1], mac_addr[2], mac_addr[3], mac_addr[4],
+                   mac_addr[5]);
   delete_mac(mac_addr, bridge_h);
   switchlink_db_delete_mac(mac_addr, bridge_h);
 }
@@ -264,9 +262,9 @@ void switchlink_create_mac(switchlink_mac_addr_t mac_addr,
       return;
     }
   }
-  krnlmon_log_info("Create a FDB entry: %x:%x:%x:%x:%x:%x", mac_addr[0], mac_addr[1],
-                                                     mac_addr[2], mac_addr[3],
-                                                     mac_addr[4], mac_addr[5]);
+  krnlmon_log_info("Create a FDB entry: %x:%x:%x:%x:%x:%x", mac_addr[0],
+                   mac_addr[1], mac_addr[2], mac_addr[3], mac_addr[4],
+                   mac_addr[5]);
 
   create_mac(mac_addr, bridge_h, intf_h);
   switchlink_db_add_mac(mac_addr, bridge_h, intf_h);
@@ -287,7 +285,7 @@ void switchlink_create_mac(switchlink_mac_addr_t mac_addr,
  */
 
 void switchlink_create_neigh(switchlink_handle_t vrf_h,
-                             const switchlink_ip_addr_t *ipaddr,
+                             const switchlink_ip_addr_t* ipaddr,
                              switchlink_mac_addr_t mac_addr,
                              switchlink_handle_t intf_h) {
   bool nhop_available = false;
@@ -326,17 +324,16 @@ void switchlink_create_neigh(switchlink_handle_t vrf_h,
 
   status = switchlink_db_get_nexthop_info(&nexthop_info);
   if (status == SWITCHLINK_DB_STATUS_SUCCESS) {
-      nhop_available = true;
+    nhop_available = true;
   }
 
-  if (!nhop_available &&
-      switchlink_create_nexthop(&nexthop_info) == -1) {
+  if (!nhop_available && switchlink_create_nexthop(&nexthop_info) == -1) {
     return;
   }
 
   if (create_neighbor(&neigh_info) == -1) {
     if (!nhop_available) {
-        switchlink_delete_nexthop(nexthop_info.nhop_h);
+      switchlink_delete_nexthop(nexthop_info.nhop_h);
     }
     return;
   }
@@ -370,7 +367,7 @@ void switchlink_create_neigh(switchlink_handle_t vrf_h,
  */
 
 void switchlink_delete_neigh(switchlink_handle_t vrf_h,
-                             const switchlink_ip_addr_t *ipaddr,
+                             const switchlink_ip_addr_t* ipaddr,
                              switchlink_handle_t intf_h) {
   switchlink_db_nexthop_info_t nexthop_info;
   switchlink_db_neigh_info_t neigh_info;
@@ -397,16 +394,17 @@ void switchlink_delete_neigh(switchlink_handle_t vrf_h,
 
   status = switchlink_db_get_nexthop_info(&nexthop_info);
   if (status == SWITCHLINK_DB_STATUS_SUCCESS) {
-      if (validate_delete_nexthop(nexthop_info.using_by,
-                                  SWITCHLINK_NHOP_FROM_NEIGHBOR)) {
-          krnlmon_log_debug("Deleting nhop with neighbor delete 0x%lx", nexthop_info.nhop_h);
-          switchlink_delete_nexthop(nexthop_info.nhop_h);
-          switchlink_db_delete_nexthop(&nexthop_info);
-      } else {
-          krnlmon_log_debug("Removing Neighbor learn from nhop");
-          nexthop_info.using_by &= ~SWITCHLINK_NHOP_FROM_NEIGHBOR;
-          switchlink_db_update_nexthop_using_by(&nexthop_info);
-      }
+    if (validate_delete_nexthop(nexthop_info.using_by,
+                                SWITCHLINK_NHOP_FROM_NEIGHBOR)) {
+      krnlmon_log_debug("Deleting nhop with neighbor delete 0x%lx",
+                        nexthop_info.nhop_h);
+      switchlink_delete_nexthop(nexthop_info.nhop_h);
+      switchlink_db_delete_nexthop(&nexthop_info);
+    } else {
+      krnlmon_log_debug("Removing Neighbor learn from nhop");
+      nexthop_info.using_by &= ~SWITCHLINK_NHOP_FROM_NEIGHBOR;
+      switchlink_db_update_nexthop_using_by(&nexthop_info);
+    }
   }
 
 #if defined(DPDK_TARGET)

--- a/switchlink/sai/switchlink_handle_neigh.c
+++ b/switchlink/sai/switchlink_handle_neigh.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchlink/sai/switchlink_handle_nexthop.c
+++ b/switchlink/sai/switchlink_handle_nexthop.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchlink/sai/switchlink_handle_nexthop.c
+++ b/switchlink/sai/switchlink_handle_nexthop.c
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-#include "switchlink_init_sai.h"
 #include "switchlink/switchlink_handle.h"
+#include "switchlink_init_sai.h"
 
-static sai_next_hop_api_t *sai_nhop_api = NULL;
-static sai_next_hop_group_api_t *sai_nhop_group_api = NULL;
+static sai_next_hop_api_t* sai_nhop_api = NULL;
+static sai_next_hop_group_api_t* sai_nhop_group_api = NULL;
 
 /*
  * Routine Description:
@@ -31,12 +31,12 @@ static sai_next_hop_group_api_t *sai_nhop_group_api = NULL;
  */
 
 sai_status_t sai_init_nhop_api() {
-   sai_status_t status = SAI_STATUS_SUCCESS;
+  sai_status_t status = SAI_STATUS_SUCCESS;
 
-   status = sai_api_query(SAI_API_NEXT_HOP, (void **)&sai_nhop_api);
-   krnlmon_assert(status == SAI_STATUS_SUCCESS);
-   status = sai_api_query(SAI_API_NEXT_HOP_GROUP, (void **)&sai_nhop_group_api);
-   krnlmon_assert(status == SAI_STATUS_SUCCESS);
+  status = sai_api_query(SAI_API_NEXT_HOP, (void**)&sai_nhop_api);
+  krnlmon_assert(status == SAI_STATUS_SUCCESS);
+  status = sai_api_query(SAI_API_NEXT_HOP_GROUP, (void**)&sai_nhop_group_api);
+  krnlmon_assert(status == SAI_STATUS_SUCCESS);
 
   return status;
 }
@@ -53,7 +53,7 @@ sai_status_t sai_init_nhop_api() {
  *   -1 in case of error
  */
 
-int switchlink_create_nexthop(switchlink_db_nexthop_info_t *nexthop_info) {
+int switchlink_create_nexthop(switchlink_db_nexthop_info_t* nexthop_info) {
   sai_status_t status = SAI_STATUS_SUCCESS;
 
   sai_attribute_t attr_list[3];
@@ -68,8 +68,7 @@ int switchlink_create_nexthop(switchlink_db_nexthop_info_t *nexthop_info) {
   } else {
     attr_list[1].value.ipaddr.addr_family = SAI_IP_ADDR_FAMILY_IPV6;
     memcpy(attr_list[1].value.ipaddr.addr.ip6,
-           &(nexthop_info->ip_addr.ip.v6addr),
-           sizeof(sai_ip6_t));
+           &(nexthop_info->ip_addr.ip.v6addr), sizeof(sai_ip6_t));
   }
   attr_list[2].id = SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID;
   attr_list[2].value.oid = nexthop_info->intf_h;
@@ -83,7 +82,7 @@ int switchlink_create_nexthop(switchlink_db_nexthop_info_t *nexthop_info) {
   attr_list[0].id = SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID;
   attr_list[0].value.oid = nexthop_info->nhop_h;
   status = sai_nhop_group_api->create_next_hop_group_member(
-           &(nexthop_info->nhop_member_h), 0, 1, attr_list);
+      &(nexthop_info->nhop_member_h), 0, 1, attr_list);
   if (status != SAI_STATUS_SUCCESS) {
     return -1;
   }

--- a/switchlink/sai/switchlink_handle_route.c
+++ b/switchlink/sai/switchlink_handle_route.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchlink/sai/switchlink_handle_route.c
+++ b/switchlink/sai/switchlink_handle_route.c
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-#include "switchlink_init_sai.h"
 #include "switchlink/switchlink_handle.h"
+#include "switchlink_init_sai.h"
 
-static sai_route_api_t *sai_route_api = NULL;
+static sai_route_api_t* sai_route_api = NULL;
 
 /*
  * Routine Description:
@@ -30,10 +30,10 @@ static sai_route_api_t *sai_route_api = NULL;
  */
 
 sai_status_t sai_init_route_api() {
-   sai_status_t status = SAI_STATUS_SUCCESS;
+  sai_status_t status = SAI_STATUS_SUCCESS;
 
-   status = sai_api_query(SAI_API_ROUTE, (void **)&sai_route_api);
-   krnlmon_assert(status == SAI_STATUS_SUCCESS);
+  status = sai_api_query(SAI_API_ROUTE, (void**)&sai_route_api);
+  krnlmon_assert(status == SAI_STATUS_SUCCESS);
 
   return status;
 }
@@ -50,7 +50,7 @@ sai_status_t sai_init_route_api() {
  *   -1 in case of error
  */
 
-static int delete_create(const switchlink_db_route_info_t *route_info) {
+static int delete_create(const switchlink_db_route_info_t* route_info) {
   sai_status_t status = SAI_STATUS_SUCCESS;
 
   sai_route_entry_t route_entry;
@@ -65,8 +65,7 @@ static int delete_create(const switchlink_db_route_info_t *route_info) {
   } else {
     krnlmon_assert(route_info->ip_addr.family == AF_INET6);
     route_entry.destination.addr_family = SAI_IP_ADDR_FAMILY_IPV6;
-    memcpy(route_entry.destination.addr.ip6,
-           &(route_info->ip_addr.ip.v6addr),
+    memcpy(route_entry.destination.addr.ip6, &(route_info->ip_addr.ip.v6addr),
            sizeof(sai_ip6_t));
     struct in6_addr mask =
         ipv6_prefix_len_to_mask(route_info->ip_addr.prefix_len);
@@ -99,7 +98,7 @@ static int delete_create(const switchlink_db_route_info_t *route_info) {
  *   -1 in case of error
  */
 
-static int delete_route(const switchlink_db_route_info_t *route_info) {
+static int delete_route(const switchlink_db_route_info_t* route_info) {
   sai_status_t status = SAI_STATUS_SUCCESS;
 
   sai_route_entry_t route_entry;
@@ -114,8 +113,7 @@ static int delete_route(const switchlink_db_route_info_t *route_info) {
   } else {
     krnlmon_assert(route_info->ip_addr.family == AF_INET6);
     route_entry.destination.addr_family = SAI_IP_ADDR_FAMILY_IPV6;
-    memcpy(route_entry.destination.addr.ip6,
-           &(route_info->ip_addr.ip.v6addr),
+    memcpy(route_entry.destination.addr.ip6, &(route_info->ip_addr.ip.v6addr),
            sizeof(sai_ip6_t));
     struct in6_addr mask =
         ipv6_prefix_len_to_mask(route_info->ip_addr.prefix_len);
@@ -142,8 +140,8 @@ static int delete_route(const switchlink_db_route_info_t *route_info) {
  */
 
 void switchlink_create_route(switchlink_handle_t vrf_h,
-                             const switchlink_ip_addr_t *dst,
-                             const switchlink_ip_addr_t *gateway,
+                             const switchlink_ip_addr_t* dst,
+                             const switchlink_ip_addr_t* gateway,
                              switchlink_handle_t ecmp_h,
                              switchlink_handle_t intf_h) {
   if (!dst || (!gateway && !ecmp_h)) {
@@ -168,7 +166,8 @@ void switchlink_create_route(switchlink_handle_t vrf_h,
   if (!ecmp_h) {
     // Ignore NULL gateway address, dont create a NHOP for that
     if ((gateway->family == AF_INET && gateway->ip.v4addr.s_addr) ||
-        (gateway->family == AF_INET6 && gateway->ip.v6addr.__in6_u.__u6_addr8[0])) {
+        (gateway->family == AF_INET6 &&
+         gateway->ip.v6addr.__in6_u.__u6_addr8[0])) {
       switchlink_db_nexthop_info_t nexthop_info;
       memset(&nexthop_info, 0, sizeof(switchlink_db_nexthop_info_t));
       memcpy(&(nexthop_info.ip_addr), gateway, sizeof(switchlink_ip_addr_t));
@@ -177,15 +176,19 @@ void switchlink_create_route(switchlink_handle_t vrf_h,
       switchlink_db_status_t status;
       status = switchlink_db_get_nexthop_info(&nexthop_info);
       if (status == SWITCHLINK_DB_STATUS_SUCCESS) {
-          krnlmon_log_debug("Received nhop 0x%lx handler, update from"
-                   " route", nexthop_info.nhop_h);
+        krnlmon_log_debug(
+            "Received nhop 0x%lx handler, update from"
+            " route",
+            nexthop_info.nhop_h);
         nhop_h = nexthop_info.nhop_h;
         nexthop_info.using_by |= SWITCHLINK_NHOP_FROM_ROUTE;
         switchlink_db_update_nexthop_using_by(&nexthop_info);
       } else {
         if (!switchlink_create_nexthop(&nexthop_info)) {
-          krnlmon_log_debug("Created nhop 0x%lx handle, update from "
-                   " route", nexthop_info.nhop_h);
+          krnlmon_log_debug(
+              "Created nhop 0x%lx handle, update from "
+              " route",
+              nexthop_info.nhop_h);
           nhop_h = nexthop_info.nhop_h;
           nexthop_info.using_by |= SWITCHLINK_NHOP_FROM_ROUTE;
           switchlink_db_add_nexthop(&nexthop_info);
@@ -222,7 +225,7 @@ void switchlink_create_route(switchlink_handle_t vrf_h,
 
   // add the route
   krnlmon_log_info("Create route: 0x%x/%d", dst->ip.v4addr.s_addr,
-             dst->prefix_len);
+                   dst->prefix_len);
   if (delete_create(&route_info) == -1) {
     if (route_info.ecmp) {
       switchlink_delete_ecmp(route_info.nhop_h);
@@ -251,7 +254,7 @@ void switchlink_create_route(switchlink_handle_t vrf_h,
  */
 
 void switchlink_delete_route(switchlink_handle_t vrf_h,
-                             const switchlink_ip_addr_t *dst) {
+                             const switchlink_ip_addr_t* dst) {
   bool ecmp_enable = false;
   switchlink_handle_t ecmp_h;
 
@@ -274,7 +277,7 @@ void switchlink_delete_route(switchlink_handle_t vrf_h,
   }
 
   krnlmon_log_info("Route deleted: 0x%x/%d", dst->ip.v4addr.s_addr,
-             dst->prefix_len);
+                   dst->prefix_len);
   ecmp_enable = route_info.ecmp;
   ecmp_h = route_info.nhop_h;
 
@@ -285,4 +288,3 @@ void switchlink_delete_route(switchlink_handle_t vrf_h,
     }
   }
 }
-

--- a/switchlink/sai/switchlink_handle_tunnel.c
+++ b/switchlink/sai/switchlink_handle_tunnel.c
@@ -15,16 +15,16 @@
  * limitations under the License.
  */
 
-#include "switchlink_init_sai.h"
 #include "switchlink/switchlink_handle.h"
+#include "switchlink_init_sai.h"
 
-static sai_tunnel_api_t *sai_tunnel_intf_api = NULL;
+static sai_tunnel_api_t* sai_tunnel_intf_api = NULL;
 
 sai_status_t sai_init_tunnel_api() {
-   sai_status_t status = SAI_STATUS_SUCCESS;
+  sai_status_t status = SAI_STATUS_SUCCESS;
 
-   status = sai_api_query(SAI_API_TUNNEL, (void **)&sai_tunnel_intf_api);
-   krnlmon_assert(status == SAI_STATUS_SUCCESS);
+  status = sai_api_query(SAI_API_TUNNEL, (void**)&sai_tunnel_intf_api);
+  krnlmon_assert(status == SAI_STATUS_SUCCESS);
 
   return status;
 }
@@ -43,36 +43,35 @@ sai_status_t sai_init_tunnel_api() {
  */
 
 static sai_status_t create_tunnel(
-          const switchlink_db_tunnel_interface_info_t *tnl_intf,
-          switchlink_handle_t *tnl_intf_h) {
-    sai_attribute_t attr_list[10];
-    int ac = 0;
-    memset(attr_list, 0, sizeof(attr_list));
+    const switchlink_db_tunnel_interface_info_t* tnl_intf,
+    switchlink_handle_t* tnl_intf_h) {
+  sai_attribute_t attr_list[10];
+  int ac = 0;
+  memset(attr_list, 0, sizeof(attr_list));
 
-
-    // TODO looks like remote is valid only for PEER_MODE = P2P
-    if (tnl_intf->src_ip.family == AF_INET) {
-        attr_list[ac].id = SAI_TUNNEL_ATTR_ENCAP_SRC_IP;
-        attr_list[ac].value.ipaddr.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
-        attr_list[ac].value.ipaddr.addr.ip4 =
-                        htonl(tnl_intf->src_ip.ip.v4addr.s_addr);
-        ac++;
-    }
-
-    // TODO looks like remote is valid only for PEER_MODE = P2P
-    if (tnl_intf->dst_ip.family == AF_INET) {
-        attr_list[ac].id = SAI_TUNNEL_ATTR_ENCAP_DST_IP;
-        attr_list[ac].value.ipaddr.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
-        attr_list[ac].value.ipaddr.addr.ip4 =
-                        htonl(tnl_intf->dst_ip.ip.v4addr.s_addr);
-        ac++;
-    }
-
-    attr_list[ac].id = SAI_TUNNEL_ATTR_VXLAN_UDP_SPORT;
-    attr_list[ac].value.u16 = tnl_intf->dst_port;
+  // TODO looks like remote is valid only for PEER_MODE = P2P
+  if (tnl_intf->src_ip.family == AF_INET) {
+    attr_list[ac].id = SAI_TUNNEL_ATTR_ENCAP_SRC_IP;
+    attr_list[ac].value.ipaddr.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+    attr_list[ac].value.ipaddr.addr.ip4 =
+        htonl(tnl_intf->src_ip.ip.v4addr.s_addr);
     ac++;
+  }
 
-    return sai_tunnel_intf_api->create_tunnel(tnl_intf_h, 0, ac, attr_list);
+  // TODO looks like remote is valid only for PEER_MODE = P2P
+  if (tnl_intf->dst_ip.family == AF_INET) {
+    attr_list[ac].id = SAI_TUNNEL_ATTR_ENCAP_DST_IP;
+    attr_list[ac].value.ipaddr.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+    attr_list[ac].value.ipaddr.addr.ip4 =
+        htonl(tnl_intf->dst_ip.ip.v4addr.s_addr);
+    ac++;
+  }
+
+  attr_list[ac].id = SAI_TUNNEL_ATTR_VXLAN_UDP_SPORT;
+  attr_list[ac].value.u16 = tnl_intf->dst_port;
+  ac++;
+
+  return sai_tunnel_intf_api->create_tunnel(tnl_intf_h, 0, ac, attr_list);
 }
 
 /*
@@ -89,40 +88,39 @@ static sai_status_t create_tunnel(
  */
 
 static sai_status_t create_term_table_entry(
-                         const switchlink_db_tunnel_interface_info_t *tnl_intf,
-                         switchlink_handle_t *tnl_term_intf_h) {
-    sai_attribute_t attr_list[10];
-    memset(attr_list, 0, sizeof(attr_list));
-    int ac = 0;
+    const switchlink_db_tunnel_interface_info_t* tnl_intf,
+    switchlink_handle_t* tnl_term_intf_h) {
+  sai_attribute_t attr_list[10];
+  memset(attr_list, 0, sizeof(attr_list));
+  int ac = 0;
 
-    if (tnl_intf->dst_ip.family == AF_INET) {
-        attr_list[ac].id = SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_DST_IP;
-        attr_list[ac].value.ipaddr.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
-        attr_list[ac].value.ipaddr.addr.ip4 =
-                        htonl(tnl_intf->dst_ip.ip.v4addr.s_addr);
-        ac++;
-    }
-
-    if (tnl_intf->src_ip.family == AF_INET) {
-        attr_list[ac].id = SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_SRC_IP;
-        attr_list[ac].value.ipaddr.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
-        attr_list[ac].value.ipaddr.addr.ip4 =
-                        htonl(tnl_intf->src_ip.ip.v4addr.s_addr);
-        ac++;
-    }
-
-    attr_list[ac].id = SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_ACTION_TUNNEL_ID;
-    attr_list[ac].value.u32 = tnl_intf->vni_id;
+  if (tnl_intf->dst_ip.family == AF_INET) {
+    attr_list[ac].id = SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_DST_IP;
+    attr_list[ac].value.ipaddr.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+    attr_list[ac].value.ipaddr.addr.ip4 =
+        htonl(tnl_intf->dst_ip.ip.v4addr.s_addr);
     ac++;
+  }
 
-    return sai_tunnel_intf_api->create_tunnel_term_table_entry(tnl_term_intf_h,
-                                                           0, ac,
-                                                           attr_list);
+  if (tnl_intf->src_ip.family == AF_INET) {
+    attr_list[ac].id = SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_SRC_IP;
+    attr_list[ac].value.ipaddr.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+    attr_list[ac].value.ipaddr.addr.ip4 =
+        htonl(tnl_intf->src_ip.ip.v4addr.s_addr);
+    ac++;
+  }
+
+  attr_list[ac].id = SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_ACTION_TUNNEL_ID;
+  attr_list[ac].value.u32 = tnl_intf->vni_id;
+  ac++;
+
+  return sai_tunnel_intf_api->create_tunnel_term_table_entry(tnl_term_intf_h, 0,
+                                                             ac, attr_list);
 }
 
 /*
  * Routine Description:
- *    Wrapper function to create tunnel interface and create tunnel 
+ *    Wrapper function to create tunnel interface and create tunnel
  *    term table entry
  *
  * Arguments:
@@ -135,65 +133,75 @@ static sai_status_t create_term_table_entry(
  *   -1 in case of error
  */
 
-static int
-create_tunnel_interface(const switchlink_db_tunnel_interface_info_t *tnl_intf,
-                        switchlink_handle_t *tnl_intf_h,
-                        switchlink_handle_t *tnl_term_h) {
-    sai_status_t status = SAI_STATUS_SUCCESS;
-
-    status = create_tunnel(tnl_intf, tnl_intf_h);
-    if (status != SAI_STATUS_SUCCESS) {
-        krnlmon_log_error("Cannot create tunnel for interface: %s", tnl_intf->ifname);
-        return -1;
-    }
-    krnlmon_log_info("Created tunnel interface: %s", tnl_intf->ifname);
-
-    status = create_term_table_entry(tnl_intf, tnl_term_h);
-    if (status != SAI_STATUS_SUCCESS) {
-        krnlmon_log_error("Cannot create tunnel termination table entry for "
-                 "interface: %s", tnl_intf->ifname);
-        return -1;
-    }
-    krnlmon_log_info("Created tunnel termination entry for "
-              "interface: %s", tnl_intf->ifname);
-
-    return 0;
-}
-
-/*
- * Routine Description:
- *    Wrapper function to delete tunnel interface and delete tunnel 
- *    term table entry
- *
- * Arguments:
- *    [in] tnl_intf - tunnel interface info
- *    [in] tnl_intf_h - tunnel interface handle
- *    [in] tnl_term_h - tunnel term handle
- *
- * Return Values:
- *    0 on success
- *   -1 in case of error
- */
-
-static int delete_tunnel_interface(const switchlink_db_tunnel_interface_info_t
-                                   *tnl_intf) {
+static int create_tunnel_interface(
+    const switchlink_db_tunnel_interface_info_t* tnl_intf,
+    switchlink_handle_t* tnl_intf_h, switchlink_handle_t* tnl_term_h) {
   sai_status_t status = SAI_STATUS_SUCCESS;
 
-  status = 
-    sai_tunnel_intf_api->remove_tunnel_term_table_entry(tnl_intf->tnl_term_h);
+  status = create_tunnel(tnl_intf, tnl_intf_h);
   if (status != SAI_STATUS_SUCCESS) {
-      krnlmon_log_error("Cannot remove tunnel termination entry for "
-               "interface: %s", tnl_intf->ifname);
-      return -1;
+    krnlmon_log_error("Cannot create tunnel for interface: %s",
+                      tnl_intf->ifname);
+    return -1;
   }
-  krnlmon_log_info("Removed tunnel termination entry for "
-            "interface: %s", tnl_intf->ifname);
+  krnlmon_log_info("Created tunnel interface: %s", tnl_intf->ifname);
+
+  status = create_term_table_entry(tnl_intf, tnl_term_h);
+  if (status != SAI_STATUS_SUCCESS) {
+    krnlmon_log_error(
+        "Cannot create tunnel termination table entry for "
+        "interface: %s",
+        tnl_intf->ifname);
+    return -1;
+  }
+  krnlmon_log_info(
+      "Created tunnel termination entry for "
+      "interface: %s",
+      tnl_intf->ifname);
+
+  return 0;
+}
+
+/*
+ * Routine Description:
+ *    Wrapper function to delete tunnel interface and delete tunnel
+ *    term table entry
+ *
+ * Arguments:
+ *    [in] tnl_intf - tunnel interface info
+ *    [in] tnl_intf_h - tunnel interface handle
+ *    [in] tnl_term_h - tunnel term handle
+ *
+ * Return Values:
+ *    0 on success
+ *   -1 in case of error
+ */
+
+static int delete_tunnel_interface(
+    const switchlink_db_tunnel_interface_info_t* tnl_intf) {
+  sai_status_t status = SAI_STATUS_SUCCESS;
+
+  status =
+      sai_tunnel_intf_api->remove_tunnel_term_table_entry(tnl_intf->tnl_term_h);
+  if (status != SAI_STATUS_SUCCESS) {
+    krnlmon_log_error(
+        "Cannot remove tunnel termination entry for "
+        "interface: %s",
+        tnl_intf->ifname);
+    return -1;
+  }
+  krnlmon_log_info(
+      "Removed tunnel termination entry for "
+      "interface: %s",
+      tnl_intf->ifname);
 
   status = sai_tunnel_intf_api->remove_tunnel(tnl_intf->orif_h);
   if (status != SAI_STATUS_SUCCESS) {
-      krnlmon_log_error("Cannot remove tunnel entry for "
-               "interface: %s", tnl_intf->ifname);
-      return -1;
+    krnlmon_log_error(
+        "Cannot remove tunnel entry for "
+        "interface: %s",
+        tnl_intf->ifname);
+    return -1;
   }
 
   krnlmon_log_info("Removed tunnel entry for interface: %s", tnl_intf->ifname);
@@ -214,21 +222,21 @@ static int delete_tunnel_interface(const switchlink_db_tunnel_interface_info_t
  */
 
 void switchlink_create_tunnel_interface(
-                       switchlink_db_tunnel_interface_info_t *tnl_intf) {
+    switchlink_db_tunnel_interface_info_t* tnl_intf) {
   switchlink_db_status_t status;
   switchlink_db_tunnel_interface_info_t tnl_ifinfo;
 
-  status = switchlink_db_get_tunnel_interface_info(tnl_intf->ifindex,
-                                                   &tnl_ifinfo);
+  status =
+      switchlink_db_get_tunnel_interface_info(tnl_intf->ifindex, &tnl_ifinfo);
   if (status == SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND) {
-
     krnlmon_log_debug("Switchlink tunnel interface: %s", tnl_intf->ifname);
-    status = create_tunnel_interface(tnl_intf,
-                                     &(tnl_intf->orif_h),
+    status = create_tunnel_interface(tnl_intf, &(tnl_intf->orif_h),
                                      &(tnl_intf->tnl_term_h));
     if (status) {
-      krnlmon_log_error("newlink: Failed to create switchlink tunnel interface :%s, "
-               "error: %d", tnl_intf->ifname, status);
+      krnlmon_log_error(
+          "newlink: Failed to create switchlink tunnel interface :%s, "
+          "error: %d",
+          tnl_intf->ifname, status);
       return;
     }
 
@@ -236,8 +244,10 @@ void switchlink_create_tunnel_interface(
     switchlink_db_add_tunnel_interface(tnl_intf->ifindex, tnl_intf);
     return;
   }
-  krnlmon_log_debug("Switchlink DB already has tunnel config for "
-           "interface: %s", tnl_intf->ifname);
+  krnlmon_log_debug(
+      "Switchlink DB already has tunnel config for "
+      "interface: %s",
+      tnl_intf->ifname);
   return;
 }
 
@@ -256,8 +266,9 @@ void switchlink_delete_tunnel_interface(uint32_t ifindex) {
   switchlink_db_tunnel_interface_info_t tnl_intf;
   if (switchlink_db_get_tunnel_interface_info(ifindex, &tnl_intf) ==
       SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND) {
-      krnlmon_log_info("Trying to delete a tunnel which is not "
-                "available");
+    krnlmon_log_info(
+        "Trying to delete a tunnel which is not "
+        "available");
     return;
   }
 

--- a/switchlink/sai/switchlink_handle_tunnel.c
+++ b/switchlink/sai/switchlink_handle_tunnel.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchlink/sai/switchlink_init_sai.c
+++ b/switchlink/sai/switchlink_init_sai.c
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-#include "sai.h"
 #include "switchlink_init_sai.h"
+
+#include "sai.h"
 
 extern sai_status_t sai_initialize(void);
 

--- a/switchlink/sai/switchlink_init_sai.c
+++ b/switchlink/sai/switchlink_init_sai.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchlink/sai/switchlink_init_sai.h
+++ b/switchlink/sai/switchlink_init_sai.h
@@ -15,17 +15,16 @@
  * limitations under the License.
  */
 
-
 #ifndef __SWITCHLINK_ANALYZE_H__
 #define __SWITCHLINK_ANALYZE_H__
 
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 
+#include "sai.h"
 #include "switchlink/switchlink.h"
 #include "switchlink/switchlink_db.h"
 #include "switchlink/switchlink_utils.h"
-#include "sai.h"
 #include "switchsai/saiinternal.h"
 
 // Init SAI API
@@ -42,27 +41,27 @@ sai_status_t sai_init_lag_api();
 
 // SWITCHLINK_LINK_TYPE_VXLAN handlers
 void switchlink_create_tunnel_interface(
-         switchlink_db_tunnel_interface_info_t *tnl_intf);
+    switchlink_db_tunnel_interface_info_t* tnl_intf);
 void switchlink_delete_tunnel_interface(uint32_t ifindex);
 
 // SWITCHLINK_LINK_TYPE_BOND handlers
 void switchlink_create_lag(switchlink_db_interface_info_t* lag_intf);
 void switchlink_delete_lag(uint32_t ifindex);
-void switchlink_create_lag_member(switchlink_db_lag_member_info_t* lag_member_info);
+void switchlink_create_lag_member(
+    switchlink_db_lag_member_info_t* lag_member_info);
 void switchlink_delete_lag_member(uint32_t ifindex);
 
 // SWITCHLINK_LINK_TYPE_TUN handlers
-void switchlink_create_interface(switchlink_db_interface_info_t *intf);
+void switchlink_create_interface(switchlink_db_interface_info_t* intf);
 void switchlink_delete_interface(uint32_t ifindex);
-
 
 // RTM_NEWNEIGH/ RTM_DELNEIGH handlers
 void switchlink_create_neigh(switchlink_handle_t vrf_h,
-                             const switchlink_ip_addr_t *ipaddr,
+                             const switchlink_ip_addr_t* ipaddr,
                              switchlink_mac_addr_t mac_addr,
                              switchlink_handle_t intf_h);
 void switchlink_delete_neigh(switchlink_handle_t vrf_h,
-                             const switchlink_ip_addr_t *ipaddr,
+                             const switchlink_ip_addr_t* ipaddr,
                              switchlink_handle_t intf_h);
 void switchlink_create_mac(switchlink_mac_addr_t mac_addr,
                            switchlink_handle_t bridge_h,
@@ -71,27 +70,26 @@ void switchlink_delete_mac(switchlink_mac_addr_t mac_addr,
                            switchlink_handle_t bridge_h);
 
 // Nexthop handlers
-int switchlink_create_nexthop(switchlink_db_nexthop_info_t *nexthop_info);
+int switchlink_create_nexthop(switchlink_db_nexthop_info_t* nexthop_info);
 int switchlink_delete_nexthop(switchlink_handle_t nhop_h);
 
 // RTM_NEWROUTE/ RTM_DELROUTE handlers
 void switchlink_create_route(switchlink_handle_t vrf_h,
-                             const switchlink_ip_addr_t *dst,
-                             const switchlink_ip_addr_t *gateway,
+                             const switchlink_ip_addr_t* dst,
+                             const switchlink_ip_addr_t* gateway,
                              switchlink_handle_t ecmp_h,
                              switchlink_handle_t intf_h);
 void switchlink_delete_route(switchlink_handle_t vrf_h,
-                             const switchlink_ip_addr_t *dst);
+                             const switchlink_ip_addr_t* dst);
 
 // ECMP handlers
-int switchlink_create_ecmp(switchlink_db_ecmp_info_t *ecmp_info);
+int switchlink_create_ecmp(switchlink_db_ecmp_info_t* ecmp_info);
 void switchlink_delete_ecmp(switchlink_handle_t ecmp_h);
 
 // VRF handler
-int switchlink_create_vrf(switchlink_handle_t *vrf_h);
+int switchlink_create_vrf(switchlink_handle_t* vrf_h);
 
-//General utility function
-bool
-validate_delete_nexthop(uint32_t using_by,
-                        switchlink_nhop_using_by_e type);
+// General utility function
+bool validate_delete_nexthop(uint32_t using_by,
+                             switchlink_nhop_using_by_e type);
 #endif /* __SWITCHLINK_ANALYZE_H__ */

--- a/switchlink/sai/switchlink_init_sai.h
+++ b/switchlink/sai/switchlink_init_sai.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef __SWITCHLINK_ANALYZE_H__
-#define __SWITCHLINK_ANALYZE_H__
+#ifndef __SWITCHLINK_INIT_SAI_H__
+#define __SWITCHLINK_INIT_SAI_H__
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -92,4 +92,5 @@ int switchlink_create_vrf(switchlink_handle_t* vrf_h);
 // General utility function
 bool validate_delete_nexthop(uint32_t using_by,
                              switchlink_nhop_using_by_e type);
-#endif /* __SWITCHLINK_ANALYZE_H__ */
+
+#endif /* __SWITCHLINK_INIT_SAI_H__ */

--- a/switchlink/switchlink.h
+++ b/switchlink/switchlink.h
@@ -18,8 +18,8 @@
 #ifndef __SWITCHLINK_H__
 #define __SWITCHLINK_H__
 
-#include <stdlib.h>
 #include <netinet/in.h>
+#include <stdlib.h>
 
 #include "switchutils/switch_utils.h"
 
@@ -49,20 +49,19 @@ extern switchlink_handle_t g_default_vrf_h;
 extern switchlink_handle_t g_default_bridge_h;
 extern switchlink_handle_t g_cpu_rx_nhop_h;
 
-struct nl_sock *switchlink_get_nl_sock(void);
+struct nl_sock* switchlink_get_nl_sock(void);
 
 typedef enum switchlink_entry_type {
   SWITCHLINK_FDB_NONE = 0,
   SWITCHLINK_FDB_ADD = 1,
   SWITCHLINK_FDB_DEL = 2,
   SWITCHLINK_FDB_MAX = 3,
-}switchlink_entry_type_e;
+} switchlink_entry_type_e;
 
 typedef enum switchlink_nhop_using_by {
   SWITCHLINK_NHOP_FROM_NONE = 0,
   SWITCHLINK_NHOP_FROM_NEIGHBOR = 1 << 0,
   SWITCHLINK_NHOP_FROM_ROUTE = 1 << 1,
-}switchlink_nhop_using_by_e;
-
+} switchlink_nhop_using_by_e;
 
 #endif /* __SWITCHLINK_H__ */

--- a/switchlink/switchlink.h
+++ b/switchlink/switchlink.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchlink/switchlink_address.c
+++ b/switchlink/switchlink_address.c
@@ -17,9 +17,9 @@
  * limitations under the License.
  */
 
-#include "switchlink_route.h"
-#include "switchlink_int.h"
 #include "switchlink_handle.h"
+#include "switchlink_int.h"
+#include "switchlink_route.h"
 
 /*
  * Routine Description:
@@ -33,24 +33,22 @@
  *    void
  */
 
-void switchlink_process_address_msg(const struct nlmsghdr *nlmsg, int msgtype) {
+void switchlink_process_address_msg(const struct nlmsghdr* nlmsg, int msgtype) {
   int hdrlen, attrlen;
-  struct nlattr *attr;
-  struct ifaddrmsg *addrmsg;
+  struct nlattr* attr;
+  struct ifaddrmsg* addrmsg;
   bool addr_valid = false;
   switchlink_ip_addr_t addr;
 
   krnlmon_assert((msgtype == RTM_NEWADDR) || (msgtype == RTM_DELADDR));
   addrmsg = nlmsg_data(nlmsg);
   hdrlen = sizeof(struct ifaddrmsg);
-  krnlmon_log_debug("%saddr: family = %d, prefixlen = %d, flags = 0x%x, "
-       "scope = 0x%x ifindex = %d\n",
-       ((msgtype == RTM_NEWADDR) ? "new" : "del"),
-       addrmsg->ifa_family,
-       addrmsg->ifa_prefixlen,
-       addrmsg->ifa_flags,
-       addrmsg->ifa_scope,
-       addrmsg->ifa_index);
+  krnlmon_log_debug(
+      "%saddr: family = %d, prefixlen = %d, flags = 0x%x, "
+      "scope = 0x%x ifindex = %d\n",
+      ((msgtype == RTM_NEWADDR) ? "new" : "del"), addrmsg->ifa_family,
+      addrmsg->ifa_prefixlen, addrmsg->ifa_flags, addrmsg->ifa_scope,
+      addrmsg->ifa_index);
 
   if ((addrmsg->ifa_family != AF_INET) && (addrmsg->ifa_family != AF_INET6)) {
     // an address family that we are not interested in, skip
@@ -64,7 +62,7 @@ void switchlink_process_address_msg(const struct nlmsghdr *nlmsg, int msgtype) {
   status = switchlink_db_get_interface_info(addrmsg->ifa_index, &ifinfo);
   if (status == SWITCHLINK_DB_STATUS_SUCCESS) {
     krnlmon_log_debug("Found interface cache for: %s", ifinfo.ifname);
-    if(ifinfo.link_type == SWITCHLINK_LINK_TYPE_BOND) {
+    if (ifinfo.link_type == SWITCHLINK_LINK_TYPE_BOND) {
       intf_h = ifinfo.lag_h;
     } else {
       intf_h = ifinfo.intf_h;
@@ -73,7 +71,7 @@ void switchlink_process_address_msg(const struct nlmsghdr *nlmsg, int msgtype) {
     // TODO P4-OVS, for now we ignore these notifications.
     // Needed when, we get address add before port create notification
     krnlmon_log_debug("Ignoring interface address notification ifindex: %d",
-             addrmsg->ifa_index);
+                      addrmsg->ifa_index);
     return;
   }
 

--- a/switchlink/switchlink_address.c
+++ b/switchlink/switchlink_address.c
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include <netlink/msg.h>
+
 #include "switchlink_handle.h"
 #include "switchlink_int.h"
 #include "switchlink_route.h"

--- a/switchlink/switchlink_db.c
+++ b/switchlink/switchlink_db.c
@@ -28,11 +28,7 @@
 #include "switchlink_link.h"
 #include "switchlink_neigh.h"
 #include "switchlink_route.h"
-#include "tommyds/tommyhashlin.h"
-#include "tommyds/tommylist.h"
-#include "tommyds/tommytrieinp.h"
 #include "xxHash/xxhash.h"
-//#include "utils.h"
 
 #define SWITCHLINK_MAC_KEY_LEN 14
 

--- a/switchlink/switchlink_db.c
+++ b/switchlink/switchlink_db.c
@@ -15,22 +15,23 @@
  * limitations under the License.
  */
 
-#include <stdint.h>
-#include <stdbool.h>
-#include <string.h>
-#include <netinet/in.h>
+#include "switchlink_db.h"
 
-#include "tommyds/tommytrieinp.h"
-#include "tommyds/tommyhashlin.h"
-#include "tommyds/tommylist.h"
-#include "xxHash/xxhash.h"
+#include <netinet/in.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
 #include "switchlink.h"
+#include "switchlink_db_int.h"
+#include "switchlink_int.h"
 #include "switchlink_link.h"
 #include "switchlink_neigh.h"
 #include "switchlink_route.h"
-#include "switchlink_db.h"
-#include "switchlink_db_int.h"
-#include "switchlink_int.h"
+#include "tommyds/tommyhashlin.h"
+#include "tommyds/tommylist.h"
+#include "tommyds/tommytrieinp.h"
+#include "xxHash/xxhash.h"
 //#include "utils.h"
 
 #define SWITCHLINK_MAC_KEY_LEN 14
@@ -61,8 +62,8 @@ static tommy_list switchlink_db_mac_lag_obj_list;
  *    Object from the database matching the handle h
  */
 
-static void *switchlink_db_get_handle_obj(switchlink_handle_t h) {
-  void *obj;
+static void* switchlink_db_get_handle_obj(switchlink_handle_t h) {
+  void* obj;
   obj = tommy_trie_inplace_search(&switchlink_db_handle_obj_map, h);
   return obj;
 }
@@ -79,19 +80,17 @@ static void *switchlink_db_get_handle_obj(switchlink_handle_t h) {
  */
 
 switchlink_db_status_t switchlink_db_add_interface(
-    uint32_t ifindex, switchlink_db_interface_info_t *intf_info) {
+    uint32_t ifindex, switchlink_db_interface_info_t* intf_info) {
   krnlmon_assert(intf_info != NULL);
-  switchlink_db_intf_obj_t *obj =
+  switchlink_db_intf_obj_t* obj =
       switchlink_malloc(sizeof(switchlink_db_intf_obj_t), 1);
   krnlmon_assert(obj != NULL);
   obj->ifindex = ifindex;
   memcpy(&(obj->intf_info), intf_info, sizeof(switchlink_db_interface_info_t));
-  tommy_trie_inplace_insert(
-      &switchlink_db_interface_obj_map, &obj->ifindex_node, obj, obj->ifindex);
-  tommy_trie_inplace_insert(&switchlink_db_handle_obj_map,
-                            &obj->handle_node,
-                            obj,
-                            obj->intf_info.intf_h);
+  tommy_trie_inplace_insert(&switchlink_db_interface_obj_map,
+                            &obj->ifindex_node, obj, obj->ifindex);
+  tommy_trie_inplace_insert(&switchlink_db_handle_obj_map, &obj->handle_node,
+                            obj, obj->intf_info.intf_h);
   return SWITCHLINK_DB_STATUS_SUCCESS;
 }
 
@@ -108,19 +107,17 @@ switchlink_db_status_t switchlink_db_add_interface(
  */
 
 switchlink_db_status_t switchlink_db_add_tuntap(
-    uint32_t ifindex, switchlink_db_tuntap_info_t *tunp_info) {
+    uint32_t ifindex, switchlink_db_tuntap_info_t* tunp_info) {
   krnlmon_assert(tunp_info != NULL);
-  switchlink_db_tuntap_obj_t *obj =
+  switchlink_db_tuntap_obj_t* obj =
       switchlink_malloc(sizeof(switchlink_db_tuntap_obj_t), 1);
   krnlmon_assert(obj != NULL);
   obj->ifindex = ifindex;
   memcpy(&(obj->tunp_info), tunp_info, sizeof(switchlink_db_tuntap_info_t));
-  tommy_trie_inplace_insert(
-      &switchlink_db_tuntap_obj_map, &obj->ifindex_node, obj, obj->ifindex);
-  tommy_trie_inplace_insert(&switchlink_db_handle_obj_map,
-                            &obj->handle_node,
-                            obj,
-                            obj->tunp_info.tunp_h);
+  tommy_trie_inplace_insert(&switchlink_db_tuntap_obj_map, &obj->ifindex_node,
+                            obj, obj->ifindex);
+  tommy_trie_inplace_insert(&switchlink_db_handle_obj_map, &obj->handle_node,
+                            obj, obj->tunp_info.tunp_h);
   return SWITCHLINK_DB_STATUS_SUCCESS;
 }
 
@@ -138,9 +135,9 @@ switchlink_db_status_t switchlink_db_add_tuntap(
  */
 
 switchlink_db_status_t switchlink_db_get_tuntap_info(
-    uint32_t ifindex, switchlink_db_tuntap_info_t *tunp_info) {
+    uint32_t ifindex, switchlink_db_tuntap_info_t* tunp_info) {
   krnlmon_assert(tunp_info != NULL);
-  switchlink_db_tuntap_obj_t *obj;
+  switchlink_db_tuntap_obj_t* obj;
   obj = tommy_trie_inplace_search(&switchlink_db_tuntap_obj_map, ifindex);
   if (!obj) {
     return SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND;
@@ -163,9 +160,9 @@ switchlink_db_status_t switchlink_db_get_tuntap_info(
  */
 
 switchlink_db_status_t switchlink_db_get_interface_info(
-    uint32_t ifindex, switchlink_db_interface_info_t *intf_info) {
+    uint32_t ifindex, switchlink_db_interface_info_t* intf_info) {
   krnlmon_assert(intf_info != NULL);
-  switchlink_db_intf_obj_t *obj;
+  switchlink_db_intf_obj_t* obj;
   obj = tommy_trie_inplace_search(&switchlink_db_interface_obj_map, ifindex);
   if (!obj) {
     return SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND;
@@ -188,8 +185,8 @@ switchlink_db_status_t switchlink_db_get_interface_info(
  */
 
 switchlink_db_status_t switchlink_db_get_interface_ifindex(
-    switchlink_handle_t intf_h, uint32_t *ifindex) {
-  switchlink_db_intf_obj_t *obj;
+    switchlink_handle_t intf_h, uint32_t* ifindex) {
+  switchlink_db_intf_obj_t* obj;
   obj = switchlink_db_get_handle_obj(intf_h);
   if (!obj) {
     return SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND;
@@ -213,8 +210,8 @@ switchlink_db_status_t switchlink_db_get_interface_ifindex(
  */
 
 switchlink_db_status_t switchlink_db_update_interface(
-    uint32_t ifindex, switchlink_db_interface_info_t *intf_info) {
-  switchlink_db_intf_obj_t *obj;
+    uint32_t ifindex, switchlink_db_interface_info_t* intf_info) {
+  switchlink_db_intf_obj_t* obj;
   obj = tommy_trie_inplace_search(&switchlink_db_interface_obj_map, ifindex);
   if (!obj) {
     return SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND;
@@ -236,7 +233,7 @@ switchlink_db_status_t switchlink_db_update_interface(
  */
 
 switchlink_db_status_t switchlink_db_delete_interface(uint32_t ifindex) {
-  switchlink_db_intf_obj_t *obj;
+  switchlink_db_intf_obj_t* obj;
   obj = tommy_trie_inplace_remove(&switchlink_db_interface_obj_map, ifindex);
   if (!obj) {
     return SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND;
@@ -260,20 +257,18 @@ switchlink_db_status_t switchlink_db_delete_interface(uint32_t ifindex) {
  */
 
 switchlink_db_status_t switchlink_db_add_tunnel_interface(
-    uint32_t ifindex, switchlink_db_tunnel_interface_info_t *tnl_intf_info) {
+    uint32_t ifindex, switchlink_db_tunnel_interface_info_t* tnl_intf_info) {
   krnlmon_assert(tnl_intf_info != NULL);
-  switchlink_db_tunnel_intf_obj_t *obj =
+  switchlink_db_tunnel_intf_obj_t* obj =
       switchlink_malloc(sizeof(switchlink_db_tunnel_intf_obj_t), 1);
   krnlmon_assert(obj != NULL);
   obj->ifindex = ifindex;
   memcpy(&(obj->tnl_intf_info), tnl_intf_info,
          sizeof(switchlink_db_tunnel_interface_info_t));
-  tommy_trie_inplace_insert(
-      &switchlink_db_tunnel_obj_map, &obj->ifindex_node, obj, obj->ifindex);
-  tommy_trie_inplace_insert(&switchlink_db_handle_obj_map,
-                            &obj->handle_node,
-                            obj,
-                            obj->tnl_intf_info.urif_h);
+  tommy_trie_inplace_insert(&switchlink_db_tunnel_obj_map, &obj->ifindex_node,
+                            obj, obj->ifindex);
+  tommy_trie_inplace_insert(&switchlink_db_handle_obj_map, &obj->handle_node,
+                            obj, obj->tnl_intf_info.urif_h);
   return SWITCHLINK_DB_STATUS_SUCCESS;
 }
 
@@ -291,8 +286,8 @@ switchlink_db_status_t switchlink_db_add_tunnel_interface(
  */
 
 switchlink_db_status_t switchlink_db_get_tunnel_interface_info(
-    uint32_t ifindex, switchlink_db_tunnel_interface_info_t *tunnel_intf_info) {
-  switchlink_db_tunnel_intf_obj_t *obj;
+    uint32_t ifindex, switchlink_db_tunnel_interface_info_t* tunnel_intf_info) {
+  switchlink_db_tunnel_intf_obj_t* obj;
   obj = tommy_trie_inplace_search(&switchlink_db_tunnel_obj_map, ifindex);
   if (!obj) {
     return SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND;
@@ -315,7 +310,7 @@ switchlink_db_status_t switchlink_db_get_tunnel_interface_info(
  */
 
 switchlink_db_status_t switchlink_db_delete_tunnel_interface(uint32_t ifindex) {
-  switchlink_db_tunnel_intf_obj_t *obj;
+  switchlink_db_tunnel_intf_obj_t* obj;
   obj = tommy_trie_inplace_remove(&switchlink_db_tunnel_obj_map, ifindex);
   if (!obj) {
     return SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND;
@@ -328,7 +323,7 @@ switchlink_db_status_t switchlink_db_delete_tunnel_interface(uint32_t ifindex) {
 
 /*
  * Routine Description:
- *    Get the hash for mac address 
+ *    Get the hash for mac address
  *
  * Arguments:
  *    [in] mac_addr - MAC address
@@ -342,8 +337,7 @@ switchlink_db_status_t switchlink_db_delete_tunnel_interface(uint32_t ifindex) {
 
 static inline void switchlink_db_hash_mac_key(switchlink_mac_addr_t mac_addr,
                                               switchlink_handle_t bridge_h,
-                                              uint8_t *key,
-                                              uint32_t *hash) {
+                                              uint8_t* key, uint32_t* hash) {
   memset(key, 0, SWITCHLINK_MAC_KEY_LEN);
   memcpy(&key[0], &bridge_h, min(sizeof(bridge_h), (uint32_t)8));
   memcpy(&key[8], mac_addr, 6);
@@ -364,9 +358,8 @@ static inline void switchlink_db_hash_mac_key(switchlink_mac_addr_t mac_addr,
  * Return Values:
  *    void
  */
-static inline void switchlink_db_hash_mac_lag_key(switchlink_mac_addr_t mac_addr,
-                                              uint8_t *key,
-                                              uint32_t *hash) {
+static inline void switchlink_db_hash_mac_lag_key(
+    switchlink_mac_addr_t mac_addr, uint8_t* key, uint32_t* hash) {
   memset(key, 0, SWITCHLINK_MAC_KEY_LEN);
   memcpy(&key[8], mac_addr, 6);
   if (hash) {
@@ -376,7 +369,7 @@ static inline void switchlink_db_hash_mac_lag_key(switchlink_mac_addr_t mac_addr
 
 /*
  * Routine Description:
- *    Compare the mac address with the one in database 
+ *    Compare the mac address with the one in database
  *
  * Arguments:
  *    [in] mac_addr - MAC address
@@ -390,8 +383,8 @@ static inline void switchlink_db_hash_mac_lag_key(switchlink_mac_addr_t mac_addr
  *    < 1 if key1 is smaller than key2
  */
 
-static inline int switchlink_db_cmp_mac(const void *key1, const void *arg) {
-  switchlink_db_mac_obj_t *obj = (switchlink_db_mac_obj_t *)arg;
+static inline int switchlink_db_cmp_mac(const void* key1, const void* arg) {
+  switchlink_db_mac_obj_t* obj = (switchlink_db_mac_obj_t*)arg;
   uint8_t key2[SWITCHLINK_MAC_KEY_LEN];
 
   switchlink_db_hash_mac_key(obj->addr, obj->bridge_h, key2, NULL);
@@ -413,8 +406,8 @@ static inline int switchlink_db_cmp_mac(const void *key1, const void *arg) {
  *    < 1 if key1 is smaller than key2
  */
 
-static inline int switchlink_db_cmp_lag_mac(const void *key1, const void *arg) {
-  switchlink_db_mac_obj_t *obj = (switchlink_db_mac_obj_t *)arg;
+static inline int switchlink_db_cmp_lag_mac(const void* key1, const void* arg) {
+  switchlink_db_mac_obj_t* obj = (switchlink_db_mac_obj_t*)arg;
   uint8_t key2[SWITCHLINK_MAC_KEY_LEN];
 
   switchlink_db_hash_mac_lag_key(obj->addr, key2, NULL);
@@ -437,7 +430,7 @@ static inline int switchlink_db_cmp_lag_mac(const void *key1, const void *arg) {
 switchlink_db_status_t switchlink_db_add_mac(switchlink_mac_addr_t mac_addr,
                                              switchlink_handle_t bridge_h,
                                              switchlink_handle_t intf_h) {
-  switchlink_db_mac_obj_t *obj =
+  switchlink_db_mac_obj_t* obj =
       switchlink_malloc(sizeof(switchlink_db_mac_obj_t), 1);
   krnlmon_assert(obj != NULL);
   memcpy(obj->addr, mac_addr, sizeof(switchlink_mac_addr_t));
@@ -466,8 +459,8 @@ switchlink_db_status_t switchlink_db_add_mac(switchlink_mac_addr_t mac_addr,
  */
 
 switchlink_db_status_t switchlink_db_add_mac_lag(switchlink_mac_addr_t mac_addr,
-                                             switchlink_handle_t lag_h) {
-  switchlink_db_mac_lag_obj_t *obj =
+                                                 switchlink_handle_t lag_h) {
+  switchlink_db_mac_lag_obj_t* obj =
       switchlink_malloc(sizeof(switchlink_db_mac_lag_obj_t), 1);
   krnlmon_assert(obj != NULL);
   memcpy(obj->addr, mac_addr, sizeof(switchlink_mac_addr_t));
@@ -476,7 +469,8 @@ switchlink_db_status_t switchlink_db_add_mac_lag(switchlink_mac_addr_t mac_addr,
   uint32_t hash;
   uint8_t key[SWITCHLINK_MAC_KEY_LEN];
   switchlink_db_hash_mac_lag_key(mac_addr, key, &hash);
-  tommy_hashlin_insert(&switchlink_db_mac_lag_obj_hash, &obj->hash_node, obj, hash);
+  tommy_hashlin_insert(&switchlink_db_mac_lag_obj_hash, &obj->hash_node, obj,
+                       hash);
   tommy_list_insert_tail(&switchlink_db_mac_lag_obj_list, &obj->list_node, obj);
   return SWITCHLINK_DB_STATUS_SUCCESS;
 }
@@ -496,16 +490,15 @@ switchlink_db_status_t switchlink_db_add_mac_lag(switchlink_mac_addr_t mac_addr,
  */
 
 switchlink_db_status_t switchlink_db_get_mac_intf(
-    switchlink_mac_addr_t mac_addr,
-    switchlink_handle_t bridge_h,
-    switchlink_handle_t *intf_h) {
-  switchlink_db_mac_obj_t *obj;
+    switchlink_mac_addr_t mac_addr, switchlink_handle_t bridge_h,
+    switchlink_handle_t* intf_h) {
+  switchlink_db_mac_obj_t* obj;
   uint32_t hash;
   uint8_t key[SWITCHLINK_MAC_KEY_LEN];
   switchlink_db_hash_mac_key(mac_addr, bridge_h, key, &hash);
 
-  obj = tommy_hashlin_search(
-      &switchlink_db_mac_obj_hash, switchlink_db_cmp_mac, key, hash);
+  obj = tommy_hashlin_search(&switchlink_db_mac_obj_hash, switchlink_db_cmp_mac,
+                             key, hash);
   if (!obj) {
     return SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND;
   }
@@ -526,15 +519,14 @@ switchlink_db_status_t switchlink_db_get_mac_intf(
  *    SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND otherwise
  */
 switchlink_db_status_t switchlink_db_get_mac_lag_handle(
-    switchlink_mac_addr_t mac_addr,
-    switchlink_handle_t *lag_h) {
-  switchlink_db_mac_lag_obj_t *obj;
+    switchlink_mac_addr_t mac_addr, switchlink_handle_t* lag_h) {
+  switchlink_db_mac_lag_obj_t* obj;
   uint32_t hash;
   uint8_t key[SWITCHLINK_MAC_KEY_LEN];
   switchlink_db_hash_mac_lag_key(mac_addr, key, &hash);
 
-  obj = tommy_hashlin_search(
-      &switchlink_db_mac_lag_obj_hash, switchlink_db_cmp_lag_mac, key, hash);
+  obj = tommy_hashlin_search(&switchlink_db_mac_lag_obj_hash,
+                             switchlink_db_cmp_lag_mac, key, hash);
   if (!obj) {
     return SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND;
   }
@@ -556,13 +548,13 @@ switchlink_db_status_t switchlink_db_get_mac_lag_handle(
 
 switchlink_db_status_t switchlink_db_delete_mac(switchlink_mac_addr_t mac_addr,
                                                 switchlink_handle_t bridge_h) {
-  switchlink_db_mac_obj_t *obj;
+  switchlink_db_mac_obj_t* obj;
   uint32_t hash;
   uint8_t key[SWITCHLINK_MAC_KEY_LEN];
   switchlink_db_hash_mac_key(mac_addr, bridge_h, key, &hash);
 
-  obj = tommy_hashlin_search(
-      &switchlink_db_mac_obj_hash, switchlink_db_cmp_mac, key, hash);
+  obj = tommy_hashlin_search(&switchlink_db_mac_obj_hash, switchlink_db_cmp_mac,
+                             key, hash);
   if (!obj) {
     return SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND;
   }
@@ -583,18 +575,20 @@ switchlink_db_status_t switchlink_db_delete_mac(switchlink_mac_addr_t mac_addr,
  *    SWITCHLINK_DB_STATUS_SUCCESS on success
  *    SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND otherwise
  */
-switchlink_db_status_t switchlink_db_delete_mac_lag(switchlink_mac_addr_t mac_addr) {
-  switchlink_db_mac_obj_t *obj;
+switchlink_db_status_t switchlink_db_delete_mac_lag(
+    switchlink_mac_addr_t mac_addr) {
+  switchlink_db_mac_obj_t* obj;
   uint32_t hash;
   uint8_t key[SWITCHLINK_MAC_KEY_LEN];
   switchlink_db_hash_mac_lag_key(mac_addr, key, &hash);
 
-  obj = tommy_hashlin_search(
-      &switchlink_db_mac_lag_obj_hash, switchlink_db_cmp_lag_mac, key, hash);
+  obj = tommy_hashlin_search(&switchlink_db_mac_lag_obj_hash,
+                             switchlink_db_cmp_lag_mac, key, hash);
   if (!obj) {
     return SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND;
   }
-  tommy_hashlin_remove_existing(&switchlink_db_mac_lag_obj_hash, &obj->hash_node);
+  tommy_hashlin_remove_existing(&switchlink_db_mac_lag_obj_hash,
+                                &obj->hash_node);
   tommy_list_remove_existing(&switchlink_db_mac_lag_obj_list, &obj->list_node);
   switchlink_free(obj);
   return SWITCHLINK_DB_STATUS_SUCCESS;
@@ -613,9 +607,9 @@ switchlink_db_status_t switchlink_db_delete_mac_lag(switchlink_mac_addr_t mac_ad
  */
 
 switchlink_db_status_t switchlink_db_add_neighbor(
-    switchlink_db_neigh_info_t *neigh_info) {
+    switchlink_db_neigh_info_t* neigh_info) {
   krnlmon_assert(neigh_info != NULL);
-  switchlink_db_neigh_obj_t *obj =
+  switchlink_db_neigh_obj_t* obj =
       switchlink_malloc(sizeof(switchlink_db_neigh_obj_t), 1);
   krnlmon_assert(obj != NULL);
   memcpy(&(obj->neigh_info), neigh_info, sizeof(switchlink_db_neigh_info_t));
@@ -636,20 +630,19 @@ switchlink_db_status_t switchlink_db_add_neighbor(
  */
 
 switchlink_db_status_t switchlink_db_get_neighbor_info(
-    switchlink_db_neigh_info_t *neigh_info) {
+    switchlink_db_neigh_info_t* neigh_info) {
   krnlmon_assert(neigh_info != NULL);
-  tommy_node *node = tommy_list_head(&switchlink_db_neigh_obj_list);
+  tommy_node* node = tommy_list_head(&switchlink_db_neigh_obj_list);
   while (node) {
-    switchlink_db_neigh_obj_t *obj = node->data;
+    switchlink_db_neigh_obj_t* obj = node->data;
     krnlmon_assert(obj != NULL);
     node = node->next;
-    if ((memcmp(&(neigh_info->ip_addr),
-                &(obj->neigh_info.ip_addr),
+    if ((memcmp(&(neigh_info->ip_addr), &(obj->neigh_info.ip_addr),
                 sizeof(switchlink_ip_addr_t)) == 0) &&
         (neigh_info->vrf_h == obj->neigh_info.vrf_h) &&
         (neigh_info->intf_h == obj->neigh_info.intf_h)) {
-      memcpy(
-          neigh_info, &(obj->neigh_info), sizeof(switchlink_db_neigh_info_t));
+      memcpy(neigh_info, &(obj->neigh_info),
+             sizeof(switchlink_db_neigh_info_t));
       return SWITCHLINK_DB_STATUS_SUCCESS;
     }
   }
@@ -669,15 +662,14 @@ switchlink_db_status_t switchlink_db_get_neighbor_info(
  */
 
 switchlink_db_status_t switchlink_db_delete_neighbor(
-    switchlink_db_neigh_info_t *neigh_info) {
+    switchlink_db_neigh_info_t* neigh_info) {
   krnlmon_assert(neigh_info != NULL);
-  tommy_node *node = tommy_list_head(&switchlink_db_neigh_obj_list);
+  tommy_node* node = tommy_list_head(&switchlink_db_neigh_obj_list);
   while (node) {
-    switchlink_db_neigh_obj_t *obj = node->data;
+    switchlink_db_neigh_obj_t* obj = node->data;
     krnlmon_assert(obj != NULL);
     node = node->next;
-    if ((memcmp(&(neigh_info->ip_addr),
-                &(obj->neigh_info.ip_addr),
+    if ((memcmp(&(neigh_info->ip_addr), &(obj->neigh_info.ip_addr),
                 sizeof(switchlink_ip_addr_t)) == 0) &&
         (neigh_info->intf_h == obj->neigh_info.intf_h)) {
       tommy_list_remove_existing(&switchlink_db_neigh_obj_list,
@@ -702,9 +694,9 @@ switchlink_db_status_t switchlink_db_delete_neighbor(
  */
 
 switchlink_db_status_t switchlink_db_add_nexthop(
-    switchlink_db_nexthop_info_t *nexthop_info) {
+    switchlink_db_nexthop_info_t* nexthop_info) {
   krnlmon_assert(nexthop_info != NULL);
-  switchlink_db_nexthop_obj_t *obj =
+  switchlink_db_nexthop_obj_t* obj =
       switchlink_malloc(sizeof(switchlink_db_nexthop_obj_t), 1);
   krnlmon_assert(obj != NULL);
   memcpy(&(obj->nexthop_info), nexthop_info,
@@ -726,20 +718,19 @@ switchlink_db_status_t switchlink_db_add_nexthop(
  */
 
 switchlink_db_status_t switchlink_db_get_nexthop_info(
-    switchlink_db_nexthop_info_t *nexthop_info) {
+    switchlink_db_nexthop_info_t* nexthop_info) {
   krnlmon_assert(nexthop_info != NULL);
-  tommy_node *node = tommy_list_head(&switchlink_db_nexthop_obj_list);
+  tommy_node* node = tommy_list_head(&switchlink_db_nexthop_obj_list);
   while (node) {
-    switchlink_db_nexthop_obj_t *obj = node->data;
+    switchlink_db_nexthop_obj_t* obj = node->data;
     krnlmon_assert(obj != NULL);
     node = node->next;
-    if ((memcmp(&(nexthop_info->ip_addr),
-                &(obj->nexthop_info.ip_addr),
+    if ((memcmp(&(nexthop_info->ip_addr), &(obj->nexthop_info.ip_addr),
                 sizeof(switchlink_ip_addr_t)) == 0) &&
         (nexthop_info->vrf_h == obj->nexthop_info.vrf_h) &&
         (nexthop_info->intf_h == obj->nexthop_info.intf_h)) {
-        memcpy(nexthop_info, &(obj->nexthop_info),
-               sizeof(switchlink_db_nexthop_info_t));
+      memcpy(nexthop_info, &(obj->nexthop_info),
+             sizeof(switchlink_db_nexthop_info_t));
       return SWITCHLINK_DB_STATUS_SUCCESS;
     }
   }
@@ -758,19 +749,18 @@ switchlink_db_status_t switchlink_db_get_nexthop_info(
  *    SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND otherwise
  */
 switchlink_db_status_t switchlink_db_update_nexthop_using_by(
-    switchlink_db_nexthop_info_t *nexthop_info) {
+    switchlink_db_nexthop_info_t* nexthop_info) {
   krnlmon_assert(nexthop_info != NULL);
-  tommy_node *node = tommy_list_head(&switchlink_db_nexthop_obj_list);
+  tommy_node* node = tommy_list_head(&switchlink_db_nexthop_obj_list);
   while (node) {
-    switchlink_db_nexthop_obj_t *obj = node->data;
+    switchlink_db_nexthop_obj_t* obj = node->data;
     krnlmon_assert(obj != NULL);
     node = node->next;
-    if ((memcmp(&(nexthop_info->ip_addr),
-                &(obj->nexthop_info.ip_addr),
+    if ((memcmp(&(nexthop_info->ip_addr), &(obj->nexthop_info.ip_addr),
                 sizeof(switchlink_ip_addr_t)) == 0) &&
         (nexthop_info->vrf_h == obj->nexthop_info.vrf_h) &&
         (nexthop_info->intf_h == obj->nexthop_info.intf_h)) {
-        obj->nexthop_info.using_by = nexthop_info->using_by;
+      obj->nexthop_info.using_by = nexthop_info->using_by;
       return SWITCHLINK_DB_STATUS_SUCCESS;
     }
   }
@@ -792,10 +782,10 @@ switchlink_db_status_t switchlink_db_update_nexthop_using_by(
  */
 
 switchlink_db_status_t switchlink_db_get_nexthop_handle_info(
-    switchlink_handle_t nhop_h, switchlink_db_nexthop_info_t *nexthop_info) {
-  tommy_node *node = tommy_list_head(&switchlink_db_nexthop_obj_list);
+    switchlink_handle_t nhop_h, switchlink_db_nexthop_info_t* nexthop_info) {
+  tommy_node* node = tommy_list_head(&switchlink_db_nexthop_obj_list);
   while (node) {
-    switchlink_db_nexthop_obj_t *obj = node->data;
+    switchlink_db_nexthop_obj_t* obj = node->data;
     krnlmon_assert(obj != NULL);
     node = node->next;
     if (nhop_h == obj->nexthop_info.nhop_h) {
@@ -822,15 +812,14 @@ switchlink_db_status_t switchlink_db_get_nexthop_handle_info(
  */
 
 switchlink_db_status_t switchlink_db_delete_nexthop(
-    switchlink_db_nexthop_info_t *nexthop_info) {
+    switchlink_db_nexthop_info_t* nexthop_info) {
   krnlmon_assert(nexthop_info != NULL);
-  tommy_node *node = tommy_list_head(&switchlink_db_nexthop_obj_list);
+  tommy_node* node = tommy_list_head(&switchlink_db_nexthop_obj_list);
   while (node) {
-    switchlink_db_nexthop_obj_t *obj = node->data;
+    switchlink_db_nexthop_obj_t* obj = node->data;
     krnlmon_assert(obj != NULL);
     node = node->next;
-    if ((memcmp(&(nexthop_info->ip_addr),
-                &(obj->nexthop_info.ip_addr),
+    if ((memcmp(&(nexthop_info->ip_addr), &(obj->nexthop_info.ip_addr),
                 sizeof(switchlink_ip_addr_t)) == 0) &&
         (nexthop_info->intf_h == obj->nexthop_info.intf_h)) {
       tommy_list_remove_existing(&switchlink_db_nexthop_obj_list,
@@ -841,7 +830,6 @@ switchlink_db_status_t switchlink_db_delete_nexthop(
   }
   return SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND;
 }
-
 
 /*
  * Routine Description:
@@ -855,19 +843,17 @@ switchlink_db_status_t switchlink_db_delete_nexthop(
  */
 
 switchlink_db_status_t switchlink_db_add_ecmp(
-    switchlink_db_ecmp_info_t *ecmp_info) {
+    switchlink_db_ecmp_info_t* ecmp_info) {
   krnlmon_assert(ecmp_info != NULL);
   krnlmon_assert(ecmp_info->num_nhops < SWITCHLINK_ECMP_NUM_MEMBERS_MAX);
-  switchlink_db_ecmp_obj_t *obj =
+  switchlink_db_ecmp_obj_t* obj =
       switchlink_malloc(sizeof(switchlink_db_ecmp_obj_t), 1);
   krnlmon_assert(obj != NULL);
   memcpy(&(obj->ecmp_info), ecmp_info, sizeof(switchlink_db_ecmp_info_t));
   obj->ref_count = 0;
   tommy_list_insert_tail(&switchlink_db_ecmp_obj_list, &obj->list_node, obj);
-  tommy_trie_inplace_insert(&switchlink_db_handle_obj_map,
-                            &obj->handle_node,
-                            obj,
-                            obj->ecmp_info.ecmp_h);
+  tommy_trie_inplace_insert(&switchlink_db_handle_obj_map, &obj->handle_node,
+                            obj, obj->ecmp_info.ecmp_h);
   return SWITCHLINK_DB_STATUS_SUCCESS;
 }
 
@@ -884,11 +870,11 @@ switchlink_db_status_t switchlink_db_add_ecmp(
  */
 
 switchlink_db_status_t switchlink_db_get_ecmp_info(
-    switchlink_db_ecmp_info_t *ecmp_info) {
+    switchlink_db_ecmp_info_t* ecmp_info) {
   krnlmon_assert(ecmp_info != NULL);
-  tommy_node *node = tommy_list_head(&switchlink_db_ecmp_obj_list);
+  tommy_node* node = tommy_list_head(&switchlink_db_ecmp_obj_list);
   while (node) {
-    switchlink_db_ecmp_obj_t *obj = node->data;
+    switchlink_db_ecmp_obj_t* obj = node->data;
     krnlmon_assert(obj != NULL);
     node = node->next;
     if (obj->ecmp_info.num_nhops == ecmp_info->num_nhops) {
@@ -926,9 +912,9 @@ switchlink_db_status_t switchlink_db_get_ecmp_info(
  */
 
 switchlink_db_status_t switchlink_db_ecmp_handle_get_info(
-    switchlink_handle_t ecmp_h, switchlink_db_ecmp_info_t *ecmp_info) {
+    switchlink_handle_t ecmp_h, switchlink_db_ecmp_info_t* ecmp_info) {
   krnlmon_assert(ecmp_info != NULL);
-  switchlink_db_ecmp_obj_t *obj;
+  switchlink_db_ecmp_obj_t* obj;
   obj = switchlink_db_get_handle_obj(ecmp_h);
   if (!obj) {
     return SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND;
@@ -950,7 +936,7 @@ switchlink_db_status_t switchlink_db_ecmp_handle_get_info(
  */
 
 switchlink_db_status_t switchlink_db_inc_ecmp_ref(switchlink_handle_t ecmp_h) {
-  switchlink_db_ecmp_obj_t *obj;
+  switchlink_db_ecmp_obj_t* obj;
   obj = switchlink_db_get_handle_obj(ecmp_h);
   if (!obj) {
     return SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND;
@@ -974,8 +960,8 @@ switchlink_db_status_t switchlink_db_inc_ecmp_ref(switchlink_handle_t ecmp_h) {
  */
 
 switchlink_db_status_t switchlink_db_dec_ecmp_ref(switchlink_handle_t ecmp_h,
-                                                  int *ref_count) {
-  switchlink_db_ecmp_obj_t *obj;
+                                                  int* ref_count) {
+  switchlink_db_ecmp_obj_t* obj;
   obj = switchlink_db_get_handle_obj(ecmp_h);
   if (!obj) {
     return SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND;
@@ -1001,7 +987,7 @@ switchlink_db_status_t switchlink_db_dec_ecmp_ref(switchlink_handle_t ecmp_h,
  */
 
 switchlink_db_status_t switchlink_db_delete_ecmp(switchlink_handle_t ecmp_h) {
-  switchlink_db_ecmp_obj_t *obj;
+  switchlink_db_ecmp_obj_t* obj;
   obj = switchlink_db_get_handle_obj(ecmp_h);
   if (!obj) {
     return SWITCHLINK_DB_STATUS_ITEM_NOT_FOUND;
@@ -1026,9 +1012,9 @@ switchlink_db_status_t switchlink_db_delete_ecmp(switchlink_handle_t ecmp_h) {
  */
 
 switchlink_db_status_t switchlink_db_add_route(
-    switchlink_db_route_info_t *route_info) {
+    switchlink_db_route_info_t* route_info) {
   krnlmon_assert(route_info != NULL);
-  switchlink_db_route_obj_t *obj =
+  switchlink_db_route_obj_t* obj =
       switchlink_malloc(sizeof(switchlink_db_route_obj_t), 1);
   krnlmon_assert(obj != NULL);
   memcpy(&(obj->route_info), route_info, sizeof(switchlink_db_route_info_t));
@@ -1049,16 +1035,15 @@ switchlink_db_status_t switchlink_db_add_route(
  */
 
 switchlink_db_status_t switchlink_db_delete_route(
-    switchlink_db_route_info_t *route_info) {
+    switchlink_db_route_info_t* route_info) {
   krnlmon_assert(route_info != NULL);
-  tommy_node *node = tommy_list_head(&switchlink_db_route_obj_list);
+  tommy_node* node = tommy_list_head(&switchlink_db_route_obj_list);
   while (node) {
-    switchlink_db_route_obj_t *obj = node->data;
+    switchlink_db_route_obj_t* obj = node->data;
     krnlmon_assert(obj != NULL);
     node = node->next;
     if ((obj->route_info.vrf_h == route_info->vrf_h) &&
-        (memcmp(&(obj->route_info.ip_addr),
-                &(route_info->ip_addr),
+        (memcmp(&(obj->route_info.ip_addr), &(route_info->ip_addr),
                 sizeof(switchlink_ip_addr_t)) == 0)) {
       tommy_list_remove_existing(&switchlink_db_route_obj_list,
                                  &obj->list_node);
@@ -1082,19 +1067,18 @@ switchlink_db_status_t switchlink_db_delete_route(
  */
 
 switchlink_db_status_t switchlink_db_get_route_info(
-    switchlink_db_route_info_t *route_info) {
+    switchlink_db_route_info_t* route_info) {
   krnlmon_assert(route_info != NULL);
-  tommy_node *node = tommy_list_head(&switchlink_db_route_obj_list);
+  tommy_node* node = tommy_list_head(&switchlink_db_route_obj_list);
   while (node) {
-    switchlink_db_route_obj_t *obj = node->data;
+    switchlink_db_route_obj_t* obj = node->data;
     krnlmon_assert(obj != NULL);
     node = node->next;
     if ((obj->route_info.vrf_h == route_info->vrf_h) &&
-        (memcmp(&(obj->route_info.ip_addr),
-                &(route_info->ip_addr),
+        (memcmp(&(obj->route_info.ip_addr), &(route_info->ip_addr),
                 sizeof(switchlink_ip_addr_t)) == 0)) {
-      memcpy(
-          route_info, &(obj->route_info), sizeof(switchlink_db_route_info_t));
+      memcpy(route_info, &(obj->route_info),
+             sizeof(switchlink_db_route_info_t));
       return SWITCHLINK_DB_STATUS_SUCCESS;
     }
   }

--- a/switchlink/switchlink_db.h
+++ b/switchlink/switchlink_db.h
@@ -19,6 +19,7 @@
 #define __SWITCHLINK_DB_H__
 
 #include <stdbool.h>
+
 #include "switchlink.h"
 #include "switchlink_link.h"
 
@@ -36,9 +37,9 @@ typedef struct switchlink_db_tuntap_info_ {
   switchlink_handle_t tunp_h;
   switchlink_mac_addr_t mac_addr;
   switchlink_link_type_t link_type;
-  //struct tuntap_flags {
-    //bool <?>_enabled;
-    //uint8_t <?>_mode;
+  // struct tuntap_flags {
+  // bool <?>_enabled;
+  // uint8_t <?>_mode;
   //} flags;
 } switchlink_db_tuntap_info_t;
 
@@ -140,116 +141,112 @@ typedef struct switchlink_db_lag_member_info_ {
 
 /*** interface ***/
 extern switchlink_db_status_t switchlink_db_add_interface(
-    uint32_t ifindex, switchlink_db_interface_info_t *intf_info);
+    uint32_t ifindex, switchlink_db_interface_info_t* intf_info);
 
 extern switchlink_db_status_t switchlink_db_get_interface_info(
-    uint32_t ifindex, switchlink_db_interface_info_t *intf_info);
+    uint32_t ifindex, switchlink_db_interface_info_t* intf_info);
 
 extern switchlink_db_status_t switchlink_db_get_interface_ifindex(
-    switchlink_handle_t intf_h, uint32_t *ifindex);
+    switchlink_handle_t intf_h, uint32_t* ifindex);
 
 extern switchlink_db_status_t switchlink_db_update_interface(
-    uint32_t ifindex, switchlink_db_interface_info_t *intf_info);
+    uint32_t ifindex, switchlink_db_interface_info_t* intf_info);
 
 extern switchlink_db_status_t switchlink_db_delete_interface(uint32_t ifindex);
 
 /*** Tunnel ***/
 extern switchlink_db_status_t switchlink_db_add_tunnel_interface(
-    uint32_t ifindex, switchlink_db_tunnel_interface_info_t *tnl_intf_info);
+    uint32_t ifindex, switchlink_db_tunnel_interface_info_t* tnl_intf_info);
 
 extern switchlink_db_status_t switchlink_db_get_tunnel_interface_info(
-    uint32_t ifindex, switchlink_db_tunnel_interface_info_t *tunnel_intf_info);
+    uint32_t ifindex, switchlink_db_tunnel_interface_info_t* tunnel_intf_info);
 
 extern switchlink_db_status_t switchlink_db_delete_tunnel_interface(
     uint32_t ifindex);
 
 /*** mac ***/
 extern switchlink_db_status_t switchlink_db_add_mac(
-    switchlink_mac_addr_t mac_addr,
-    switchlink_handle_t bridge_h,
+    switchlink_mac_addr_t mac_addr, switchlink_handle_t bridge_h,
     switchlink_handle_t intf_h);
 
 extern switchlink_db_status_t switchlink_db_get_mac_intf(
-    switchlink_mac_addr_t mac_addr,
-    switchlink_handle_t bridge_h,
-    switchlink_handle_t *int_h);
+    switchlink_mac_addr_t mac_addr, switchlink_handle_t bridge_h,
+    switchlink_handle_t* int_h);
 
 extern switchlink_db_status_t switchlink_db_delete_mac(
     switchlink_mac_addr_t mac_addr, switchlink_handle_t bridge_h);
 
 /*** lag mac ***/
 extern switchlink_db_status_t switchlink_db_add_mac_lag(
-    switchlink_mac_addr_t mac_addr,
-    switchlink_handle_t lag_h);
+    switchlink_mac_addr_t mac_addr, switchlink_handle_t lag_h);
 
 extern switchlink_db_status_t switchlink_db_get_mac_lag_handle(
-    switchlink_mac_addr_t mac_addr,
-    switchlink_handle_t *lag_h);
+    switchlink_mac_addr_t mac_addr, switchlink_handle_t* lag_h);
 
 extern switchlink_db_status_t switchlink_db_delete_mac_lag(
     switchlink_mac_addr_t mac_addr);
 
 /*** neighbor ***/
 extern switchlink_db_status_t switchlink_db_add_neighbor(
-    switchlink_db_neigh_info_t *neigh_info);
+    switchlink_db_neigh_info_t* neigh_info);
 
 extern switchlink_db_status_t switchlink_db_delete_neighbor(
-    switchlink_db_neigh_info_t *neigh_info);
+    switchlink_db_neigh_info_t* neigh_info);
 
 extern switchlink_db_status_t switchlink_db_get_neighbor_info(
-    switchlink_db_neigh_info_t *neigh_info);
+    switchlink_db_neigh_info_t* neigh_info);
 
 /*** nexthop ***/
 extern switchlink_db_status_t switchlink_db_add_nexthop(
-    switchlink_db_nexthop_info_t *nexthop_info);
+    switchlink_db_nexthop_info_t* nexthop_info);
 
 extern switchlink_db_status_t switchlink_db_delete_nexthop(
-    switchlink_db_nexthop_info_t *nexthop_info);
+    switchlink_db_nexthop_info_t* nexthop_info);
 
 extern switchlink_db_status_t switchlink_db_get_nexthop_info(
-    switchlink_db_nexthop_info_t *nexthop_info);
+    switchlink_db_nexthop_info_t* nexthop_info);
 
 extern switchlink_db_status_t switchlink_db_update_nexthop_using_by(
-    switchlink_db_nexthop_info_t *nexthop_info);
+    switchlink_db_nexthop_info_t* nexthop_info);
 
 extern switchlink_db_status_t switchlink_db_get_nexthop_handle_info(
-    switchlink_handle_t nhop_h, switchlink_db_nexthop_info_t *nexthop_info);
+    switchlink_handle_t nhop_h, switchlink_db_nexthop_info_t* nexthop_info);
 
 /*** ecmp ***/
 extern switchlink_db_status_t switchlink_db_add_ecmp(
-    switchlink_db_ecmp_info_t *ecmp_info);
+    switchlink_db_ecmp_info_t* ecmp_info);
 
 extern switchlink_db_status_t switchlink_db_get_ecmp_info(
-    switchlink_db_ecmp_info_t *ecmp_info);
+    switchlink_db_ecmp_info_t* ecmp_info);
 
 extern switchlink_db_status_t switchlink_db_ecmp_handle_get_info(
-    switchlink_handle_t ecmp_h, switchlink_db_ecmp_info_t *ecmp_info);
+    switchlink_handle_t ecmp_h, switchlink_db_ecmp_info_t* ecmp_info);
 
 extern switchlink_db_status_t switchlink_db_inc_ecmp_ref(
     switchlink_handle_t ecmp_h);
 
 extern switchlink_db_status_t switchlink_db_dec_ecmp_ref(
-    switchlink_handle_t ecmp_h, int *ref_count);
+    switchlink_handle_t ecmp_h, int* ref_count);
 
 extern switchlink_db_status_t switchlink_db_delete_ecmp(
     switchlink_handle_t ecmp_h);
 
 /*** route ***/
 extern switchlink_db_status_t switchlink_db_add_route(
-    switchlink_db_route_info_t *route_info);
+    switchlink_db_route_info_t* route_info);
 
 extern switchlink_db_status_t switchlink_db_delete_route(
-    switchlink_db_route_info_t *route_info);
+    switchlink_db_route_info_t* route_info);
 
 extern switchlink_db_status_t switchlink_db_get_route_info(
-    switchlink_db_route_info_t *route_info);
+    switchlink_db_route_info_t* route_info);
 
 /*** Tuntap entry ***/
 extern switchlink_db_status_t switchlink_db_add_tuntap(
-    uint32_t ifindex, switchlink_db_tuntap_info_t *tunp_info);
+    uint32_t ifindex, switchlink_db_tuntap_info_t* tunp_info);
 
 extern switchlink_db_status_t switchlink_db_get_tuntap_info(
-    uint32_t ifindex, switchlink_db_tuntap_info_t *tunp_info);
+    uint32_t ifindex, switchlink_db_tuntap_info_t* tunp_info);
 
 /*** LAG ***/
 extern switchlink_handle_t switchlink_db_get_lag_handle(

--- a/switchlink/switchlink_db.h
+++ b/switchlink/switchlink_db.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchlink/switchlink_db_int.h
+++ b/switchlink/switchlink_db_int.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,10 @@
 
 #ifndef __SWITCHLINK_DB_INT_H__
 #define __SWITCHLINK_DB_INT_H__
+
+#include "tommyds/tommyhashlin.h"
+#include "tommyds/tommylist.h"
+#include "tommyds/tommytrieinp.h"
 
 #define min(a, b)           \
   ({                        \

--- a/switchlink/switchlink_db_int.h
+++ b/switchlink/switchlink_db_int.h
@@ -71,7 +71,6 @@ typedef struct switchlink_db_nexthop_obj_ {
   switchlink_db_nexthop_info_t nexthop_info;
 } switchlink_db_nexthop_obj_t;
 
-
 typedef struct switchlink_db_ecmp_obj_ {
   tommy_node list_node;
   int32_t ref_count;

--- a/switchlink/switchlink_globals.c
+++ b/switchlink/switchlink_globals.c
@@ -8,4 +8,3 @@
 switchlink_handle_t g_default_vrf_h = 0;
 switchlink_handle_t g_default_bridge_h = 0;
 switchlink_handle_t g_cpu_rx_nhop_h = 0;
-

--- a/switchlink/switchlink_handle.h
+++ b/switchlink/switchlink_handle.h
@@ -15,16 +15,15 @@
  * limitations under the License.
  */
 
-
 #ifndef __SWITCHLINK_ANALYZE_H__
 #define __SWITCHLINK_ANALYZE_H__
 
-#include <stdint.h>
-#include <stdbool.h>
 #include <netlink/msg.h>
 #include <netlink/netlink.h>
-#include <netlink/route/nexthop.h>
 #include <netlink/route/neighbour.h>
+#include <netlink/route/nexthop.h>
+#include <stdbool.h>
+#include <stdint.h>
 
 #include "switchlink/switchlink.h"
 #include "switchlink/switchlink_db.h"
@@ -33,27 +32,27 @@ extern void switchlink_init_api(void);
 
 // SWITCHLINK_LINK_TYPE_VXLAN handlers
 extern void switchlink_create_tunnel_interface(
-         switchlink_db_tunnel_interface_info_t *tnl_intf);
+    switchlink_db_tunnel_interface_info_t* tnl_intf);
 extern void switchlink_delete_tunnel_interface(uint32_t ifindex);
 
 // SWITCHLINK_LINK_TYPE_BOND handlers
 extern void switchlink_create_lag(switchlink_db_interface_info_t* lag_info);
 extern void switchlink_delete_lag(uint32_t ifindex);
-extern void switchlink_create_lag_member(switchlink_db_lag_member_info_t* lag_member_info);
+extern void switchlink_create_lag_member(
+    switchlink_db_lag_member_info_t* lag_member_info);
 extern void switchlink_delete_lag_member(uint32_t ifindex);
 
 // SWITCHLINK_LINK_TYPE_TUN handlers
-extern void switchlink_create_interface(switchlink_db_interface_info_t *intf);
+extern void switchlink_create_interface(switchlink_db_interface_info_t* intf);
 extern void switchlink_delete_interface(uint32_t ifindex);
-
 
 // RTM_NEWNEIGH/ RTM_DELNEIGH handlers
 extern void switchlink_create_neigh(switchlink_handle_t vrf_h,
-                                    const switchlink_ip_addr_t *ipaddr,
+                                    const switchlink_ip_addr_t* ipaddr,
                                     switchlink_mac_addr_t mac_addr,
                                     switchlink_handle_t intf_h);
 extern void switchlink_delete_neigh(switchlink_handle_t vrf_h,
-                                    const switchlink_ip_addr_t *ipaddr,
+                                    const switchlink_ip_addr_t* ipaddr,
                                     switchlink_handle_t intf_h);
 extern void switchlink_create_mac(switchlink_mac_addr_t mac_addr,
                                   switchlink_handle_t bridge_h,
@@ -62,29 +61,28 @@ extern void switchlink_delete_mac(switchlink_mac_addr_t mac_addr,
                                   switchlink_handle_t bridge_h);
 
 // Nexthop handlers
-extern int 
-switchlink_create_nexthop(switchlink_db_nexthop_info_t *nexthop_info);
+extern int switchlink_create_nexthop(
+    switchlink_db_nexthop_info_t* nexthop_info);
 extern int switchlink_delete_nexthop(switchlink_handle_t nhop_h);
 
 // RTM_NEWROUTE/ RTM_DELROUTE handlers
 extern void switchlink_create_route(switchlink_handle_t vrf_h,
-                                    const switchlink_ip_addr_t *dst,
-                                    const switchlink_ip_addr_t *gateway,
+                                    const switchlink_ip_addr_t* dst,
+                                    const switchlink_ip_addr_t* gateway,
                                     switchlink_handle_t ecmp_h,
                                     switchlink_handle_t intf_h);
 extern void switchlink_delete_route(switchlink_handle_t vrf_h,
-                                    const switchlink_ip_addr_t *dst);
+                                    const switchlink_ip_addr_t* dst);
 
 // ECMP handlers
-extern int switchlink_create_ecmp(switchlink_db_ecmp_info_t *ecmp_info);
+extern int switchlink_create_ecmp(switchlink_db_ecmp_info_t* ecmp_info);
 extern void switchlink_delete_ecmp(switchlink_handle_t ecmp_h);
 
 // VRF handler
-extern int switchlink_create_vrf(switchlink_handle_t *vrf_h);
+extern int switchlink_create_vrf(switchlink_handle_t* vrf_h);
 
-//General utility function
-extern bool
-validate_delete_nexthop(uint32_t using_by,
-                        switchlink_nhop_using_by_e type);
+// General utility function
+extern bool validate_delete_nexthop(uint32_t using_by,
+                                    switchlink_nhop_using_by_e type);
 
 #endif /* __SWITCHLINK_ANALYZE_H__ */

--- a/switchlink/switchlink_handle.h
+++ b/switchlink/switchlink_handle.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,9 @@
  * limitations under the License.
  */
 
-#ifndef __SWITCHLINK_ANALYZE_H__
-#define __SWITCHLINK_ANALYZE_H__
+#ifndef __SWITCHLINK_HANDLE_H__
+#define __SWITCHLINK_HANDLE_H__
 
-#include <netlink/msg.h>
-#include <netlink/netlink.h>
-#include <netlink/route/neighbour.h>
-#include <netlink/route/nexthop.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -85,4 +81,4 @@ extern int switchlink_create_vrf(switchlink_handle_t* vrf_h);
 extern bool validate_delete_nexthop(uint32_t using_by,
                                     switchlink_nhop_using_by_e type);
 
-#endif /* __SWITCHLINK_ANALYZE_H__ */
+#endif /* __SWITCHLINK_HANDLE_H__ */

--- a/switchlink/switchlink_int.h
+++ b/switchlink/switchlink_int.h
@@ -25,13 +25,13 @@ extern void switchlink_init_db(void);
 extern void switchlink_init_api(void);
 extern void switchlink_init_link(void);
 
-extern void switchlink_process_link_msg(const struct nlmsghdr *nlmsg,
+extern void switchlink_process_link_msg(const struct nlmsghdr* nlmsg,
                                         int msgtype);
-extern void switchlink_process_neigh_msg(const struct nlmsghdr *nlmsg,
+extern void switchlink_process_neigh_msg(const struct nlmsghdr* nlmsg,
                                          int msgtype);
-extern void switchlink_process_address_msg(const struct nlmsghdr *nlmsg,
+extern void switchlink_process_address_msg(const struct nlmsghdr* nlmsg,
                                            int msgtype);
-extern void switchlink_process_route_msg(const struct nlmsghdr *nlmsg,
+extern void switchlink_process_route_msg(const struct nlmsghdr* nlmsg,
                                          int msgtype);
 
 #endif /* __SWITCHLINK_INT_H__ */

--- a/switchlink/switchlink_link.c
+++ b/switchlink/switchlink_link.c
@@ -23,6 +23,9 @@
 #include <linux/if.h>
 #include <linux/if_bridge.h>
 #include <linux/version.h>
+#include <netlink/attr.h>
+#include <netlink/msg.h>
+#include <netlink/netlink.h>
 #include <unistd.h>
 
 #include "switchlink.h"

--- a/switchlink/switchlink_link.h
+++ b/switchlink/switchlink_link.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchlink/switchlink_link_test.cc
+++ b/switchlink/switchlink_link_test.cc
@@ -74,7 +74,8 @@ std::vector<test_results> results(2);
 
 void switchlink_create_lag(switchlink_db_interface_info_t* lag_info) {}
 void switchlink_delete_lag(uint32_t ifindex) {}
-void switchlink_create_lag_member(switchlink_db_lag_member_info_t* lag_member_info) {}
+void switchlink_create_lag_member(
+    switchlink_db_lag_member_info_t* lag_member_info) {}
 void switchlink_delete_lag_member(uint32_t ifindex) {}
 
 void switchlink_create_interface(switchlink_db_interface_info_t* intf) {

--- a/switchlink/switchlink_main.c
+++ b/switchlink/switchlink_main.c
@@ -25,23 +25,22 @@
 #define _GNU_SOURCE
 #endif
 
-#include <assert.h>
-
 #include "switchlink_main.h"
 
-#include <stdint.h>
-#include <pthread.h>
-#include <fcntl.h>
+#include <assert.h>
 #include <errno.h>
-#include <unistd.h>
-#include <sys/select.h>
+#include <fcntl.h>
 #include <netlink/msg.h>
 #include <netlink/netlink.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <sys/select.h>
+#include <unistd.h>
 
 #include "switchlink.h"
 #include "switchlink_int.h"
 
-static struct nl_sock *g_nlsk = NULL;
+static struct nl_sock* g_nlsk = NULL;
 static pthread_t switchlink_thread;
 
 enum {
@@ -149,7 +148,7 @@ static void nl_sync_state(void) {
  *    void
  */
 
-static void nl_process_message(struct nlmsghdr *nlmsg) {
+static void nl_process_message(struct nlmsghdr* nlmsg) {
   /* TODO: P4OVS: Enabling callback for link msg type only and prints for
      few protocol families to avoid flood of messages. Enable, as needed.
   */
@@ -195,13 +194,14 @@ static void nl_process_message(struct nlmsghdr *nlmsg) {
       // P4-OVS comment nl_sync_state();
       break;
     default:
-      krnlmon_log_debug("Unknown netlink message(%d). Ignoring\n", nlmsg->nlmsg_type);
+      krnlmon_log_debug("Unknown netlink message(%d). Ignoring\n",
+                        nlmsg->nlmsg_type);
       break;
   }
 }
 
-static int nl_recv_sock_msg(struct nl_msg *msg, void *arg) {
-  struct nlmsghdr *nl_msg = nlmsg_hdr(msg);
+static int nl_recv_sock_msg(struct nl_msg* msg, void* arg) {
+  struct nlmsghdr* nl_msg = nlmsg_hdr(msg);
   int nl_msg_sz = nlmsg_get_max_size(msg);
   while (nlmsg_ok(nl_msg, nl_msg_sz)) {
     nl_process_message(nl_msg);
@@ -233,10 +233,10 @@ static void switchlink_nl_sock_intf_init(void) {
   nl_socket_disable_seq_check(g_nlsk);
 
   // set the callback function
-  nl_socket_modify_cb(
-      g_nlsk, NL_CB_VALID, NL_CB_CUSTOM, nl_recv_sock_msg, NULL);
-  nl_socket_modify_cb(
-      g_nlsk, NL_CB_FINISH, NL_CB_CUSTOM, nl_recv_sock_msg, NULL);
+  nl_socket_modify_cb(g_nlsk, NL_CB_VALID, NL_CB_CUSTOM, nl_recv_sock_msg,
+                      NULL);
+  nl_socket_modify_cb(g_nlsk, NL_CB_FINISH, NL_CB_CUSTOM, nl_recv_sock_msg,
+                      NULL);
 
   // connect to the netlink route socket
   if (nl_connect(g_nlsk, NETLINK_ROUTE) < 0) {
@@ -253,8 +253,8 @@ static void switchlink_nl_sock_intf_init(void) {
   nl_socket_add_memberships(g_nlsk, RTNLGRP_IPV4_ROUTE, 0);
   nl_socket_add_memberships(g_nlsk, RTNLGRP_IPV6_IFADDR, 0);
   nl_socket_add_memberships(g_nlsk, RTNLGRP_IPV6_ROUTE, 0);
-  //nl_add_socket_memberships(g_nlsk, RTNLGRP_IPV4_RULE, 0);
-  //nl_add_socket_memberships(g_nlsk, RTNLGRP_IPV6_RULE, 0);
+  // nl_add_socket_memberships(g_nlsk, RTNLGRP_IPV4_RULE, 0);
+  // nl_add_socket_memberships(g_nlsk, RTNLGRP_IPV6_RULE, 0);
 
   // set socket to be non-blocking
   nlsk_fd = nl_socket_get_fd(g_nlsk);
@@ -294,11 +294,10 @@ static void nl_process_event_loop(void) {
       int err = errno;
 
       // This is not really an error condition. Ignore it.
-      if (err == EINTR)
-        continue;
+      if (err == EINTR) continue;
 
       krnlmon_log_critical("Error selecting event socket: %s",
-                            strerror_r(err, errbuf, sizeof(errbuf)));
+                           strerror_r(err, errbuf, sizeof(errbuf)));
       return;
     } else {
       if (FD_ISSET(nlsk_fd, &read_fds)) {
@@ -308,12 +307,12 @@ static void nl_process_event_loop(void) {
   }
 }
 
-struct nl_sock *switchlink_get_nl_sock(void) {
+struct nl_sock* switchlink_get_nl_sock(void) {
   return g_nlsk;
 }
 
 // start_routine if running in a thread
-void *switchlink_start(void *args) {
+void* switchlink_start(void* args) {
   (void)args;
   krnlmon_log_debug("switchlink main started");
   (void)switchlink_main();

--- a/switchlink/switchlink_main.h
+++ b/switchlink/switchlink_main.h
@@ -11,10 +11,10 @@ extern "C" {
 int switchlink_main(void);
 int switchlink_stop(void);
 
-void *switchlink_start(void *arg);
+void* switchlink_start(void* arg);
 
 #ifdef __cplusplus
-} // extern "C"
+}  // extern "C"
 #endif
 
 #endif /* _SWITCHLINK_MAIN_H_ */

--- a/switchlink/switchlink_neigh.c
+++ b/switchlink/switchlink_neigh.c
@@ -17,11 +17,12 @@
  * limitations under the License.
  */
 
+#include "switchlink_neigh.h"
+
 #include <linux/if_ether.h>
 #include <net/if.h>
 
 #include "switchlink.h"
-#include "switchlink_neigh.h"
 #include "switchlink_handle.h"
 
 /*
@@ -36,10 +37,10 @@
  *    void
  */
 
-void switchlink_process_neigh_msg(const struct nlmsghdr *nlmsg, int msgtype) {
+void switchlink_process_neigh_msg(const struct nlmsghdr* nlmsg, int msgtype) {
   int hdrlen, attrlen;
-  struct nlattr *attr;
-  struct ndmsg *nbh;
+  struct nlattr* attr;
+  struct ndmsg* nbh;
   switchlink_mac_addr_t mac_addr;
   bool mac_addr_valid = false;
   bool ipaddr_valid = false;
@@ -50,26 +51,26 @@ void switchlink_process_neigh_msg(const struct nlmsghdr *nlmsg, int msgtype) {
   nbh = nlmsg_data(nlmsg);
   hdrlen = sizeof(struct ndmsg);
 
-  krnlmon_log_debug("%sneigh: family = %d, ifindex = %d, state = 0x%x, \
+  krnlmon_log_debug(
+      "%sneigh: family = %d, ifindex = %d, state = 0x%x, \
        flags = 0x%x, type = %u\n",
-       ((msgtype == RTM_NEWNEIGH) ? "new" : "del"),
-       nbh->ndm_family,
-       nbh->ndm_ifindex,
-       nbh->ndm_state,
-       nbh->ndm_flags,
-       nbh->ndm_type);
+      ((msgtype == RTM_NEWNEIGH) ? "new" : "del"), nbh->ndm_family,
+      nbh->ndm_ifindex, nbh->ndm_state, nbh->ndm_flags, nbh->ndm_type);
 
   switchlink_db_interface_info_t ifinfo;
   if (switchlink_db_get_interface_info(nbh->ndm_ifindex, &ifinfo) !=
       SWITCHLINK_DB_STATUS_SUCCESS) {
     char intf_name[16] = {0};
     if (!if_indextoname(nbh->ndm_ifindex, intf_name)) {
-        krnlmon_log_error("Failed to get ifname for the index: %d", nbh->ndm_ifindex);
-        return;
+      krnlmon_log_error("Failed to get ifname for the index: %d",
+                        nbh->ndm_ifindex);
+      return;
     }
     if_indextoname(nbh->ndm_ifindex, intf_name);
-    krnlmon_log_debug("neigh: Failed to get switchlink database interface info "
-             "for :%s\n", intf_name);
+    krnlmon_log_debug(
+        "neigh: Failed to get switchlink database interface info "
+        "for :%s\n",
+        intf_name);
     return;
   }
 
@@ -82,21 +83,22 @@ void switchlink_process_neigh_msg(const struct nlmsghdr *nlmsg, int msgtype) {
       case NDA_DST:
         if ((nbh->ndm_state == NUD_REACHABLE) ||
             (nbh->ndm_state == NUD_PERMANENT) ||
-            (nbh->ndm_state == NUD_STALE) ||
-            (nbh->ndm_state == NUD_FAILED)) {
-            ipaddr_valid = true;
-            ipaddr.family = nbh->ndm_family;
-            if (nbh->ndm_family == AF_INET) {
-              ipaddr.ip.v4addr.s_addr = ntohl(nla_get_u32(attr));
-              ipaddr.prefix_len = 32;
-            } else {
-              memcpy(&(ipaddr.ip.v6addr), nla_data(attr), nla_len(attr));
-              ipaddr.prefix_len = 128;
-            }
+            (nbh->ndm_state == NUD_STALE) || (nbh->ndm_state == NUD_FAILED)) {
+          ipaddr_valid = true;
+          ipaddr.family = nbh->ndm_family;
+          if (nbh->ndm_family == AF_INET) {
+            ipaddr.ip.v4addr.s_addr = ntohl(nla_get_u32(attr));
+            ipaddr.prefix_len = 32;
+          } else {
+            memcpy(&(ipaddr.ip.v6addr), nla_data(attr), nla_len(attr));
+            ipaddr.prefix_len = 128;
+          }
         } else {
-            krnlmon_log_debug("Ignoring unused neighbor states for attribute "
-                        "type %d\n", attr_type);
-            return;
+          krnlmon_log_debug(
+              "Ignoring unused neighbor states for attribute "
+              "type %d\n",
+              attr_type);
+          return;
         }
         break;
       case NDA_LLADDR: {
@@ -111,7 +113,7 @@ void switchlink_process_neigh_msg(const struct nlmsghdr *nlmsg, int msgtype) {
     attr = nla_next(attr, &attrlen);
   }
 
-  if(ifinfo.link_type == SWITCHLINK_LINK_TYPE_BOND) {
+  if (ifinfo.link_type == SWITCHLINK_LINK_TYPE_BOND) {
     intf_h = ifinfo.lag_h;
   } else {
     intf_h = ifinfo.intf_h;
@@ -125,7 +127,7 @@ void switchlink_process_neigh_msg(const struct nlmsghdr *nlmsg, int msgtype) {
   if (msgtype == RTM_NEWNEIGH) {
     if (bridge_h && mac_addr_valid) {
       switchlink_create_mac(mac_addr, bridge_h, intf_h);
-    } else if(mac_addr_valid && ifinfo.intf_type == SWITCHLINK_INTF_TYPE_L3) {
+    } else if (mac_addr_valid && ifinfo.intf_type == SWITCHLINK_INTF_TYPE_L3) {
       /* Here we are creating FDB entry from neighbor table, check for
        * type as SWITCHLINK_INTF_TYPE_L3 */
       switchlink_create_mac(mac_addr, bridge_h, intf_h);

--- a/switchlink/switchlink_neigh.c
+++ b/switchlink/switchlink_neigh.c
@@ -21,6 +21,7 @@
 
 #include <linux/if_ether.h>
 #include <net/if.h>
+#include <netlink/msg.h>
 
 #include "switchlink.h"
 #include "switchlink_handle.h"

--- a/switchlink/switchlink_neigh.h
+++ b/switchlink/switchlink_neigh.h
@@ -34,6 +34,6 @@ extern void switchlink_linux_mac_update(switchlink_mac_addr_t mac_addr,
                                         switchlink_handle_t intf_h,
                                         bool create);
 */
-void switchlink_process_neigh_msg(const struct nlmsghdr *nlmsg, int msgtype);
+void switchlink_process_neigh_msg(const struct nlmsghdr* nlmsg, int msgtype);
 
 #endif /* __SWITCHLINK_NEIGH_H__ */

--- a/switchlink/switchlink_route.c
+++ b/switchlink/switchlink_route.c
@@ -19,6 +19,10 @@
 
 #include "switchlink_route.h"
 
+#include <netlink/attr.h>
+#include <netlink/msg.h>
+#include <netlink/netlink.h>
+
 /*
  * Routine Description:
  *    Process ecmp netlink messages

--- a/switchlink/switchlink_route.c
+++ b/switchlink/switchlink_route.c
@@ -33,8 +33,7 @@
  *    0 in case of failure
  */
 
-static switchlink_handle_t process_ecmp(uint8_t family,
-                                        struct nlattr *attr,
+static switchlink_handle_t process_ecmp(uint8_t family, struct nlattr* attr,
                                         switchlink_handle_t vrf_h) {
   switchlink_db_status_t status;
 
@@ -45,16 +44,16 @@ static switchlink_handle_t process_ecmp(uint8_t family,
   switchlink_db_ecmp_info_t ecmp_info;
   memset(&ecmp_info, 0, sizeof(switchlink_db_ecmp_info_t));
 
-  struct rtnexthop *rnh = (struct rtnexthop *)nla_data(attr);
+  struct rtnexthop* rnh = (struct rtnexthop*)nla_data(attr);
   int attrlen = nla_len(attr);
   while (RTNH_OK(rnh, attrlen)) {
-    struct rtattr *rta = RTNH_DATA(rnh);
+    struct rtattr* rta = RTNH_DATA(rnh);
     if (rta->rta_type == RTA_GATEWAY) {
       switchlink_ip_addr_t gateway;
       memset(&gateway, 0, sizeof(switchlink_ip_addr_t));
       gateway.family = family;
       if (family == AF_INET) {
-        gateway.ip.v4addr.s_addr = ntohl(*((uint32_t *)RTA_DATA(rta)));
+        gateway.ip.v4addr.s_addr = ntohl(*((uint32_t*)RTA_DATA(rta)));
         gateway.prefix_len = 32;
       } else {
         gateway.prefix_len = 128;
@@ -71,18 +70,22 @@ static switchlink_handle_t process_ecmp(uint8_t family,
         nexthop_info.vrf_h = vrf_h;
         status = switchlink_db_get_nexthop_info(&nexthop_info);
         if (status == SWITCHLINK_DB_STATUS_SUCCESS) {
-          krnlmon_log_debug("Fetched nhop 0x%lx handler, update from"
-                   " route", nexthop_info.nhop_h);
+          krnlmon_log_debug(
+              "Fetched nhop 0x%lx handler, update from"
+              " route",
+              nexthop_info.nhop_h);
           ecmp_info.nhops[ecmp_info.num_nhops] = nexthop_info.nhop_h;
           nexthop_info.using_by |= SWITCHLINK_NHOP_FROM_ROUTE;
           switchlink_db_update_nexthop_using_by(&nexthop_info);
         } else {
           if (!switchlink_create_nexthop(&nexthop_info)) {
-             krnlmon_log_debug("Created nhop 0x%lx handler, update from"
-                      " route", nexthop_info.nhop_h);
-             ecmp_info.nhops[ecmp_info.num_nhops] = nexthop_info.nhop_h;
-             nexthop_info.using_by |= SWITCHLINK_NHOP_FROM_ROUTE;
-             switchlink_db_add_nexthop(&nexthop_info);
+            krnlmon_log_debug(
+                "Created nhop 0x%lx handler, update from"
+                " route",
+                nexthop_info.nhop_h);
+            ecmp_info.nhops[ecmp_info.num_nhops] = nexthop_info.nhop_h;
+            nexthop_info.using_by |= SWITCHLINK_NHOP_FROM_ROUTE;
+            switchlink_db_add_nexthop(&nexthop_info);
           } else {
             ecmp_info.nhops[ecmp_info.num_nhops] = g_cpu_rx_nhop_h;
           }
@@ -108,8 +111,8 @@ static switchlink_handle_t process_ecmp(uint8_t family,
 }
 
 /* TODO: P4-OVS: Dummy Processing of Netlink messages received
-* Support IPv4 Routing
-*/
+ * Support IPv4 Routing
+ */
 
 /*
  * Routine Description:
@@ -123,10 +126,10 @@ static switchlink_handle_t process_ecmp(uint8_t family,
  *    void
  */
 
-void switchlink_process_route_msg(const struct nlmsghdr *nlmsg, int msgtype) {
+void switchlink_process_route_msg(const struct nlmsghdr* nlmsg, int msgtype) {
   int hdrlen, attrlen;
-  struct nlattr *attr;
-  struct rtmsg *rmsg;
+  struct nlattr* attr;
+  struct rtmsg* rmsg;
   bool src_valid = false;
   bool dst_valid = false;
   bool gateway_valid = false;
@@ -148,18 +151,11 @@ void switchlink_process_route_msg(const struct nlmsghdr *nlmsg, int msgtype) {
   hdrlen = sizeof(struct rtmsg);
   krnlmon_log_debug(
       "%sroute: family = %d, dst_len = %d, src_len = %d, tos = %d, "
-       "table = %d, proto = %d, scope = %d, type = %d, "
-       "flags = 0x%x\n",
-       ((msgtype == RTM_NEWROUTE) ? "new" : "del"),
-       rmsg->rtm_family,
-       rmsg->rtm_dst_len,
-       rmsg->rtm_src_len,
-       rmsg->rtm_tos,
-       rmsg->rtm_table,
-       rmsg->rtm_protocol,
-       rmsg->rtm_scope,
-       rmsg->rtm_type,
-       rmsg->rtm_flags);
+      "table = %d, proto = %d, scope = %d, type = %d, "
+      "flags = 0x%x\n",
+      ((msgtype == RTM_NEWROUTE) ? "new" : "del"), rmsg->rtm_family,
+      rmsg->rtm_dst_len, rmsg->rtm_src_len, rmsg->rtm_tos, rmsg->rtm_table,
+      rmsg->rtm_protocol, rmsg->rtm_scope, rmsg->rtm_type, rmsg->rtm_flags);
 
   if (rmsg->rtm_family > AF_MAX) {
     krnlmon_assert(rmsg->rtm_type == RTN_MULTICAST);
@@ -219,7 +215,7 @@ void switchlink_process_route_msg(const struct nlmsghdr *nlmsg, int msgtype) {
         }
         break;
       case RTA_MULTIPATH:
-          ecmp_h = process_ecmp(af, attr, g_default_vrf_h);
+        ecmp_h = process_ecmp(af, attr, g_default_vrf_h);
         break;
       case RTA_OIF:
         oif_valid = true;
@@ -247,31 +243,29 @@ void switchlink_process_route_msg(const struct nlmsghdr *nlmsg, int msgtype) {
     if (oif_valid) {
       switchlink_db_status_t status;
       status = switchlink_db_get_interface_info(oif, &ifinfo);
-      if(status == SWITCHLINK_DB_STATUS_SUCCESS) {
+      if (status == SWITCHLINK_DB_STATUS_SUCCESS) {
         krnlmon_log_debug("Found interface cache for: %s", ifinfo.ifname);
-        if(ifinfo.link_type == SWITCHLINK_LINK_TYPE_BOND) {
+        if (ifinfo.link_type == SWITCHLINK_LINK_TYPE_BOND) {
           intf_h = ifinfo.lag_h;
         } else {
           intf_h = ifinfo.intf_h;
         }
       } else if (status != SWITCHLINK_DB_STATUS_SUCCESS) {
-        krnlmon_log_error("route: Failed to get switchlink DB interface info, "
-                 "error: %d \n", status);
+        krnlmon_log_error(
+            "route: Failed to get switchlink DB interface info, "
+            "error: %d \n",
+            status);
         return;
       }
     }
     krnlmon_log_info("Create route for %s, with addr: 0x%x", ifinfo.ifname,
-                                                     dst_valid ?
-                                                     dst_addr.ip.v4addr.s_addr :
-                                                     0);
-    switchlink_create_route(g_default_vrf_h,
-                            (dst_valid ? &dst_addr : NULL),
-                            (gateway_valid ? &gateway_addr : NULL),
-                            ecmp_h,
+                     dst_valid ? dst_addr.ip.v4addr.s_addr : 0);
+    switchlink_create_route(g_default_vrf_h, (dst_valid ? &dst_addr : NULL),
+                            (gateway_valid ? &gateway_addr : NULL), ecmp_h,
                             intf_h);
   } else {
-    krnlmon_log_info("Delete route with addr: 0x%x", dst_valid ?
-                                             dst_addr.ip.v4addr.s_addr : 0);
+    krnlmon_log_info("Delete route with addr: 0x%x",
+                     dst_valid ? dst_addr.ip.v4addr.s_addr : 0);
     switchlink_delete_route(g_default_vrf_h, (dst_valid ? &dst_addr : NULL));
   }
 }

--- a/switchlink/switchlink_route.h
+++ b/switchlink/switchlink_route.h
@@ -22,6 +22,6 @@
 
 #include "switchlink_handle.h"
 
-void switchlink_process_route_msg(const struct nlmsghdr *nlmsg, int msgtype);
+void switchlink_process_route_msg(const struct nlmsghdr* nlmsg, int msgtype);
 
 #endif /* __SWITCHLINK_ROUTE_H__ */

--- a/switchlink/switchlink_route.h
+++ b/switchlink/switchlink_route.h
@@ -20,6 +20,8 @@
 #ifndef __SWITCHLINK_ROUTE_H__
 #define __SWITCHLINK_ROUTE_H__
 
+#include <netlink/netlink.h>
+
 #include "switchlink_handle.h"
 
 void switchlink_process_route_msg(const struct nlmsghdr* nlmsg, int msgtype);

--- a/switchlink/switchlink_utils.c
+++ b/switchlink/switchlink_utils.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchlink/switchlink_utils.h
+++ b/switchlink/switchlink_utils.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchlink/switchlink_utils.h
+++ b/switchlink/switchlink_utils.h
@@ -18,10 +18,9 @@
 #ifndef __SWITCHLINK_UTILS_H__
 #define __SWITCHLINK_UTILS_H__
 
-
-#include <stdint.h>
-#include <stdbool.h>
 #include <netinet/in.h>
+#include <stdbool.h>
+#include <stdint.h>
 
 #include "switchutils/switch_utils.h"
 

--- a/switchsai/sai.c
+++ b/switchsai/sai.c
@@ -16,9 +16,9 @@
  */
 
 #include "saiinternal.h"
+#include "switchapi/switch_base_types.h"
 #include "switchapi/switch_handle.h"
 #include "switchapi/switch_nhop.h"
-#include "switchapi/switch_base_types.h"
 
 static sai_api_service_t sai_api_service;
 
@@ -26,7 +26,7 @@ static sai_api_service_t sai_api_service;
 extern "C" {
 #endif /* __cplusplus */
 
-static const char *module[SAI_API_MAX] = {"SAI_API_UNSPECIFIED",
+static const char* module[SAI_API_MAX] = {"SAI_API_UNSPECIFIED",
                                           "SAI_API_SWITCH",
                                           "SAI_API_PORT",
                                           "SAI_API_FDB",
@@ -68,7 +68,7 @@ static const char *module[SAI_API_MAX] = {"SAI_API_UNSPECIFIED",
                                           "SAI_API_ISOLATION_GROUP"};
 
 sai_status_t sai_api_query(_In_ sai_api_t sai_api_id,
-                           _Out_ void **api_method_table) {
+                           _Out_ void** api_method_table) {
   sai_status_t status = SAI_STATUS_SUCCESS;
 
   if (!api_method_table) {
@@ -229,7 +229,7 @@ sai_status_t sai_api_query(_In_ sai_api_t sai_api_id,
     krnlmon_log_error("api query failed, invalid api id: %d\n", sai_api_id);
   } else {
     krnlmon_log_error("api query failed, api %s not implemented\n",
-                  module[sai_api_id]);
+                      module[sai_api_id]);
   }
 
   return status;
@@ -272,8 +272,7 @@ sai_object_type_t sai_object_type_query(_In_ sai_object_id_t sai_object_id) {
       object_type = SAI_OBJECT_TYPE_VIRTUAL_ROUTER;
       break;
     case SWITCH_HANDLE_TYPE_NHOP:
-      switch_api_nhop_id_type_get(0, sai_object_id,
-                                  &nhop_type);
+      switch_api_nhop_id_type_get(0, sai_object_id, &nhop_type);
       if (nhop_type == SWITCH_NHOP_ID_TYPE_ONE_PATH) {
         object_type = SAI_OBJECT_TYPE_NEXT_HOP;
       } else if (nhop_type == SWITCH_NHOP_ID_TYPE_ECMP) {

--- a/switchsai/sai.c
+++ b/switchsai/sai.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchsai/saifdb.c
+++ b/switchsai/saifdb.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchsai/saiinternal.h
+++ b/switchsai/saiinternal.h
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 
-#include <stdio.h>
-#include <stdarg.h>
-#include <syslog.h>
-#include <string.h>
 #include <arpa/inet.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <syslog.h>
 
-#include "saitypes.h"
 #include "sai.h"
+#include "saitypes.h"
 #include "switchapi/switch_base_types.h"
 #include "switchutils/switch_utils.h"
 
@@ -47,26 +47,20 @@
 #define SAI_MEMCPY memcpy
 #define SAI_MEMCMP memcmp
 
-typedef enum sai_l2_learn_from_t
-{
-    SAI_L2_FWD_LEARN_NONE,
-    SAI_L2_FWD_LEARN_TUNNEL_INTERFACE,
-    SAI_L2_FWD_LEARN_VLAN_INTERFACE,
-    SAI_L2_FWD_LEARN_PHYSICAL_INTERFACE,
-    SAI_L2_FWD_LEARN_MAX
-}sai_l2_learn_from_t;
+typedef enum sai_l2_learn_from_t {
+  SAI_L2_FWD_LEARN_NONE,
+  SAI_L2_FWD_LEARN_TUNNEL_INTERFACE,
+  SAI_L2_FWD_LEARN_VLAN_INTERFACE,
+  SAI_L2_FWD_LEARN_PHYSICAL_INTERFACE,
+  SAI_L2_FWD_LEARN_MAX
+} sai_l2_learn_from_t;
 
-void sai_log(int level, sai_api_t api, char *fmt, ...);
+void sai_log(int level, sai_api_t api, char* fmt, ...);
 
-#define SAI_LOG(level, api_id, fmt, arg...) \
-  do {                                      \
-    sai_log(level,                          \
-            api_id,                         \
-            "[F:%s L:%d Func:%s] " fmt,     \
-            __FILE__,                       \
-            __LINE__,                       \
-            __func__,                       \
-            ##arg);                         \
+#define SAI_LOG(level, api_id, fmt, arg...)                                \
+  do {                                                                     \
+    sai_log(level, api_id, "[F:%s L:%d Func:%s] " fmt, __FILE__, __LINE__, \
+            __func__, ##arg);                                              \
   } while (0);
 
 // L2 learn timeout in milliseconds
@@ -115,78 +109,76 @@ typedef struct _sai_switch_notification_t {
 
 extern sai_switch_notification_t sai_switch_notifications;
 
-sai_status_t sai_acl_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_buffer_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_fdb_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_hash_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_hostif_initialize(sai_api_service_t *sai_api_service);
+sai_status_t sai_acl_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_buffer_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_fdb_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_hash_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_hostif_initialize(sai_api_service_t* sai_api_service);
 sai_status_t sai_initialize(void);
-sai_status_t sai_ipmc_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_l2mc_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_lag_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_mirror_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_neighbor_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_next_hop_group_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_next_hop_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_policer_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_port_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_qos_map_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_bridge_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_route_initialize(sai_api_service_t *sai_api_service);
+sai_status_t sai_ipmc_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_l2mc_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_lag_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_mirror_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_neighbor_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_next_hop_group_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_next_hop_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_policer_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_port_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_qos_map_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_bridge_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_route_initialize(sai_api_service_t* sai_api_service);
 sai_status_t sai_router_interface_initialize(
-    sai_api_service_t *sai_api_service);
-sai_status_t sai_scheduler_group_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_scheduler_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_stp_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_switch_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_udf_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_virtual_router_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_vlan_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_queue_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_dtel_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_wred_initialize(sai_api_service_t *sai_api_service);
-sai_status_t sai_tunnel_initialize(sai_api_service_t *sai_api_service);
+    sai_api_service_t* sai_api_service);
+sai_status_t sai_scheduler_group_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_scheduler_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_stp_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_switch_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_udf_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_virtual_router_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_vlan_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_queue_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_dtel_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_wred_initialize(sai_api_service_t* sai_api_service);
+sai_status_t sai_tunnel_initialize(sai_api_service_t* sai_api_service);
 
-char *sai_status_to_string(_In_ const sai_status_t status);
+char* sai_status_to_string(_In_ const sai_status_t status);
 
-char *sai_object_type_to_string(_In_ sai_object_type_t object_type);
+char* sai_object_type_to_string(_In_ sai_object_type_t object_type);
 
 sai_status_t sai_ipv4_prefix_length(_In_ sai_ip4_t ip4,
-                                    _Out_ uint32_t *prefix_length);
+                                    _Out_ uint32_t* prefix_length);
 
 sai_status_t sai_ipv6_prefix_length(_In_ const sai_ip6_t ip6,
-                                    _Out_ uint32_t *prefix_length);
+                                    _Out_ uint32_t* prefix_length);
 
-sai_status_t sai_ipv4_to_string(_In_ sai_ip4_t ip4,
-                                _In_ uint32_t max_length,
-                                _Out_ char *entry_string,
-                                _Out_ int *entry_length);
+sai_status_t sai_ipv4_to_string(_In_ sai_ip4_t ip4, _In_ uint32_t max_length,
+                                _Out_ char* entry_string,
+                                _Out_ int* entry_length);
 
-sai_status_t sai_ipv6_to_string(_In_ sai_ip6_t ip6,
-                                _In_ uint32_t max_length,
-                                _Out_ char *entry_string,
-                                _Out_ int *entry_length);
+sai_status_t sai_ipv6_to_string(_In_ sai_ip6_t ip6, _In_ uint32_t max_length,
+                                _Out_ char* entry_string,
+                                _Out_ int* entry_length);
 
 sai_status_t sai_ipaddress_to_string(_In_ sai_ip_address_t ip_addr,
                                      _In_ uint32_t max_length,
-                                     _Out_ char *entry_string,
-                                     _Out_ int *entry_length);
+                                     _Out_ char* entry_string,
+                                     _Out_ int* entry_length);
 
 sai_status_t sai_ipprefix_to_string(_In_ sai_ip_prefix_t ip_prefix,
                                     _In_ uint32_t max_length,
-                                    _Out_ char *entry_string,
-                                    _Out_ int *entry_length);
+                                    _Out_ char* entry_string,
+                                    _Out_ int* entry_length);
 
 sai_status_t sai_ip_prefix_to_switch_ip_addr(
-    const _In_ sai_ip_prefix_t *sai_ip_prefix, _Out_ switch_ip_addr_t *ip_addr);
+    const _In_ sai_ip_prefix_t* sai_ip_prefix, _Out_ switch_ip_addr_t* ip_addr);
 
 sai_status_t sai_ip_addr_to_switch_ip_addr(
-    const _In_ sai_ip_address_t *sai_ip_addr, _Out_ switch_ip_addr_t *ip_addr);
+    const _In_ sai_ip_address_t* sai_ip_addr, _Out_ switch_ip_addr_t* ip_addr);
 
 sai_status_t sai_switch_status_to_sai_status(_In_ const switch_status_t status);
 
-const sai_attribute_t *get_attr_from_list(_In_ sai_attr_id_t attr_id,
-                                          _In_ const sai_attribute_t *attr_list,
+const sai_attribute_t* get_attr_from_list(_In_ sai_attr_id_t attr_id,
+                                          _In_ const sai_attribute_t* attr_list,
                                           _In_ uint32_t attr_count);
 
 sai_object_id_t sai_id_to_oid(_In_ uint32_t type, _In_ uint32_t id);
@@ -197,21 +189,20 @@ typedef unsigned int switch_uint32_t;
 typedef switch_uint32_t switch_size_t;
 
 typedef struct sai_array_ {
-  void *array;
+  void* array;
   switch_size_t num_entries;
 } sai_array_t;
 
-sai_status_t sai_array_init(sai_array_t *array);
+sai_status_t sai_array_init(sai_array_t* array);
 
-switch_uint32_t sai_array_count(sai_array_t *array);
+switch_uint32_t sai_array_count(sai_array_t* array);
 
-sai_status_t sai_array_insert(sai_array_t *array,
-                              sai_uint64_t index,
-                              void *data);
+sai_status_t sai_array_insert(sai_array_t* array, sai_uint64_t index,
+                              void* data);
 
-sai_status_t sai_array_delete(sai_array_t *array, sai_uint64_t index);
+sai_status_t sai_array_delete(sai_array_t* array, sai_uint64_t index);
 
-sai_status_t sai_array_get(sai_array_t *array, sai_uint64_t index, void **data);
+sai_status_t sai_array_get(sai_array_t* array, sai_uint64_t index, void** data);
 
 // -----------------------------------------------------------------------------
 // Hash table utils
@@ -258,7 +249,7 @@ switch_uint32_t switch_sai_port_non_default_ppgs(void);
 bool switch_sai_default_initialize(void);
 
 #if defined(STATIC_LINK_LIB) && defined(THRIFT_ENABLED)
-int start_p4_sai_thrift_rpc_server(char *port);
+int start_p4_sai_thrift_rpc_server(char* port);
 #endif  // STATIC_LINK_LIB && THRIFT_ENABLED
 
 // -----------------------------------------------------------------------------

--- a/switchsai/saiinternal.h
+++ b/switchsai/saiinternal.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchsai/saineighbor.c
+++ b/switchsai/saineighbor.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchsai/saineighbor.c
+++ b/switchsai/saineighbor.c
@@ -15,49 +15,45 @@
  * limitations under the License.
  */
 
+#include "saineighbor.h"
+
 #include <arpa/inet.h>
 
-#include "saineighbor.h"
+#include "saiinternal.h"
+#include "switchapi/switch_l3.h"
 #include "switchapi/switch_neighbor.h"
 #include "switchapi/switch_nhop.h"
 #include "switchapi/switch_rif.h"
-#include "switchapi/switch_l3.h"
-#include "saiinternal.h"
 
 static void sai_neighbor_entry_to_string(
-    _In_ const sai_neighbor_entry_t *neighbor_entry, _Out_ char *entry_string) {
+    _In_ const sai_neighbor_entry_t* neighbor_entry, _Out_ char* entry_string) {
   int count = 0;
   int entry_length = 0;
-  count = snprintf(entry_string,
-                   SAI_MAX_ENTRY_STRING_LEN,
-                   "neighbor:  rif %" PRIx64 " ",
-                   neighbor_entry->rif_id);
+  count = snprintf(entry_string, SAI_MAX_ENTRY_STRING_LEN,
+                   "neighbor:  rif %" PRIx64 " ", neighbor_entry->rif_id);
   sai_ipaddress_to_string(neighbor_entry->ip_address,
                           SAI_MAX_ENTRY_STRING_LEN - count,
-                          entry_string + count,
-                          &entry_length);
+                          entry_string + count, &entry_length);
   return;
 }
 
-static void sai_neighbor_entry_parse(const sai_neighbor_entry_t *neighbor_entry,
-                                     switch_api_neighbor_info_t *api_neighbor) {
+static void sai_neighbor_entry_parse(const sai_neighbor_entry_t* neighbor_entry,
+                                     switch_api_neighbor_info_t* api_neighbor) {
   api_neighbor->rif_handle = (switch_handle_t)neighbor_entry->rif_id;
   sai_ip_addr_to_switch_ip_addr(&neighbor_entry->ip_address,
                                 &api_neighbor->ip_addr);
 }
 
 static void sai_neighbor_entry_attribute_parse(
-    uint32_t attr_count,
-    const sai_attribute_t *attr_list,
-    switch_api_neighbor_info_t *api_neighbor) {
-  const sai_attribute_t *attribute;
+    uint32_t attr_count, const sai_attribute_t* attr_list,
+    switch_api_neighbor_info_t* api_neighbor) {
+  const sai_attribute_t* attribute;
   uint32_t index = 0;
   for (index = 0; index < attr_count; index++) {
     attribute = &attr_list[index];
     switch (attribute->id) {
       case SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS:
-        memcpy(&api_neighbor->mac_addr,
-               attribute->value.mac,
+        memcpy(&api_neighbor->mac_addr, attribute->value.mac,
                sizeof(switch_mac_addr_t));
         break;
       case SAI_NEIGHBOR_ENTRY_ATTR_PACKET_ACTION:
@@ -68,7 +64,7 @@ static void sai_neighbor_entry_attribute_parse(
 }
 
 static void sai_neighbor_entry_nexthop_get(
-    switch_api_neighbor_info_t *api_neighbor) {
+    switch_api_neighbor_info_t* api_neighbor) {
   switch_ip_addr_t ip_addr;
   switch_nhop_key_t nhop_key;
   memset(&ip_addr, 0, sizeof(switch_ip_addr_t));
@@ -94,10 +90,8 @@ static void sai_neighbor_entry_nexthop_get(
  * Note: IP address expected in Network Byte Order.
  */
 static sai_status_t sai_create_neighbor_entry(
-    _In_ const sai_neighbor_entry_t *neighbor_entry,
-    _In_ uint32_t attr_count,
-    _In_ const sai_attribute_t *attr_list) {
-
+    _In_ const sai_neighbor_entry_t* neighbor_entry, _In_ uint32_t attr_count,
+    _In_ const sai_attribute_t* attr_list) {
   sai_status_t status = SAI_STATUS_SUCCESS;
   switch_handle_t neighbor_handle = SWITCH_API_INVALID_HANDLE;
   char entry_string[SAI_MAX_ENTRY_STRING_LEN];
@@ -124,7 +118,7 @@ static sai_status_t sai_create_neighbor_entry(
   status = switch_api_neighbor_create(0, &api_neighbor, &neighbor_handle);
   if (status != SAI_STATUS_SUCCESS) {
     krnlmon_log_error("Failed to create neighbor entry, error: %s",
-                  sai_status_to_string(status));
+                      sai_status_to_string(status));
   }
 
   return (sai_status_t)status;
@@ -144,8 +138,7 @@ static sai_status_t sai_create_neighbor_entry(
  * Note: IP address expected in Network Byte Order.
  */
 static sai_status_t sai_remove_neighbor_entry(
-    _In_ const sai_neighbor_entry_t *neighbor_entry) {
-
+    _In_ const sai_neighbor_entry_t* neighbor_entry) {
   sai_status_t status = SAI_STATUS_SUCCESS;
   switch_status_t switch_status = SWITCH_STATUS_SUCCESS;
   switch_api_neighbor_info_t api_neighbor = {0};
@@ -161,14 +154,14 @@ static sai_status_t sai_remove_neighbor_entry(
   sai_neighbor_entry_parse(neighbor_entry, &api_neighbor);
   sai_neighbor_entry_nexthop_get(&api_neighbor);
 
-  switch_status = switch_api_neighbor_handle_get(
-      0, api_neighbor.nhop_handle, &neighbor_handle);
+  switch_status = switch_api_neighbor_handle_get(0, api_neighbor.nhop_handle,
+                                                 &neighbor_handle);
 
   switch_status = switch_api_neighbor_delete(0, neighbor_handle);
   status = sai_switch_status_to_sai_status(switch_status);
   if (status != SAI_STATUS_SUCCESS) {
     krnlmon_log_error("Failed to remove neighbor entry, error: %s",
-                  sai_status_to_string(status));
+                      sai_status_to_string(status));
     status = SAI_STATUS_SUCCESS;
   }
 
@@ -182,7 +175,7 @@ sai_neighbor_api_t neighbor_api = {
     .create_neighbor_entry = sai_create_neighbor_entry,
     .remove_neighbor_entry = sai_remove_neighbor_entry};
 
-sai_status_t sai_neighbor_initialize(sai_api_service_t *sai_api_service) {
+sai_status_t sai_neighbor_initialize(sai_api_service_t* sai_api_service) {
   sai_api_service->neighbor_api = neighbor_api;
   return SAI_STATUS_SUCCESS;
 }

--- a/switchsai/sainexthop.c
+++ b/switchsai/sainexthop.c
@@ -16,10 +16,11 @@
  */
 
 #include "sainexthop.h"
+
+#include "saiinternal.h"
 #include "switchapi/switch_nhop.h"
 #include "switchapi/switch_rif.h"
 #include "switchapi/switch_tunnel.h"
-#include "saiinternal.h"
 
 static switch_nhop_type_t sai_nhop_type_to_switch_nhop_type(
     sai_next_hop_type_t sai_type) {
@@ -53,15 +54,12 @@ static switch_nhop_type_t sai_nhop_type_to_switch_nhop_type(
  * Note: IP address expected in Network Byte Order.
  */
 static sai_status_t sai_create_next_hop_entry(
-                                       _Out_ sai_object_id_t *next_hop_id,
-                                       _In_ sai_object_id_t switch_id,
-                                       _In_ uint32_t attr_count,
-                                       _In_ const sai_attribute_t *attr_list) {
-
-  const sai_attribute_t *attribute;
+    _Out_ sai_object_id_t* next_hop_id, _In_ sai_object_id_t switch_id,
+    _In_ uint32_t attr_count, _In_ const sai_attribute_t* attr_list) {
+  const sai_attribute_t* attribute;
   sai_status_t status = SAI_STATUS_SUCCESS;
   uint32_t index = 0;
-  const sai_ip_address_t *sai_ip_addr;
+  const sai_ip_address_t* sai_ip_addr;
   switch_api_nhop_info_t api_nhop_info;
   sai_next_hop_type_t nhtype = SAI_NEXT_HOP_TYPE_IP;
   switch_handle_t next_hop_handle = SWITCH_API_INVALID_HANDLE;
@@ -97,8 +95,7 @@ static sai_status_t sai_create_next_hop_entry(
         api_nhop_info.tunnel_vni = attribute->value.u32;
         break;
       case SAI_NEXT_HOP_ATTR_TUNNEL_MAC:
-        memcpy(&api_nhop_info.mac_addr,
-               attribute->value.mac,
+        memcpy(&api_nhop_info.mac_addr, attribute->value.mac,
                sizeof(switch_mac_addr_t));
         break;
       default:
@@ -111,7 +108,7 @@ static sai_status_t sai_create_next_hop_entry(
   status = switch_api_nhop_create(switch_id, &api_nhop_info, &next_hop_handle);
   if (status != SAI_STATUS_SUCCESS) {
     krnlmon_log_error("Failed to create nexthop, error: %s",
-              sai_status_to_string(status));
+                      sai_status_to_string(status));
   } else {
     *next_hop_id = next_hop_handle;
   }
@@ -130,15 +127,15 @@ static sai_status_t sai_create_next_hop_entry(
  *    SAI_STATUS_SUCCESS on success
  *    Failure status code on error
  */
-static
-sai_status_t sai_remove_next_hop_entry(_In_ sai_object_id_t next_hop_id) {
-
+static sai_status_t sai_remove_next_hop_entry(
+    _In_ sai_object_id_t next_hop_id) {
   sai_status_t status = SAI_STATUS_SUCCESS;
   switch_status_t switch_status = SWITCH_STATUS_SUCCESS;
 
   if (sai_object_type_query(next_hop_id) != SAI_OBJECT_TYPE_NEXT_HOP) {
-    krnlmon_log_error("Failed to remove nexthop entry: invalid nexthop handle %lx\n",
-                  next_hop_id);
+    krnlmon_log_error(
+        "Failed to remove nexthop entry: invalid nexthop handle %lx\n",
+        next_hop_id);
     return SAI_STATUS_INVALID_PARAMETER;
   }
 
@@ -146,9 +143,8 @@ sai_status_t sai_remove_next_hop_entry(_In_ sai_object_id_t next_hop_id) {
   status = sai_switch_status_to_sai_status(switch_status);
 
   if (status != SAI_STATUS_SUCCESS) {
-    krnlmon_log_error("Failed to remove nexthop %lx, error: %s",
-                  next_hop_id,
-                  sai_status_to_string(status));
+    krnlmon_log_error("Failed to remove nexthop %lx, error: %s", next_hop_id,
+                      sai_status_to_string(status));
   }
 
   return (sai_status_t)status;
@@ -157,11 +153,10 @@ sai_status_t sai_remove_next_hop_entry(_In_ sai_object_id_t next_hop_id) {
 /*
  *  Next Hop methods table retrieved with sai_api_query()
  */
-sai_next_hop_api_t nhop_api = {
-    .create_next_hop = sai_create_next_hop_entry,
-    .remove_next_hop = sai_remove_next_hop_entry};
+sai_next_hop_api_t nhop_api = {.create_next_hop = sai_create_next_hop_entry,
+                               .remove_next_hop = sai_remove_next_hop_entry};
 
-sai_status_t sai_next_hop_initialize(sai_api_service_t *sai_api_service) {
+sai_status_t sai_next_hop_initialize(sai_api_service_t* sai_api_service) {
   sai_api_service->nhop_api = nhop_api;
   return SAI_STATUS_SUCCESS;
 }

--- a/switchsai/sainexthop.c
+++ b/switchsai/sainexthop.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchsai/sainexthopgroup.c
+++ b/switchsai/sainexthopgroup.c
@@ -16,30 +16,28 @@
  */
 
 #include "sainexthopgroup.h"
+
 #include "saiinternal.h"
 #include "switchapi/switch_device.h"
 #include "switchapi/switch_nhop.h"
 
 /*
-* Routine Description:
-*    Create next hop group
-*
-* Arguments:
-*    [out] next_hop_group_id - next hop group id
-*    [in] switch_id - device ID
-*    [in] attr_count - number of attributes
-*    [in] attr_list - array of attributes
-*
-* Return Values:
-*    SAI_STATUS_SUCCESS on success
-*    Failure status code on error
-*/
+ * Routine Description:
+ *    Create next hop group
+ *
+ * Arguments:
+ *    [out] next_hop_group_id - next hop group id
+ *    [in] switch_id - device ID
+ *    [in] attr_count - number of attributes
+ *    [in] attr_list - array of attributes
+ *
+ * Return Values:
+ *    SAI_STATUS_SUCCESS on success
+ *    Failure status code on error
+ */
 static sai_status_t sai_create_next_hop_group_entry(
-    _Out_ sai_object_id_t *next_hop_group_id,
-    _In_ sai_object_id_t switch_id,
-    _In_ uint32_t attr_count,
-    _In_ const sai_attribute_t *attr_list) {
-
+    _Out_ sai_object_id_t* next_hop_group_id, _In_ sai_object_id_t switch_id,
+    _In_ uint32_t attr_count, _In_ const sai_attribute_t* attr_list) {
   sai_status_t status = SAI_STATUS_SUCCESS;
   sai_attribute_t attribute;
   sai_next_hop_group_type_t nhgroup_type = -1;
@@ -69,7 +67,7 @@ static sai_status_t sai_create_next_hop_group_entry(
   status = switch_api_create_nhop_group(switch_id, &next_hop_group_handle);
   if (status != SAI_STATUS_SUCCESS) {
     krnlmon_log_error("failed to create NHOP group %s",
-                  sai_status_to_string(status));
+                      sai_status_to_string(status));
     return status;
   }
   *next_hop_group_id = next_hop_group_handle;
@@ -78,19 +76,18 @@ static sai_status_t sai_create_next_hop_group_entry(
 }
 
 /*
-* Routine Description:
-*    Remove next hop group
-*
-* Arguments:
-*    [in] next_hop_group_id - next hop group id
-*
-* Return Values:
-*    SAI_STATUS_SUCCESS on success
-*    Failure status code on error
-*/
-static sai_status_t sai_remove_next_hop_group_entry(_In_ sai_object_id_t
-                                                 next_hop_group_id) {
-
+ * Routine Description:
+ *    Remove next hop group
+ *
+ * Arguments:
+ *    [in] next_hop_group_id - next hop group id
+ *
+ * Return Values:
+ *    SAI_STATUS_SUCCESS on success
+ *    Failure status code on error
+ */
+static sai_status_t sai_remove_next_hop_group_entry(
+    _In_ sai_object_id_t next_hop_group_id) {
   sai_status_t status = SAI_STATUS_SUCCESS;
   switch_status_t switch_status = SWITCH_STATUS_SUCCESS;
 
@@ -98,9 +95,8 @@ static sai_status_t sai_remove_next_hop_group_entry(_In_ sai_object_id_t
       switch_api_delete_nhop_group(0, (switch_handle_t)next_hop_group_id);
   status = sai_switch_status_to_sai_status(switch_status);
   if (status != SAI_STATUS_SUCCESS) {
-    krnlmon_log_error("failed to remove NHOP group %lx: %s",
-                  next_hop_group_id,
-                  sai_status_to_string(status));
+    krnlmon_log_error("failed to remove NHOP group %lx: %s", next_hop_group_id,
+                      sai_status_to_string(status));
   }
 
   return (sai_status_t)status;
@@ -117,11 +113,9 @@ static sai_status_t sai_remove_next_hop_group_entry(_In_ sai_object_id_t
  * @return #SAI_STATUS_SUCCESS on success Failure status code on error
  */
 static sai_status_t sai_create_next_hop_group_member(
-    _Out_ sai_object_id_t *next_hop_group_member_id,
-    _In_ sai_object_id_t switch_id,
-    _In_ uint32_t attr_count,
-    _In_ const sai_attribute_t *attr_list) {
-
+    _Out_ sai_object_id_t* next_hop_group_member_id,
+    _In_ sai_object_id_t switch_id, _In_ uint32_t attr_count,
+    _In_ const sai_attribute_t* attr_list) {
   sai_status_t status = SAI_STATUS_SUCCESS;
   switch_status_t switch_status = SWITCH_STATUS_SUCCESS;
   switch_handle_t nhop_group_id = 0;
@@ -155,26 +149,23 @@ static sai_status_t sai_create_next_hop_group_member(
 #if defined(DPDK_TARGET)
   /* If NHOP group is not created, map this member to default group */
   if (!nhop_group_id) {
-    switch_status = switch_api_get_default_nhop_group(switch_id,
-                                                      &nhop_group_id);
+    switch_status =
+        switch_api_get_default_nhop_group(switch_id, &nhop_group_id);
     status = sai_switch_status_to_sai_status(switch_status);
     if ((status != SAI_STATUS_SUCCESS) || !nhop_group_id) {
       krnlmon_log_error("failed to get default NHOP group %s",
-                sai_status_to_string(status));
+                        sai_status_to_string(status));
     }
   }
 #endif
 
-  switch_status = switch_api_add_nhop_member(switch_id,
-                                             (switch_handle_t)nhop_group_id,
-                                             0x1,
-                                             (switch_handle_t *)&nhop_id,
-                                             &member_id);
+  switch_status =
+      switch_api_add_nhop_member(switch_id, (switch_handle_t)nhop_group_id, 0x1,
+                                 (switch_handle_t*)&nhop_id, &member_id);
   status = sai_switch_status_to_sai_status(switch_status);
   if (status != SAI_STATUS_SUCCESS) {
     krnlmon_log_error("failed to add member to NHOP group %lx : %s",
-                  nhop_group_id,
-                  sai_status_to_string(status));
+                      nhop_group_id, sai_status_to_string(status));
   }
 
   *next_hop_group_member_id = (sai_object_id_t)member_id;
@@ -189,8 +180,8 @@ static sai_status_t sai_create_next_hop_group_member(
  *
  * @return SAI_STATUS_SUCCESS on success Failure status code on error
  */
-static sai_status_t sai_remove_next_hop_group_member(_In_ sai_object_id_t
-                                                     next_hop_group_member_id) {
+static sai_status_t sai_remove_next_hop_group_member(
+    _In_ sai_object_id_t next_hop_group_member_id) {
   switch_handle_t nhop_group_id = 0;
   switch_handle_t nhop_id = 0;
 
@@ -201,33 +192,32 @@ static sai_status_t sai_remove_next_hop_group_member(_In_ sai_object_id_t
       0, next_hop_group_member_id, &nhop_group_id, &nhop_id);
   status = sai_switch_status_to_sai_status(switch_status);
   if (status != SAI_STATUS_SUCCESS) {
-    krnlmon_log_error("failed to get NHOP group and nhop for member ID %lx : %s",
-              next_hop_group_member_id,
-              sai_status_to_string(status));
+    krnlmon_log_error(
+        "failed to get NHOP group and nhop for member ID %lx : %s",
+        next_hop_group_member_id, sai_status_to_string(status));
   }
 
   switch_status = switch_api_delete_nhop_member(
-      0, (switch_handle_t)nhop_group_id, 0x1, (switch_handle_t *)&nhop_id);
+      0, (switch_handle_t)nhop_group_id, 0x1, (switch_handle_t*)&nhop_id);
   status = sai_switch_status_to_sai_status(switch_status);
   if (status != SAI_STATUS_SUCCESS) {
     krnlmon_log_error("failed to remove member from NHOP group %lx : %s",
-                  next_hop_group_member_id,
-                  sai_status_to_string(status));
+                      next_hop_group_member_id, sai_status_to_string(status));
   }
 
   return (sai_status_t)status;
 }
 
 /*
-*  Next Hop group methods table retrieved with sai_api_query()
-*/
+ *  Next Hop group methods table retrieved with sai_api_query()
+ */
 sai_next_hop_group_api_t nhop_group_api = {
     .create_next_hop_group = sai_create_next_hop_group_entry,
     .remove_next_hop_group = sai_remove_next_hop_group_entry,
     .create_next_hop_group_member = sai_create_next_hop_group_member,
     .remove_next_hop_group_member = sai_remove_next_hop_group_member};
 
-sai_status_t sai_next_hop_group_initialize(sai_api_service_t *sai_api_service) {
+sai_status_t sai_next_hop_group_initialize(sai_api_service_t* sai_api_service) {
   krnlmon_log_debug("Initializing NHOP group");
   sai_api_service->nhop_group_api = nhop_group_api;
   return SAI_STATUS_SUCCESS;

--- a/switchsai/sainexthopgroup.c
+++ b/switchsai/sainexthopgroup.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchsai/saiport.c
+++ b/switchsai/saiport.c
@@ -16,9 +16,10 @@
  */
 
 #include "saiport.h"
+
 #include "saiinternal.h"
-#include "switchapi/switch_port.h"
 #include "switchapi/switch_base_types.h"
+#include "switchapi/switch_port.h"
 
 #define SAI_PORT_DEFAULT_MTU 9400
 /*
@@ -35,9 +36,9 @@
  */
 
 static sai_status_t sai_set_port_attribute(_In_ sai_object_id_t port_id,
-                                    _In_ const sai_attribute_t *attr) {
-    sai_status_t status = SAI_STATUS_SUCCESS;
-    return status;
+                                           _In_ const sai_attribute_t* attr) {
+  sai_status_t status = SAI_STATUS_SUCCESS;
+  return status;
 }
 
 /*
@@ -55,10 +56,10 @@ static sai_status_t sai_set_port_attribute(_In_ sai_object_id_t port_id,
  */
 
 static sai_status_t sai_get_port_attribute(_In_ sai_object_id_t port_id,
-                                    _In_ uint32_t attr_count,
-                                    _Inout_ sai_attribute_t *attr_list) {
-    sai_status_t status = SAI_STATUS_SUCCESS;
-    return status;
+                                           _In_ uint32_t attr_count,
+                                           _Inout_ sai_attribute_t* attr_list) {
+  sai_status_t status = SAI_STATUS_SUCCESS;
+  return status;
 }
 
 /*
@@ -75,53 +76,53 @@ static sai_status_t sai_get_port_attribute(_In_ sai_object_id_t port_id,
  *    Failure status code on error
  */
 
-static sai_status_t sai_create_port(_Out_ sai_object_id_t *port_id,
-                             _In_ sai_object_id_t switch_id,
-                             _In_ uint32_t attr_count,
-                             _In_ const sai_attribute_t *attr_list) {
-    sai_status_t status = SAI_STATUS_SUCCESS;
-    const sai_attribute_t *attribute = NULL;
-    uint64_t portid = 0;
-    uint32_t mtu = 0;
+static sai_status_t sai_create_port(_Out_ sai_object_id_t* port_id,
+                                    _In_ sai_object_id_t switch_id,
+                                    _In_ uint32_t attr_count,
+                                    _In_ const sai_attribute_t* attr_list) {
+  sai_status_t status = SAI_STATUS_SUCCESS;
+  const sai_attribute_t* attribute = NULL;
+  uint64_t portid = 0;
+  uint32_t mtu = 0;
 
-    switch_handle_t port_handle = SWITCH_API_INVALID_HANDLE;
-    switch_api_port_info_t api_port_info = {0};
+  switch_handle_t port_handle = SWITCH_API_INVALID_HANDLE;
+  switch_api_port_info_t api_port_info = {0};
 
-    krnlmon_log_info("[SAI_CREATE_PORT] called ..\n");
+  krnlmon_log_info("[SAI_CREATE_PORT] called ..\n");
 
-    for (uint32_t index = 0; index < attr_count; index++) {
-        attribute = &attr_list[index];
-        switch (attribute->id) {
-            case SAI_PORT_ATTR_HW_LANE_LIST:
-                portid = attribute->value.oid;
-                krnlmon_log_info("[SAI_CREATE_PORT]: Port ID = %"PRIu64, portid);
-                break;
-            case SAI_PORT_ATTR_MTU:
-                mtu = attribute->value.u32;
-                krnlmon_log_info("[SAI_CREATE_PORT]: MTU = %d\n", mtu);
-                break;
-            default:
-                status = SAI_STATUS_NOT_IMPLEMENTED;
-        }
+  for (uint32_t index = 0; index < attr_count; index++) {
+    attribute = &attr_list[index];
+    switch (attribute->id) {
+      case SAI_PORT_ATTR_HW_LANE_LIST:
+        portid = attribute->value.oid;
+        krnlmon_log_info("[SAI_CREATE_PORT]: Port ID = %" PRIu64, portid);
+        break;
+      case SAI_PORT_ATTR_MTU:
+        mtu = attribute->value.u32;
+        krnlmon_log_info("[SAI_CREATE_PORT]: MTU = %d\n", mtu);
+        break;
+      default:
+        status = SAI_STATUS_NOT_IMPLEMENTED;
     }
+  }
 
-   // UDIT: Re-create strucutre and populate only required parametes ??
-   // Filling some commmon attrs with above values for now
-      api_port_info.port = portid;
-      api_port_info.tx_mtu = mtu;
-      api_port_info.rx_mtu = mtu;
-    //api_port_info.port_speed = SWITCH_PORT_SPEED_25G;
-   // api_port_info.fec_mode = fec_mode;
-   // api_port_info.initial_admin_state = admin_state;
-   // api_port_info.non_default_ppgs = switch_sai_port_non_default_ppgs();
+  // UDIT: Re-create strucutre and populate only required parametes ??
+  // Filling some commmon attrs with above values for now
+  api_port_info.port = portid;
+  api_port_info.tx_mtu = mtu;
+  api_port_info.rx_mtu = mtu;
+  // api_port_info.port_speed = SWITCH_PORT_SPEED_25G;
+  // api_port_info.fec_mode = fec_mode;
+  // api_port_info.initial_admin_state = admin_state;
+  // api_port_info.non_default_ppgs = switch_sai_port_non_default_ppgs();
 
-    status = switch_api_port_add(1, &api_port_info, &port_handle);
-    return status;
+  status = switch_api_port_add(1, &api_port_info, &port_handle);
+  return status;
 }
 
 static sai_status_t sai_remove_port(_In_ sai_object_id_t port_id) {
-    sai_status_t status = SAI_STATUS_SUCCESS;
-    return status;
+  sai_status_t status = SAI_STATUS_SUCCESS;
+  return status;
 }
 
 /*
@@ -140,11 +141,11 @@ static sai_status_t sai_remove_port(_In_ sai_object_id_t port_id) {
  */
 
 static sai_status_t sai_get_port_stats(_In_ sai_object_id_t port_id,
-                                _In_ uint32_t number_of_counters,
-                                _In_ const sai_stat_id_t *counter_ids,
-                                _Out_ uint64_t *counters) {
-    sai_status_t status = SAI_STATUS_SUCCESS;
-    return status;
+                                       _In_ uint32_t number_of_counters,
+                                       _In_ const sai_stat_id_t* counter_ids,
+                                       _Out_ uint64_t* counters) {
+  sai_status_t status = SAI_STATUS_SUCCESS;
+  return status;
 }
 
 /*
@@ -161,11 +162,11 @@ static sai_status_t sai_get_port_stats(_In_ sai_object_id_t port_id,
  *    Failure status code on error
  */
 
-static sai_status_t sai_clear_port_stats(_In_ sai_object_id_t port_id,
-                                  _In_ uint32_t number_of_counters,
-                                  _In_ const sai_stat_id_t *counter_ids) {
-    sai_status_t status = SAI_STATUS_SUCCESS;
-    return status;
+static sai_status_t sai_clear_port_stats(
+    _In_ sai_object_id_t port_id, _In_ uint32_t number_of_counters,
+    _In_ const sai_stat_id_t* counter_ids) {
+  sai_status_t status = SAI_STATUS_SUCCESS;
+  return status;
 }
 
 /*
@@ -181,8 +182,8 @@ static sai_status_t sai_clear_port_stats(_In_ sai_object_id_t port_id,
  */
 
 static sai_status_t sai_clear_port_all_stats(_In_ sai_object_id_t port_id) {
-    sai_status_t status = SAI_STATUS_SUCCESS;
-    return status;
+  sai_status_t status = SAI_STATUS_SUCCESS;
+  return status;
 }
 
 /*
@@ -196,7 +197,7 @@ sai_port_api_t port_api = {.create_port = sai_create_port,
                            .clear_port_stats = sai_clear_port_stats,
                            .clear_port_all_stats = sai_clear_port_all_stats};
 
-sai_status_t sai_port_initialize(sai_api_service_t *sai_api_service) {
+sai_status_t sai_port_initialize(sai_api_service_t* sai_api_service) {
   sai_api_service->port_api = port_api;
   return SAI_STATUS_SUCCESS;
 }

--- a/switchsai/saiport.c
+++ b/switchsai/saiport.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchsai/sairoute.c
+++ b/switchsai/sairoute.c
@@ -16,31 +16,29 @@
  */
 
 #include "sairoute.h"
+
+#include "saiinternal.h"
 #include "switchapi/switch_device.h"
-#include "switchapi/switch_rif.h"
 #include "switchapi/switch_interface.h"
 #include "switchapi/switch_l3.h"
-#include "saiinternal.h"
+#include "switchapi/switch_rif.h"
 
-static void sai_route_entry_to_string(_In_ const sai_route_entry_t *route_entry,
-                                      _Out_ char *entry_string) {
+static void sai_route_entry_to_string(_In_ const sai_route_entry_t* route_entry,
+                                      _Out_ char* entry_string) {
   int count = 0;
   int len = 0;
-  count = snprintf(entry_string,
-                   SAI_MAX_ENTRY_STRING_LEN,
-                   "route: vrf handle 0x%" PRIx64 " ",
-                   route_entry->vr_id);
+  count = snprintf(entry_string, SAI_MAX_ENTRY_STRING_LEN,
+                   "route: vrf handle 0x%" PRIx64 " ", route_entry->vr_id);
   sai_ipprefix_to_string(route_entry->destination,
-                         SAI_MAX_ENTRY_STRING_LEN - count,
-                         entry_string + count,
+                         SAI_MAX_ENTRY_STRING_LEN - count, entry_string + count,
                          &len);
   return;
 }
 
-static void sai_route_entry_parse(_In_ const sai_route_entry_t *route_entry,
-                                  _Out_ switch_handle_t *vrf_handle,
-                                  _Out_ switch_ip_addr_t *ip_addr) {
-  const sai_ip_prefix_t *sai_ip_prefix;
+static void sai_route_entry_parse(_In_ const sai_route_entry_t* route_entry,
+                                  _Out_ switch_handle_t* vrf_handle,
+                                  _Out_ switch_ip_addr_t* ip_addr) {
+  const sai_ip_prefix_t* sai_ip_prefix;
 
   *vrf_handle = (switch_handle_t)route_entry->vr_id;
 
@@ -50,12 +48,9 @@ static void sai_route_entry_parse(_In_ const sai_route_entry_t *route_entry,
 }
 
 static void sai_route_entry_attribute_parse(
-    _In_ uint32_t attr_count,
-    _In_ const sai_attribute_t *attr_list,
-    switch_handle_t *nhop_handle,
-    int *action,
-    int *pri) {
-  const sai_attribute_t *attribute;
+    _In_ uint32_t attr_count, _In_ const sai_attribute_t* attr_list,
+    switch_handle_t* nhop_handle, int* action, int* pri) {
+  const sai_attribute_t* attribute;
   uint32_t index = 0;
 
   for (index = 0; index < attr_count; index++) {
@@ -74,9 +69,9 @@ static void sai_route_entry_attribute_parse(
   }
 }
 
-static sai_status_t sai_route_entry_update(const sai_route_entry_t *route_entry,
-                                    uint32_t attr_count,
-                                    const sai_attribute_t *attr_list) {
+static sai_status_t sai_route_entry_update(const sai_route_entry_t* route_entry,
+                                           uint32_t attr_count,
+                                           const sai_attribute_t* attr_list) {
   switch_ip_addr_t ip_addr;
   switch_handle_t nhop_handle = 0;
   switch_handle_t vrf_handle = 0;
@@ -88,33 +83,33 @@ static sai_status_t sai_route_entry_update(const sai_route_entry_t *route_entry,
   if (!route_entry) {
     status = SAI_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("null route entry for route entry update: %s",
-             sai_status_to_string(status));
+                      sai_status_to_string(status));
     return status;
   }
 
   if (!attr_list) {
     status = SAI_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("null attribute list for route entry update: %s",
-              sai_status_to_string(status));
+                      sai_status_to_string(status));
     return status;
   }
 
   sai_route_entry_parse(route_entry, &vrf_handle, &ip_addr);
-  sai_route_entry_attribute_parse(
-      attr_count, attr_list, &nhop_handle, &action, &pri);
+  sai_route_entry_attribute_parse(attr_count, attr_list, &nhop_handle, &action,
+                                  &pri);
   sai_route_entry_to_string(route_entry, entry_string);
 
   // Considering only IP address as a nexthop.
   // CR if (nhop_handle) {
-    memset(&api_route_entry, 0, sizeof(switch_api_route_entry_t));
-    api_route_entry.vrf_handle = vrf_handle;
-    api_route_entry.nhop_handle = nhop_handle;
-    api_route_entry.neighbor_installed = FALSE;
-    memcpy(&api_route_entry.ip_address, &ip_addr, sizeof(switch_ip_addr_t));
+  memset(&api_route_entry, 0, sizeof(switch_api_route_entry_t));
+  api_route_entry.vrf_handle = vrf_handle;
+  api_route_entry.nhop_handle = nhop_handle;
+  api_route_entry.neighbor_installed = FALSE;
+  memcpy(&api_route_entry.ip_address, &ip_addr, sizeof(switch_ip_addr_t));
 
-    switch_status = switch_api_l3_route_add(0, &api_route_entry);
+  switch_status = switch_api_l3_route_add(0, &api_route_entry);
 
-    status = sai_switch_status_to_sai_status(switch_status);
+  status = sai_switch_status_to_sai_status(switch_status);
 
   return status;
 }
@@ -135,11 +130,9 @@ static sai_status_t sai_route_entry_update(const sai_route_entry_t *route_entry,
  * Note: IP prefix/mask expected in Network Byte Order.
  *
  */
-static
-sai_status_t sai_create_route_entry(_In_ const sai_route_entry_t *route_entry,
-                                    _In_ uint32_t attr_count,
-                                    _In_ const sai_attribute_t *attr_list) {
-
+static sai_status_t sai_create_route_entry(
+    _In_ const sai_route_entry_t* route_entry, _In_ uint32_t attr_count,
+    _In_ const sai_attribute_t* attr_list) {
   sai_status_t status = SAI_STATUS_SUCCESS;
   char entry_string[SAI_MAX_ENTRY_STRING_LEN];
 
@@ -148,8 +141,7 @@ sai_status_t sai_create_route_entry(_In_ const sai_route_entry_t *route_entry,
   status = sai_route_entry_update(route_entry, attr_count, attr_list);
   if (status != SAI_STATUS_SUCCESS) {
     krnlmon_log_error("Failed to create route entry for %s, error: %s",
-                  entry_string,
-                  sai_status_to_string(status));
+                      entry_string, sai_status_to_string(status));
   }
 
   return (sai_status_t)status;
@@ -168,9 +160,8 @@ sai_status_t sai_create_route_entry(_In_ const sai_route_entry_t *route_entry,
  *
  * Note: IP prefix/mask expected in Network Byte Order.
  */
-static 
-sai_status_t sai_remove_route_entry(_In_ const sai_route_entry_t *route_entry) {
-
+static sai_status_t sai_remove_route_entry(
+    _In_ const sai_route_entry_t* route_entry) {
   sai_status_t status = SAI_STATUS_SUCCESS;
   switch_status_t switch_status = SWITCH_STATUS_SUCCESS;
   switch_ip_addr_t ip_addr;
@@ -179,7 +170,8 @@ sai_status_t sai_remove_route_entry(_In_ const sai_route_entry_t *route_entry) {
 
   if (!route_entry) {
     status = SAI_STATUS_INVALID_PARAMETER;
-    krnlmon_log_error("null route entry for remove route entry: %s", sai_status_to_string(status));
+    krnlmon_log_error("null route entry for remove route entry: %s",
+                      sai_status_to_string(status));
     return status;
   }
 
@@ -194,7 +186,7 @@ sai_status_t sai_remove_route_entry(_In_ const sai_route_entry_t *route_entry) {
 
   if (status != SAI_STATUS_SUCCESS) {
     krnlmon_log_error("Failed to remove route entry, error: %s",
-                  sai_status_to_string(status));
+                      sai_status_to_string(status));
   }
 
   return (sai_status_t)status;
@@ -203,11 +195,10 @@ sai_status_t sai_remove_route_entry(_In_ const sai_route_entry_t *route_entry) {
 /*
  *  Router entry methods table retrieved with sai_api_query()
  */
-sai_route_api_t route_api = {
-    .create_route_entry = sai_create_route_entry,
-    .remove_route_entry = sai_remove_route_entry};
+sai_route_api_t route_api = {.create_route_entry = sai_create_route_entry,
+                             .remove_route_entry = sai_remove_route_entry};
 
-sai_status_t sai_route_initialize(sai_api_service_t *sai_api_service) {
+sai_status_t sai_route_initialize(sai_api_service_t* sai_api_service) {
   sai_api_service->route_api = route_api;
   return SAI_STATUS_SUCCESS;
 }

--- a/switchsai/sairoute.c
+++ b/switchsai/sairoute.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchsai/sairouterinterface.c
+++ b/switchsai/sairouterinterface.c
@@ -16,21 +16,21 @@
  */
 
 #include "sairouterinterface.h"
-#include "switchapi/switch_rif.h"
-#include "switchapi/switch_rmac.h"
-#include "switchapi/switch_interface.h"
-#include "switchapi/switch_l3.h"
+
 #include "saiinternal.h"
 #include "switchapi/switch_device.h"
+#include "switchapi/switch_interface.h"
+#include "switchapi/switch_l3.h"
+#include "switchapi/switch_rif.h"
+#include "switchapi/switch_rmac.h"
 
 static sai_status_t sai_create_rmac_internal(sai_object_id_t switch_id,
-                                      uint32_t attr_count,
-                                      const sai_attribute_t *attr_list,
-                                      switch_handle_t *rmac_h) {
-
+                                             uint32_t attr_count,
+                                             const sai_attribute_t* attr_list,
+                                             switch_handle_t* rmac_h) {
   uint32_t index = 0;
   switch_mac_addr_t mac;
-  const sai_attribute_t *attribute;
+  const sai_attribute_t* attribute;
   sai_status_t sai_status = SAI_STATUS_SUCCESS;
   switch_status_t switch_status = SWITCH_STATUS_SUCCESS;
 
@@ -38,7 +38,7 @@ static sai_status_t sai_create_rmac_internal(sai_object_id_t switch_id,
   sai_status = sai_switch_status_to_sai_status(switch_status);
   if (sai_status != SAI_STATUS_SUCCESS) {
     krnlmon_log_error("Failed to get default RMAC handle, error: %s",
-                  sai_status_to_string(sai_status));
+                      sai_status_to_string(sai_status));
     return sai_status;
   }
 
@@ -53,8 +53,8 @@ static sai_status_t sai_create_rmac_internal(sai_object_id_t switch_id,
         if (switch_status == SWITCH_STATUS_SUCCESS) {
           memcpy(&mac.mac_addr, &attribute->value.mac, 6);
           krnlmon_log_debug("MAC: %02x:%02x:%02x:%02x:%02x:%02x, add to group",
-                     mac.mac_addr[0], mac.mac_addr[1], mac.mac_addr[2],
-                     mac.mac_addr[3], mac.mac_addr[4], mac.mac_addr[5]);
+                            mac.mac_addr[0], mac.mac_addr[1], mac.mac_addr[2],
+                            mac.mac_addr[3], mac.mac_addr[4], mac.mac_addr[5]);
           switch_status = switch_api_router_mac_add(switch_id, *rmac_h, &mac);
         }
         sai_status = sai_switch_status_to_sai_status(switch_status);
@@ -69,21 +69,20 @@ static sai_status_t sai_create_rmac_internal(sai_object_id_t switch_id,
 
 static sai_status_t sai_delete_rmac_internal(switch_handle_t rif_handle,
                                              switch_handle_t rmac_handle) {
-
   sai_status_t status = SAI_STATUS_SUCCESS;
   switch_status_t switch_status = SWITCH_STATUS_SUCCESS;
   switch_handle_t tmp_rmac_handle = SWITCH_API_INVALID_HANDLE;
 
   switch_api_device_default_rmac_handle_get(0, &tmp_rmac_handle);
   if (tmp_rmac_handle != rmac_handle) {
-      switch_status = switch_api_router_mac_group_delete(0, rif_handle,
-                                                         rmac_handle);
-      status = sai_switch_status_to_sai_status(switch_status);
-      if (status != SAI_STATUS_SUCCESS) {
-        krnlmon_log_error("Failed to remove router interface, error: %s",
-                  sai_status_to_string(status));
-      }
-      return status;
+    switch_status =
+        switch_api_router_mac_group_delete(0, rif_handle, rmac_handle);
+    status = sai_switch_status_to_sai_status(switch_status);
+    if (status != SAI_STATUS_SUCCESS) {
+      krnlmon_log_error("Failed to remove router interface, error: %s",
+                        sai_status_to_string(status));
+    }
+    return status;
   }
   return status;
 }
@@ -102,16 +101,13 @@ static sai_status_t sai_delete_rmac_internal(switch_handle_t rif_handle,
  *    Failure status code on error
  */
 static sai_status_t sai_create_router_interface(
-    _Out_ sai_object_id_t *rif_id,
-    _In_ sai_object_id_t switch_id,
-    _In_ uint32_t attr_count,
-    _In_ const sai_attribute_t *attr_list) {
-
+    _Out_ sai_object_id_t* rif_id, _In_ sai_object_id_t switch_id,
+    _In_ uint32_t attr_count, _In_ const sai_attribute_t* attr_list) {
   switch_status_t switch_status = SWITCH_STATUS_SUCCESS;
   sai_status_t status = SAI_STATUS_SUCCESS;
   switch_api_rif_info_t api_rif_info = {0};
 
-  const sai_attribute_t *attribute;
+  const sai_attribute_t* attribute;
   switch_handle_t rmac_handle = 0;
   switch_handle_t intf_handle = SWITCH_API_INVALID_HANDLE;
   switch_handle_t rif_handle = SWITCH_API_INVALID_HANDLE;
@@ -122,8 +118,8 @@ static sai_status_t sai_create_router_interface(
     return status;
   }
 
-  attribute = get_attr_from_list(SAI_ROUTER_INTERFACE_ATTR_TYPE,
-                                 attr_list, attr_count);
+  attribute =
+      get_attr_from_list(SAI_ROUTER_INTERFACE_ATTR_TYPE, attr_list, attr_count);
   if (attribute == NULL) {
     status = SAI_STATUS_INVALID_PARAMETER;
     krnlmon_log_error("missing attribute %s", sai_status_to_string(status));
@@ -135,12 +131,11 @@ static sai_status_t sai_create_router_interface(
   // This means interface already created, adding RMAC now
   if (intf_handle) {
     switch_api_rif_attribute_get(switch_id, intf_handle,
-                                 (switch_uint64_t)UINT64_MAX,
-                                 &api_rif_info);
+                                 (switch_uint64_t)UINT64_MAX, &api_rif_info);
     if ((status = sai_switch_status_to_sai_status(switch_status)) !=
         SAI_STATUS_SUCCESS) {
       krnlmon_log_error("Failed to get router interface, error: %s",
-               sai_status_to_string(status));
+                        sai_status_to_string(status));
       return status;
     }
 
@@ -157,7 +152,7 @@ static sai_status_t sai_create_router_interface(
                                       &rmac_handle);
     if (status != SAI_STATUS_SUCCESS) {
       krnlmon_log_error("Failed to create RMAC, error: %s",
-                sai_status_to_string(status));
+                        sai_status_to_string(status));
       return status;
     }
   } else {
@@ -169,8 +164,8 @@ static sai_status_t sai_create_router_interface(
     }
     api_rif_info.rmac_handle = rmac_handle;
 
-    attribute = get_attr_from_list(SAI_ROUTER_INTERFACE_ATTR_PORT_ID,
-                                   attr_list, attr_count);
+    attribute = get_attr_from_list(SAI_ROUTER_INTERFACE_ATTR_PORT_ID, attr_list,
+                                   attr_count);
     if (attribute == NULL) {
       status = SAI_STATUS_INVALID_PARAMETER;
       krnlmon_log_error("missing attribute %s", sai_status_to_string(status));
@@ -179,12 +174,12 @@ static sai_status_t sai_create_router_interface(
 
     api_rif_info.rif_ifindex = attribute->value.u32;
 
-    switch_status = switch_api_rif_create(switch_id, &api_rif_info,
-                                          &rif_handle);
+    switch_status =
+        switch_api_rif_create(switch_id, &api_rif_info, &rif_handle);
     status = sai_switch_status_to_sai_status(switch_status);
     if (status != SAI_STATUS_SUCCESS) {
       krnlmon_log_error("Failed to create router interface, error: %s",
-                    sai_status_to_string(status));
+                        sai_status_to_string(status));
       return status;
     }
     *rif_id = rif_handle;
@@ -204,7 +199,6 @@ static sai_status_t sai_create_router_interface(
  *    Failure status code on error
  */
 static sai_status_t sai_remove_router_interface(_In_ sai_object_id_t rif_id) {
-
   sai_status_t status = SAI_STATUS_SUCCESS;
   switch_api_rif_info_t api_rif_info;
   switch_handle_t rmac_handle = SWITCH_API_INVALID_HANDLE;
@@ -215,7 +209,7 @@ static sai_status_t sai_remove_router_interface(_In_ sai_object_id_t rif_id) {
   if ((status = sai_switch_status_to_sai_status(switch_status)) !=
       SAI_STATUS_SUCCESS) {
     krnlmon_log_error("Failed to remove router interface, error: %s",
-                  sai_status_to_string(status));
+                      sai_status_to_string(status));
     return status;
   }
 
@@ -223,14 +217,14 @@ static sai_status_t sai_remove_router_interface(_In_ sai_object_id_t rif_id) {
   status = sai_delete_rmac_internal((switch_handle_t)rif_id, rmac_handle);
   if (status != SAI_STATUS_SUCCESS) {
     krnlmon_log_error("Failed to remove RMA, erorr: %s",
-                  sai_status_to_string(status));
+                      sai_status_to_string(status));
   }
 
   switch_status = switch_api_rif_delete(0, (switch_handle_t)rif_id);
   status = sai_switch_status_to_sai_status(switch_status);
   if (status != SAI_STATUS_SUCCESS) {
     krnlmon_log_error("Failed to remove router interface, error: %s",
-                  sai_status_to_string(status));
+                      sai_status_to_string(status));
   }
 
   return (sai_status_t)status;
@@ -244,7 +238,7 @@ sai_router_interface_api_t rif_api = {
     .remove_router_interface = sai_remove_router_interface};
 
 sai_status_t sai_router_interface_initialize(
-    sai_api_service_t *sai_api_service) {
+    sai_api_service_t* sai_api_service) {
   sai_api_service->rif_api = rif_api;
   return SAI_STATUS_SUCCESS;
 }

--- a/switchsai/saitunnel.c
+++ b/switchsai/saitunnel.c
@@ -16,63 +16,57 @@
  */
 
 #include "saitunnel.h"
+
 #include "saiinternal.h"
-#include "switchapi/switch_tunnel.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_status.h"
+#include "switchapi/switch_tunnel.h"
 
-char *
-sai_status_to_string(_In_ const sai_status_t status)
-{
-    switch (status) {
-        case SAI_STATUS_INVALID_PARAMETER:
-            return "invalid parameter";
-        case SAI_STATUS_NO_MEMORY:
-            return "no memory";
-        case SAI_STATUS_FAILURE:
-        default:
-            return "unknown failure";
-    }
+char* sai_status_to_string(_In_ const sai_status_t status) {
+  switch (status) {
+    case SAI_STATUS_INVALID_PARAMETER:
+      return "invalid parameter";
+    case SAI_STATUS_NO_MEMORY:
+      return "no memory";
+    case SAI_STATUS_FAILURE:
+    default:
+      return "unknown failure";
+  }
 }
 
-
-sai_status_t
-sai_ip_addr_to_switch_ip_addr(const _In_ sai_ip_address_t *sai_ip_addr,
-                              _Out_ switch_ip_addr_t *ip_addr)
-{
-    if (sai_ip_addr->addr_family == SAI_IP_ADDR_FAMILY_IPV4) {
-        ip_addr->type = SWITCH_API_IP_ADDR_V4;
-        ip_addr->ip.v4addr = ntohl(sai_ip_addr->addr.ip4);
-        ip_addr->prefix_len = 32;
-    } else if (sai_ip_addr->addr_family == SAI_IP_ADDR_FAMILY_IPV6) {
-        ip_addr->type = SWITCH_API_IP_ADDR_V6;
-        memcpy(&ip_addr->ip.v6addr.u.addr8, &sai_ip_addr->addr.ip6, sizeof(sai_ip6_t));
-        ip_addr->prefix_len = 128;
-    }
-    return SAI_STATUS_SUCCESS;
+sai_status_t sai_ip_addr_to_switch_ip_addr(
+    const _In_ sai_ip_address_t* sai_ip_addr, _Out_ switch_ip_addr_t* ip_addr) {
+  if (sai_ip_addr->addr_family == SAI_IP_ADDR_FAMILY_IPV4) {
+    ip_addr->type = SWITCH_API_IP_ADDR_V4;
+    ip_addr->ip.v4addr = ntohl(sai_ip_addr->addr.ip4);
+    ip_addr->prefix_len = 32;
+  } else if (sai_ip_addr->addr_family == SAI_IP_ADDR_FAMILY_IPV6) {
+    ip_addr->type = SWITCH_API_IP_ADDR_V6;
+    memcpy(&ip_addr->ip.v6addr.u.addr8, &sai_ip_addr->addr.ip6,
+           sizeof(sai_ip6_t));
+    ip_addr->prefix_len = 128;
+  }
+  return SAI_STATUS_SUCCESS;
 }
 
-sai_status_t
-sai_switch_status_to_sai_status(_In_ const switch_status_t status)
-{
-    switch (status) {
-        case SWITCH_STATUS_SUCCESS:
-            return SAI_STATUS_SUCCESS;
-        case SWITCH_STATUS_FAILURE:
-            return SWITCH_STATUS_FAILURE;
-        case SWITCH_STATUS_INVALID_PARAMETER:
-            return SAI_STATUS_INVALID_PARAMETER;
-        case SWITCH_STATUS_NO_MEMORY:
-            return SAI_STATUS_NO_MEMORY;
-        default:
-           return SAI_STATUS_FAILURE;
-    }
+sai_status_t sai_switch_status_to_sai_status(
+    _In_ const switch_status_t status) {
+  switch (status) {
+    case SWITCH_STATUS_SUCCESS:
+      return SAI_STATUS_SUCCESS;
+    case SWITCH_STATUS_FAILURE:
+      return SWITCH_STATUS_FAILURE;
+    case SWITCH_STATUS_INVALID_PARAMETER:
+      return SAI_STATUS_INVALID_PARAMETER;
+    case SWITCH_STATUS_NO_MEMORY:
+      return SAI_STATUS_NO_MEMORY;
+    default:
+      return SAI_STATUS_FAILURE;
+  }
 }
 
-static sai_status_t
-sai_tunnel_to_switch_tunnel_type(sai_tunnel_type_t sai_tunnel,
-                                 switch_tunnel_type_t *switch_tunnel)
-{
+static sai_status_t sai_tunnel_to_switch_tunnel_type(
+    sai_tunnel_type_t sai_tunnel, switch_tunnel_type_t* switch_tunnel) {
   sai_status_t status = SAI_STATUS_SUCCESS;
 
   switch (sai_tunnel) {
@@ -94,12 +88,10 @@ sai_tunnel_to_switch_tunnel_type(sai_tunnel_type_t sai_tunnel,
   return status;
 }
 
-static sai_status_t
-sai_tunnel_attribute_parse(uint32_t attr_count,
-                           const sai_attribute_t *attr_list,
-                           switch_api_tunnel_info_t *tunnel_info)
-{
-  const sai_attribute_t *attribute = NULL;
+static sai_status_t sai_tunnel_attribute_parse(
+    uint32_t attr_count, const sai_attribute_t* attr_list,
+    switch_api_tunnel_info_t* tunnel_info) {
+  const sai_attribute_t* attribute = NULL;
   sai_status_t status = SAI_STATUS_SUCCESS;
   uint32_t index = 0;
   for (index = 0; index < attr_count; index++) {
@@ -138,7 +130,7 @@ sai_tunnel_attribute_parse(uint32_t attr_count,
       case SAI_TUNNEL_ATTR_VXLAN_UDP_SPORT:
         tunnel_info->udp_port = attribute->value.u16;
         break;
-      
+
       case SAI_TUNNEL_ATTR_ENCAP_GRE_KEY:
         tunnel_info->gre_key = attribute->value.u32;
         break;
@@ -182,12 +174,10 @@ sai_tunnel_attribute_parse(uint32_t attr_count,
  *    Failure status code on error
  *
  */
-static sai_status_t
-sai_create_tunnel(_Out_ sai_object_id_t *tunnel_id,
-                  _In_ sai_object_id_t switch_id,
-                  _In_ uint32_t attr_count,
-                  _In_ const sai_attribute_t *attr_list)
-{
+static sai_status_t sai_create_tunnel(_Out_ sai_object_id_t* tunnel_id,
+                                      _In_ sai_object_id_t switch_id,
+                                      _In_ uint32_t attr_count,
+                                      _In_ const sai_attribute_t* attr_list) {
   switch_api_tunnel_info_t tunnel_info = {0};
   switch_handle_t tunnel_handle = SWITCH_API_INVALID_HANDLE;
   switch_status_t switch_status = SWITCH_STATUS_SUCCESS;
@@ -205,15 +195,16 @@ sai_create_tunnel(_Out_ sai_object_id_t *tunnel_id,
       switch_api_tunnel_create(switch_id, &tunnel_info, &tunnel_handle);
   status = sai_switch_status_to_sai_status(switch_status);
   if (status != SAI_STATUS_SUCCESS) {
-    krnlmon_log_error(
-        "Failed to create tunnel, error: %s \n",
-        sai_status_to_string(status));
+    krnlmon_log_error("Failed to create tunnel, error: %s \n",
+                      sai_status_to_string(status));
     return status;
   }
 
   *tunnel_id = tunnel_handle;
-  krnlmon_log_debug("tunnel created for dest port: %d and handle"
-           "is: 0x%lx", tunnel_info.udp_port, tunnel_handle);
+  krnlmon_log_debug(
+      "tunnel created for dest port: %d and handle"
+      "is: 0x%lx",
+      tunnel_info.udp_port, tunnel_handle);
 
   return status;
 }
@@ -230,9 +221,7 @@ sai_create_tunnel(_Out_ sai_object_id_t *tunnel_id,
  *    Failure status code on error
  *
  */
-static sai_status_t
-sai_remove_tunnel(_In_ sai_object_id_t tunnel_handle)
-{
+static sai_status_t sai_remove_tunnel(_In_ sai_object_id_t tunnel_handle) {
   sai_status_t status = SAI_STATUS_SUCCESS;
   switch_status_t switch_status = SWITCH_STATUS_SUCCESS;
 
@@ -240,7 +229,7 @@ sai_remove_tunnel(_In_ sai_object_id_t tunnel_handle)
   status = sai_switch_status_to_sai_status(switch_status);
   if (status != SAI_STATUS_SUCCESS) {
     krnlmon_log_error("Failed to delete tunnel, error: %s\n",
-        sai_status_to_string(status));
+                      sai_status_to_string(status));
     return status;
   }
 
@@ -249,9 +238,7 @@ sai_remove_tunnel(_In_ sai_object_id_t tunnel_handle)
   return status;
 }
 
-static char *
-sai_tunnel_string(sai_tunnel_type_t sai_tunnel_type)
-{
+static char* sai_tunnel_string(sai_tunnel_type_t sai_tunnel_type) {
   switch (sai_tunnel_type) {
     case SAI_TUNNEL_TYPE_IPINIP:
       return "IPinIP";
@@ -268,10 +255,9 @@ sai_tunnel_string(sai_tunnel_type_t sai_tunnel_type)
   }
 }
 
-static sai_status_t
-sai_tunnel_term_to_switch_type(sai_tunnel_term_table_entry_type_t sai_type,
-                               switch_tunnel_term_entry_type_t *switch_type)
-{
+static sai_status_t sai_tunnel_term_to_switch_type(
+    sai_tunnel_term_table_entry_type_t sai_type,
+    switch_tunnel_term_entry_type_t* switch_type) {
   sai_status_t status = SAI_STATUS_SUCCESS;
   switch (sai_type) {
     case SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_P2P:
@@ -288,9 +274,8 @@ sai_tunnel_term_to_switch_type(sai_tunnel_term_table_entry_type_t sai_type,
   return status;
 }
 
-static char *
-switch_tunnel_term_type_to_string(switch_tunnel_term_entry_type_t switch_type)
-{
+static char* switch_tunnel_term_type_to_string(
+    switch_tunnel_term_entry_type_t switch_type) {
   switch (switch_type) {
     case SWITCH_TUNNEL_TERM_ENTRY_TYPE_P2P:
       return "term_type_p2p";
@@ -301,16 +286,13 @@ switch_tunnel_term_type_to_string(switch_tunnel_term_entry_type_t switch_type)
   }
 }
 
-static sai_status_t
-sai_tunnel_term_attribute_parse(uint32_t attr_count,
-                                const sai_attribute_t *attr_list,
-                                switch_api_tunnel_term_info_t
-                                *tunnel_term_info)
-{
+static sai_status_t sai_tunnel_term_attribute_parse(
+    uint32_t attr_count, const sai_attribute_t* attr_list,
+    switch_api_tunnel_term_info_t* tunnel_term_info) {
   switch_tunnel_term_entry_type_t switch_tunnel_term_type = 0;
   switch_tunnel_type_t switch_tunnel_type = 0;
   sai_status_t status = SAI_STATUS_SUCCESS;
-  const sai_attribute_t *attr = NULL;
+  const sai_attribute_t* attr = NULL;
   uint32_t index = 0;
 
   for (index = 0; index < attr_count; index++) {
@@ -339,7 +321,8 @@ sai_tunnel_term_attribute_parse(uint32_t attr_count,
                                                 &switch_tunnel_term_type);
         if (status == SAI_STATUS_SUCCESS) {
           tunnel_term_info->term_entry_type = switch_tunnel_term_type;
-          krnlmon_log_debug("Tunnel type %s", sai_tunnel_string(attr->value.s32));
+          krnlmon_log_debug("Tunnel type %s",
+                            sai_tunnel_string(attr->value.s32));
         }
         break;
       case SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TUNNEL_TYPE:
@@ -348,7 +331,7 @@ sai_tunnel_term_attribute_parse(uint32_t attr_count,
         if (status == SAI_STATUS_SUCCESS) {
           tunnel_term_info->tunnel_type = switch_tunnel_type;
           krnlmon_log_debug("Tunnel term type %s",
-                   switch_tunnel_term_type_to_string(attr->value.s32));
+                            switch_tunnel_term_type_to_string(attr->value.s32));
         }
         break;
       default:
@@ -373,12 +356,9 @@ sai_tunnel_term_attribute_parse(uint32_t attr_count,
  *    Failure status code on error
  *
  */
-static sai_status_t
-sai_create_tunnel_term_table_entry(_Out_ sai_object_id_t *tunnel_term_id,
-                                   _In_ sai_object_id_t switch_id,
-                                   _In_ uint32_t attr_count,
-                                   _In_ const sai_attribute_t *attr_list)
-{
+static sai_status_t sai_create_tunnel_term_table_entry(
+    _Out_ sai_object_id_t* tunnel_term_id, _In_ sai_object_id_t switch_id,
+    _In_ uint32_t attr_count, _In_ const sai_attribute_t* attr_list) {
   switch_handle_t tunnel_term_handle = SWITCH_API_INVALID_HANDLE;
   switch_status_t switch_status = SWITCH_STATUS_SUCCESS;
   switch_api_tunnel_term_info_t api_term_info = {0};
@@ -386,10 +366,13 @@ sai_create_tunnel_term_table_entry(_Out_ sai_object_id_t *tunnel_term_id,
 
   SAI_MEMSET(&api_term_info, 0, sizeof(switch_api_tunnel_term_info_t));
 
-  status = sai_tunnel_term_attribute_parse(attr_count, attr_list, &api_term_info);
+  status =
+      sai_tunnel_term_attribute_parse(attr_count, attr_list, &api_term_info);
   if (status != SAI_STATUS_SUCCESS) {
-    krnlmon_log_error("Failed to parse atributes when creating tunnel term "
-             "table entry, error: %s \n", sai_status_to_string(status));
+    krnlmon_log_error(
+        "Failed to parse atributes when creating tunnel term "
+        "table entry, error: %s \n",
+        sai_status_to_string(status));
     return status;
   }
 
@@ -397,13 +380,16 @@ sai_create_tunnel_term_table_entry(_Out_ sai_object_id_t *tunnel_term_id,
                                                 &tunnel_term_handle);
   status = sai_switch_status_to_sai_status(switch_status);
   if (status != SAI_STATUS_SUCCESS) {
-    krnlmon_log_error("Failed to create tunnel term table entry, "
-             "error: %s", sai_status_to_string(status));
+    krnlmon_log_error(
+        "Failed to create tunnel term table entry, "
+        "error: %s",
+        sai_status_to_string(status));
     return status;
   }
 
   *tunnel_term_id = tunnel_term_handle;
-  krnlmon_log_debug("Tunnel term table entry add, handle 0x%lx", tunnel_term_handle);
+  krnlmon_log_debug("Tunnel term table entry add, handle 0x%lx",
+                    tunnel_term_handle);
   return status;
 }
 
@@ -419,9 +405,8 @@ sai_create_tunnel_term_table_entry(_Out_ sai_object_id_t *tunnel_term_id,
  *    Failure status code on error
  *
  */
-static sai_status_t
-sai_remove_tunnel_term_table_entry(_In_ sai_object_id_t tunnel_term_handle)
-{
+static sai_status_t sai_remove_tunnel_term_table_entry(
+    _In_ sai_object_id_t tunnel_term_handle) {
   sai_status_t status = SAI_STATUS_SUCCESS;
   switch_status_t switch_status = SWITCH_STATUS_SUCCESS;
 
@@ -429,12 +414,12 @@ sai_remove_tunnel_term_table_entry(_In_ sai_object_id_t tunnel_term_handle)
   status = sai_switch_status_to_sai_status(switch_status);
   if (status != SAI_STATUS_SUCCESS) {
     krnlmon_log_error("Failed to delete tunnel term table entry, error: %s",
-              sai_status_to_string(status));
+                      sai_status_to_string(status));
     return status;
   }
 
   krnlmon_log_debug("Tunnel term table entry delete success, handle 0x%lx",
-            tunnel_term_handle);
+                    tunnel_term_handle);
   return status;
 }
 
@@ -447,9 +432,7 @@ sai_tunnel_api_t tunnel_api = {
     .create_tunnel_term_table_entry = sai_create_tunnel_term_table_entry,
     .remove_tunnel_term_table_entry = sai_remove_tunnel_term_table_entry};
 
-sai_status_t
-sai_tunnel_initialize(sai_api_service_t *sai_api_service)
-{
+sai_status_t sai_tunnel_initialize(sai_api_service_t* sai_api_service) {
   sai_api_service->tunnel_api = tunnel_api;
   return SAI_STATUS_SUCCESS;
 }

--- a/switchsai/saitunnel.c
+++ b/switchsai/saitunnel.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchsai/saiutils.c
+++ b/switchsai/saiutils.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022-2023 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchsai/saiutils.c
+++ b/switchsai/saiutils.c
@@ -15,13 +15,11 @@
  * limitations under the License.
  */
 
-#include "switchapi/switch_base_types.h"
 #include "saiinternal.h"
+#include "switchapi/switch_base_types.h"
 
-sai_status_t
-sai_ipv4_prefix_length(_In_ sai_ip4_t ip4,
-                       _Out_ uint32_t *prefix_length)
-{
+sai_status_t sai_ipv4_prefix_length(_In_ sai_ip4_t ip4,
+                                    _Out_ uint32_t* prefix_length) {
   int x = 0;
   *prefix_length = 0;
   while (ip4) {
@@ -32,10 +30,8 @@ sai_ipv4_prefix_length(_In_ sai_ip4_t ip4,
   return SAI_STATUS_SUCCESS;
 }
 
-sai_status_t
-sai_ipv6_prefix_length(_In_ const sai_ip6_t ip6,
-                       _Out_ uint32_t *prefix_length)
-{
+sai_status_t sai_ipv6_prefix_length(_In_ const sai_ip6_t ip6,
+                                    _Out_ uint32_t* prefix_length) {
   int i = 0, x = 0;
   sai_ip6_t ip6_temp;
   memcpy(ip6_temp, ip6, 16);
@@ -54,11 +50,9 @@ sai_ipv6_prefix_length(_In_ const sai_ip6_t ip6,
   return SAI_STATUS_SUCCESS;
 }
 
-const sai_attribute_t
-*get_attr_from_list(_In_ sai_attr_id_t attr_id,
-                    _In_ const sai_attribute_t *attr_list,
-                    _In_ uint32_t attr_count)
-{
+const sai_attribute_t* get_attr_from_list(_In_ sai_attr_id_t attr_id,
+                                          _In_ const sai_attribute_t* attr_list,
+                                          _In_ uint32_t attr_count) {
   if (attr_list == NULL || attr_count == 0) {
     return NULL;
   }
@@ -72,54 +66,42 @@ const sai_attribute_t
   return NULL;
 }
 
-sai_status_t
-sai_ipv4_to_string(_In_ sai_ip4_t ip4,
-                   _In_ uint32_t max_length,
-                   _Out_ char *entry_string,
-                   _Out_ int *entry_length)
-{
+sai_status_t sai_ipv4_to_string(_In_ sai_ip4_t ip4, _In_ uint32_t max_length,
+                                _Out_ char* entry_string,
+                                _Out_ int* entry_length) {
   inet_ntop(AF_INET, &ip4, entry_string, max_length);
   *entry_length = (int)strlen(entry_string);
   return SAI_STATUS_SUCCESS;
 }
 
-sai_status_t
-sai_ipv6_to_string(_In_ sai_ip6_t ip6,
-                   _In_ uint32_t max_length,
-                   _Out_ char *entry_string,
-                   _Out_ int *entry_length)
-{
+sai_status_t sai_ipv6_to_string(_In_ sai_ip6_t ip6, _In_ uint32_t max_length,
+                                _Out_ char* entry_string,
+                                _Out_ int* entry_length) {
   inet_ntop(AF_INET6, &ip6, entry_string, max_length);
   *entry_length = (int)strnlen(entry_string, max_length);
   return SAI_STATUS_SUCCESS;
 }
 
-sai_status_t
-sai_ipaddress_to_string(_In_ sai_ip_address_t ip_addr,
-                        _In_ uint32_t max_length,
-                        _Out_ char *entry_string,
-                        _Out_ int *entry_length)
-{
+sai_status_t sai_ipaddress_to_string(_In_ sai_ip_address_t ip_addr,
+                                     _In_ uint32_t max_length,
+                                     _Out_ char* entry_string,
+                                     _Out_ int* entry_length) {
   if (ip_addr.addr_family == SAI_IP_ADDR_FAMILY_IPV4) {
-    sai_ipv4_to_string(
-        ip_addr.addr.ip4, max_length, entry_string, entry_length);
+    sai_ipv4_to_string(ip_addr.addr.ip4, max_length, entry_string,
+                       entry_length);
   } else if (ip_addr.addr_family == SAI_IP_ADDR_FAMILY_IPV6) {
-    sai_ipv6_to_string(
-        ip_addr.addr.ip6, max_length, entry_string, entry_length);
+    sai_ipv6_to_string(ip_addr.addr.ip6, max_length, entry_string,
+                       entry_length);
   } else {
-    snprintf(entry_string,
-             max_length,
-             "Invalid addr family %d",
+    snprintf(entry_string, max_length, "Invalid addr family %d",
              ip_addr.addr_family);
     return SAI_STATUS_INVALID_PARAMETER;
   }
   return SAI_STATUS_SUCCESS;
 }
 
-sai_status_t
-sai_ip_prefix_to_switch_ip_addr(const _In_ sai_ip_prefix_t *sai_ip_addr,
-                                _Out_ switch_ip_addr_t *ip_addr)
-{
+sai_status_t sai_ip_prefix_to_switch_ip_addr(
+    const _In_ sai_ip_prefix_t* sai_ip_addr, _Out_ switch_ip_addr_t* ip_addr) {
   if (sai_ip_addr->addr_family == SAI_IP_ADDR_FAMILY_IPV4) {
     ip_addr->type = SWITCH_API_IP_ADDR_V4;
     ip_addr->ip.v4addr = ntohl(sai_ip_addr->addr.ip4);
@@ -132,12 +114,10 @@ sai_ip_prefix_to_switch_ip_addr(const _In_ sai_ip_prefix_t *sai_ip_addr,
   return SAI_STATUS_SUCCESS;
 }
 
-sai_status_t
-sai_ipprefix_to_string(_In_ sai_ip_prefix_t ip_prefix,
-                       _In_ uint32_t max_length,
-                       _Out_ char *entry_string,
-                       _Out_ int *entry_length)
-{
+sai_status_t sai_ipprefix_to_string(_In_ sai_ip_prefix_t ip_prefix,
+                                    _In_ uint32_t max_length,
+                                    _Out_ char* entry_string,
+                                    _Out_ int* entry_length) {
   int len = 0;
   uint32_t pos = 0;
 
@@ -153,8 +133,8 @@ sai_ipprefix_to_string(_In_ sai_ip_prefix_t ip_prefix,
       *entry_length = max_length;
       return SAI_STATUS_SUCCESS;
     }
-    sai_ipv4_to_string(
-        ip_prefix.mask.ip4, max_length - pos, entry_string + pos, &len);
+    sai_ipv4_to_string(ip_prefix.mask.ip4, max_length - pos, entry_string + pos,
+                       &len);
     pos += len;
     if (pos > max_length) {
       *entry_length = max_length;
@@ -172,17 +152,15 @@ sai_ipprefix_to_string(_In_ sai_ip_prefix_t ip_prefix,
       *entry_length = max_length;
       return SAI_STATUS_SUCCESS;
     }
-    sai_ipv6_to_string(
-        ip_prefix.mask.ip6, max_length - pos, entry_string + pos, &len);
+    sai_ipv6_to_string(ip_prefix.mask.ip6, max_length - pos, entry_string + pos,
+                       &len);
     pos += len;
     if (pos > max_length) {
       *entry_length = max_length;
       return SAI_STATUS_SUCCESS;
     }
   } else {
-    snprintf(entry_string,
-             max_length,
-             "Invalid addr family %d",
+    snprintf(entry_string, max_length, "Invalid addr family %d",
              ip_prefix.addr_family);
     return SAI_STATUS_INVALID_PARAMETER;
   }

--- a/switchsai/saivirtualrouter.c
+++ b/switchsai/saivirtualrouter.c
@@ -16,15 +16,14 @@
  */
 
 #include "saivirtualrouter.h"
-#include "switchapi/switch_vrf.h"
+
 #include "saiinternal.h"
 #include "switchapi/switch_base_types.h"
+#include "switchapi/switch_vrf.h"
 
-static void
-sai_vrf_entry_attribute_parse(uint32_t attr_count,
-                              const sai_attribute_t *attr_list)
-{
-  const sai_attribute_t *attribute;
+static void sai_vrf_entry_attribute_parse(uint32_t attr_count,
+                                          const sai_attribute_t* attr_list) {
+  const sai_attribute_t* attribute;
   uint32_t i = 0;
 
   for (i = 0; i < attr_count; i++) {
@@ -43,26 +42,22 @@ sai_vrf_entry_attribute_parse(uint32_t attr_count,
 }
 
 /*
-* Routine Description:
-*    Create virtual router
-*
-* Arguments:
-*    [out] vr_id - virtual router id
-*    [in] attr_count - number of attributes
-*    [in] attr_list - array of attributes
-*
-* Return Values:
-*  - SAI_STATUS_SUCCESS on success
-*  - SAI_STATUS_ADDR_NOT_FOUND if neither SAI_SWITCH_ATTR_SRC_MAC_ADDRESS nor
-*    SAI_VIRTUAL_ROUTER_ATTR_SRC_MAC_ADDRESS is set.
-*/
-static sai_status_t
-sai_create_virtual_router_entry(_Out_ sai_object_id_t *vr_id,
-                                _In_ sai_object_id_t switch_id,
-                                _In_ uint32_t attr_count,
-                                _In_ const sai_attribute_t *attr_list)
-{
-
+ * Routine Description:
+ *    Create virtual router
+ *
+ * Arguments:
+ *    [out] vr_id - virtual router id
+ *    [in] attr_count - number of attributes
+ *    [in] attr_list - array of attributes
+ *
+ * Return Values:
+ *  - SAI_STATUS_SUCCESS on success
+ *  - SAI_STATUS_ADDR_NOT_FOUND if neither SAI_SWITCH_ATTR_SRC_MAC_ADDRESS nor
+ *    SAI_VIRTUAL_ROUTER_ATTR_SRC_MAC_ADDRESS is set.
+ */
+static sai_status_t sai_create_virtual_router_entry(
+    _Out_ sai_object_id_t* vr_id, _In_ sai_object_id_t switch_id,
+    _In_ uint32_t attr_count, _In_ const sai_attribute_t* attr_list) {
   sai_status_t status = SAI_STATUS_SUCCESS;
   switch_vrf_t vrf_id = 0;
   switch_handle_t vrf_handle = SWITCH_API_INVALID_HANDLE;
@@ -75,7 +70,7 @@ sai_create_virtual_router_entry(_Out_ sai_object_id_t *vr_id,
   status = (sai_object_id_t)switch_api_vrf_create(0, vrf_id, &vrf_handle);
   if (status != SAI_STATUS_SUCCESS) {
     krnlmon_log_error("failed to create virtual router entry : %s",
-                  sai_status_to_string(status));
+                      sai_status_to_string(status));
   }
   *vr_id = vrf_handle;
 
@@ -83,19 +78,18 @@ sai_create_virtual_router_entry(_Out_ sai_object_id_t *vr_id,
 }
 
 /*
-* Routine Description:
-*    Remove virtual router
-*
-* Arguments:
-*    [in] vr_id - virtual router id
-*
-* Return Values:
-*    SAI_STATUS_SUCCESS on success
-*    Failure status code on error
-*/
-static sai_status_t
-sai_remove_virtual_router_entry(_In_ sai_object_id_t vr_id)
-{
+ * Routine Description:
+ *    Remove virtual router
+ *
+ * Arguments:
+ *    [in] vr_id - virtual router id
+ *
+ * Return Values:
+ *    SAI_STATUS_SUCCESS on success
+ *    Failure status code on error
+ */
+static sai_status_t sai_remove_virtual_router_entry(
+    _In_ sai_object_id_t vr_id) {
   sai_status_t status = SAI_STATUS_SUCCESS;
   switch_status_t switch_status = SWITCH_STATUS_SUCCESS;
 
@@ -104,24 +98,21 @@ sai_remove_virtual_router_entry(_In_ sai_object_id_t vr_id)
   status = sai_switch_status_to_sai_status(switch_status);
 
   if (status != SAI_STATUS_SUCCESS) {
-    krnlmon_log_error("failed to remove virtual router entry %lx : %s",
-                  vr_id,
-                  sai_status_to_string(status));
+    krnlmon_log_error("failed to remove virtual router entry %lx : %s", vr_id,
+                      sai_status_to_string(status));
   }
 
   return (sai_status_t)status;
 }
 
 /*
-*  Virtual router methods table retrieved with sai_api_query()
-*/
+ *  Virtual router methods table retrieved with sai_api_query()
+ */
 sai_virtual_router_api_t vr_api = {
     .create_virtual_router = sai_create_virtual_router_entry,
     .remove_virtual_router = sai_remove_virtual_router_entry};
 
-sai_status_t
-sai_virtual_router_initialize(sai_api_service_t *sai_api_service)
-{
+sai_status_t sai_virtual_router_initialize(sai_api_service_t* sai_api_service) {
   sai_api_service->vr_api = vr_api;
   return SAI_STATUS_SUCCESS;
 }

--- a/switchsai/saivirtualrouter.c
+++ b/switchsai/saivirtualrouter.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchutils/switch_log.h
+++ b/switchutils/switch_log.h
@@ -5,19 +5,19 @@
 #include "bf_sal/bf_sys_log.h"
 
 #define krnlmon_log_critical(...) \
-bf_sys_log_and_trace(KRNLMON, BF_LOG_CRIT, __VA_ARGS__)
+  bf_sys_log_and_trace(KRNLMON, BF_LOG_CRIT, __VA_ARGS__)
 
 #define krnlmon_log_error(...) \
-bf_sys_log_and_trace(KRNLMON, BF_LOG_ERR, __VA_ARGS__)
+  bf_sys_log_and_trace(KRNLMON, BF_LOG_ERR, __VA_ARGS__)
 
 #define krnlmon_log_warn(...) \
-bf_sys_log_and_trace(KRNLMON, BF_LOG_WARN, __VA_ARGS__)
+  bf_sys_log_and_trace(KRNLMON, BF_LOG_WARN, __VA_ARGS__)
 
 #define krnlmon_log_info(...) \
-bf_sys_log_and_trace(KRNLMON, BF_LOG_INFO, __VA_ARGS__)
+  bf_sys_log_and_trace(KRNLMON, BF_LOG_INFO, __VA_ARGS__)
 
 #define krnlmon_log_debug(...) \
-bf_sys_log_and_trace(KRNLMON, BF_LOG_DBG, __VA_ARGS__)
+  bf_sys_log_and_trace(KRNLMON, BF_LOG_DBG, __VA_ARGS__)
 
 #define krnlmon_log krnlmon_log_debug
 

--- a/switchutils/switch_utils.h
+++ b/switchutils/switch_utils.h
@@ -19,10 +19,11 @@
 #define __KRNLMON_UTILS_H__
 
 #include <assert.h>
+
 #include "switch_log.h"
 
-#define krnlmon_assert                  assert
-#define krnlmon_snprintf                snprintf
-#define krnlmon_assert_perror           assert_perror
+#define krnlmon_assert assert
+#define krnlmon_snprintf snprintf
+#define krnlmon_assert_perror assert_perror
 
 #endif /* __KRNLMON_UTILS_H__*/

--- a/switchutils/switch_utils.h
+++ b/switchutils/switch_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright 2022-2023 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
- Use clang-format to canonicalize the C source files.

- Fix issues in header file dependencies that were revealed
  when we reformatted the source files with clang-format.

- Correct a couple of aberrant include guards.

-  Update Intel copyright notices.

This is largely a _pro forma_ review. The majority of the changes were made by procedures that are inherently trustworthy (running `clang-format`; doing a global search-and-replace on comment text). As a rule, they require only cursory inspection, primarily to make you aware of the transformation.

The thing to focus on here is the [second of the three commits](https://github.com/ipdk-io/krnlmon/pull/62/commits/4d5356e22e6d9d601f6c73a443bf5a7e2bb073e7). These are manual changes that were made to fix issues that were exposed when clang-format reordered #include statements that were order-sensitive.