### PR TITLE
Build Fix for ES2K

### DIFF
--- a/switchsai/CMakeLists.txt
+++ b/switchsai/CMakeLists.txt
@@ -18,7 +18,7 @@ add_library(switchsai_o OBJECT
 )
 
 if(ES2K_TARGET)
-  target_sources(switchsai_o OBJECT PRIVATE sailag.c)
+  target_sources(switchsai_o PRIVATE sailag.c)
 endif()
 
 target_include_directories(switchsai_o PRIVATE


### PR DESCRIPTION
The P4-CP build was failing for the ES2K target. The current PR addresses it.