### PR TITLE
Fix broken DPDK build

### DIFF
--- a/switchsai/CMakeLists.txt
+++ b/switchsai/CMakeLists.txt
@@ -1,13 +1,12 @@
 # CMake build file for krnlmon/switchsai
 #
-# Copyright 2022 Intel Corporation
+# Copyright 2022-2023 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
 add_library(switchsai_o OBJECT
    sai.c
    saifdb.c
    saiinternal.h
-   sailag.c
    saineighbor.c
    sainexthop.c
    sainexthopgroup.c
@@ -17,6 +16,10 @@ add_library(switchsai_o OBJECT
    saiutils.c
    saivirtualrouter.c
 )
+
+if(ES2K_TARGET)
+  target_sources(switchsai_o OBJECT PRIVATE sailag.c)
+endif()
 
 target_include_directories(switchsai_o PRIVATE
     ${SAI_INCLUDE_DIR}

--- a/switchsai/sai.c
+++ b/switchsai/sai.c
@@ -445,7 +445,9 @@ sai_status_t sai_initialize(void) {
   sai_virtual_router_initialize(&sai_api_service);
   sai_neighbor_initialize(&sai_api_service);
   sai_tunnel_initialize(&sai_api_service);
+#if defined(ES2K_TARGET)
   sai_lag_initialize(&sai_api_service);
+#endif
 
   return SAI_STATUS_SUCCESS;
 }


### PR DESCRIPTION
- Only enable lag support when building for ES2K.