### PR TITLE
dpdk build fix for LAG

### DIFF
--- a/switchsai/CMakeLists.txt
+++ b/switchsai/CMakeLists.txt
@@ -3,20 +3,38 @@
 # Copyright 2022 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-add_library(switchsai_o OBJECT
-   sai.c
-   saifdb.c
-   saiinternal.h
-   sailag.c
-   saineighbor.c
-   sainexthop.c
-   sainexthopgroup.c
-   sairoute.c
-   sairouterinterface.c
-   saitunnel.c
-   saiutils.c
-   saivirtualrouter.c
-)
+if(DPDK_TARGET)
+  add_library(switchsai_o OBJECT
+     sai.c
+     saifdb.c
+     saiinternal.h
+     saineighbor.c
+     sainexthop.c
+     sainexthopgroup.c
+     sairoute.c
+     sairouterinterface.c
+     saitunnel.c
+     saiutils.c
+     saivirtualrouter.c
+  )
+endif()
+
+if(ES2K_TARGET)
+  add_library(switchsai_o OBJECT
+     sai.c
+     saifdb.c
+     saiinternal.h
+     sailag.c
+     saineighbor.c
+     sainexthop.c
+     sainexthopgroup.c
+     sairoute.c
+     sairouterinterface.c
+     saitunnel.c
+     saiutils.c
+     saivirtualrouter.c
+  )
+endif()
 
 target_include_directories(switchsai_o PRIVATE
     ${SAI_INCLUDE_DIR}

--- a/switchsai/sai.c
+++ b/switchsai/sai.c
@@ -445,8 +445,9 @@ sai_status_t sai_initialize(void) {
   sai_virtual_router_initialize(&sai_api_service);
   sai_neighbor_initialize(&sai_api_service);
   sai_tunnel_initialize(&sai_api_service);
+#if defined(ES2K_TARGET)
   sai_lag_initialize(&sai_api_service);
-
+#endif
   return SAI_STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
This PR fixes the breakage in the DPDK build due to introduction of LAG feature for ES2K target.

Switchsai module invokes the switchapi calls. We don't have the switchapi LAG calls for DPDK target, hence we don't want to include sailag.c in the DPDK build.