### PR TITLE
Implement Krnlmon CI pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,0 +1,95 @@
+name: "Krnlmon CI Pipeline"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+  workflow_dispatch:
+
+concurrency:
+  # If workflow for PR or push is already running, stop it and start a new one.
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  #---------------------------------------------------------------------
+  # Environment variables
+  #---------------------------------------------------------------------
+  SDE_REPOSITORY: ipdk-io/p4dev.dpdk-sde
+  SDE_TAG: 2023.10.1
+  SDE_FILENAME: dpdk-sde-dev-ubuntu-20.04.tar.gz
+  SDE_INSTALL_DIR: /opt/p4dev/dpdk-sde
+
+  DEPS_REPOSITORY: ipdk-io/stratum-deps
+  DEPS_TAG: v1.2.1
+  DEPS_FILENAME: deps-ubuntu-latest-x86_64.tar.gz
+  DEPS_INSTALL_DIR: /opt/p4dev/x86deps
+
+  PREREQS: libbsd-dev libnl-3-dev libnl-route-3-dev libnl-genl-3-dev
+
+jobs:
+  #---------------------------------------------------------------------
+  # check_krnlmon_dpdk
+  #---------------------------------------------------------------------
+  check_krnlmon_dpdk:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out krnlmon repository
+        uses: actions/checkout@v3
+        with:
+          path: krnlmon
+
+      - name: Check out SAI repository
+        uses: actions/checkout@v3
+        with:
+          repository: opencomputeproject/SAI
+          path: SAI
+
+      - name: Check out networking-recipe
+        uses: actions/checkout@v3
+        with:
+          repository: ipdk-io/networking-recipe
+          path: recipe
+
+      - name: Install prerequisites
+        run: |
+          sudo apt install $PREREQS
+
+      - name: Install DPDK SDE
+        uses: robinraju/release-downloader@v1.8
+        with:
+          repository: ${{ env.SDE_REPOSITORY }}
+          tag: ${{ env.SDE_TAG }}
+          fileName: ${{ env.SDE_FILENAME }}
+
+      - run: |
+          sudo tar -xzf $SDE_FILENAME -C /
+          rm $SDE_FILENAME
+
+      - name: Install stratum dependencies
+        uses: robinraju/release-downloader@v1.8
+        with:
+          repository: ${{ env.DEPS_REPOSITORY }}
+          tag: ${{ env.DEPS_TAG }}
+          fileName: ${{ env.DEPS_FILENAME }}
+
+      - run: |
+          sudo tar -xzf $DEPS_FILENAME -C /
+          rm $DEPS_FILENAME
+
+      - name: Create pipeline.cmake file
+        working-directory: krnlmon
+        run: |
+          echo "set(CMAKE_MODULE_PATH \"$GITHUB_WORKSPACE/recipe/cmake\" CACHE PATH \"\")" > pipeline.cmake
+          echo "set(SAI_SOURCE_DIR \"$GITHUB_WORKSPACE/SAI\" CACHE PATH \"\")" >> pipeline.cmake
+
+      - name: Run unit tests
+        working-directory: krnlmon
+        run: |
+          export DEPEND_INSTALL=$DEPS_INSTALL_DIR
+          export SDE_INSTALL=$SDE_INSTALL_DIR
+          cmake -S . -B build -C pipeline.cmake -DTDI_TARGET=DPDK
+          cmake --build build --target krnlmon-test

--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
+<!-- markdownlint-disable MD041 -->
+[![Krnlmon CI Pipeline](https://github.com/ipdk-io/krnlmon/actions/workflows/pipeline.yml/badge.svg)](https://github.com/ipdk-io/krnlmon/actions/workflows/pipeline.yml)
+<!-- markdownlint-enable MD041 -->
+
 # ipdk-io/krnlmon
-The Kernel Monitor receives RFC 3549 messages from the Linux Kernel over a Netlink socket when changes are made to the kernel networking data structures.
+
+The Kernel Monitor receives RFC 3549 messages from the Linux Kernel over a
+Netlink socket when changes are made to the kernel networking data structures.
 
 ## Breaking changes
 
 ### 11 Oct 2023
 
-- https://github.com/ipdk-io/krnlmon/pull/59: The NextHop table in the P4 program has been moved from the SEM block (exact match) to the WCM block (ternary block). The Kernel Monitor must use a different API to write the entry to the WCM block. krnlmon is no longer compatible with older versions of the P4 program.
+- https://github.com/ipdk-io/krnlmon/pull/59: The NextHop table in the P4
+program has been moved from the SEM block (exact match) to the WCM block
+(ternary block). The Kernel Monitor must use a different API to write the
+entry to the WCM block. krnlmon is no longer compatible with older versions
+of the P4 program.


### PR DESCRIPTION
- Define a GitHub pipeline to run the DPDK unit test suite when a push or pull request is issued against the main branch of the krnlmon repository.