### PR TITLE
Implement dpdk_build_check

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -31,9 +31,74 @@ env:
 
 jobs:
   #---------------------------------------------------------------------
-  # check_krnlmon_dpdk
+  # 1 - dpdk_build_check
   #---------------------------------------------------------------------
-  check_krnlmon_dpdk:
+  dpdk_build_check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out krnlmon repository
+        uses: actions/checkout@v3
+        with:
+          path: krnlmon
+
+      - name: Check out SAI repository
+        uses: actions/checkout@v3
+        with:
+          repository: opencomputeproject/SAI
+          path: SAI
+
+      - name: Check out networking-recipe
+        uses: actions/checkout@v3
+        with:
+          repository: ipdk-io/networking-recipe
+          path: recipe
+
+      - name: Install prerequisites
+        run: |
+          sudo apt install $PREREQS
+
+      - name: Install DPDK SDE
+        uses: robinraju/release-downloader@v1.8
+        with:
+          repository: ${{ env.SDE_REPOSITORY }}
+          tag: ${{ env.SDE_TAG }}
+          fileName: ${{ env.SDE_FILENAME }}
+
+      - run: |
+          sudo tar -xzf $SDE_FILENAME -C /
+          rm $SDE_FILENAME
+
+      - name: Install stratum dependencies
+        uses: robinraju/release-downloader@v1.8
+        with:
+          repository: ${{ env.DEPS_REPOSITORY }}
+          tag: ${{ env.DEPS_TAG }}
+          fileName: ${{ env.DEPS_FILENAME }}
+
+      - run: |
+          sudo tar -xzf $DEPS_FILENAME -C /
+          rm $DEPS_FILENAME
+
+      - name: Create pipeline.cmake file
+        working-directory: krnlmon
+        run: |
+          echo "set(CMAKE_MODULE_PATH \"$GITHUB_WORKSPACE/recipe/cmake\" CACHE PATH \"\")" > pipeline.cmake
+          echo "set(CMAKE_PREFIX_PATH \"$GITHUB_WORKSPACE/krnlmon/install\" CACHE PATH \"\")" > pipeline.cmake
+          echo "set(SAI_SOURCE_DIR \"$GITHUB_WORKSPACE/SAI\" CACHE PATH \"\")" >> pipeline.cmake
+
+      - name: Run unit tests
+        working-directory: krnlmon
+        run: |
+          export DEPEND_INSTALL=$DEPS_INSTALL_DIR
+          export SDE_INSTALL=$SDE_INSTALL_DIR
+          cmake -S . -B build -C pipeline.cmake -DTDI_TARGET=DPDK
+          cmake --build build -j4 --target install
+
+  #---------------------------------------------------------------------
+  # 2 - dpdk_unit_tests
+  #---------------------------------------------------------------------
+  dpdk_unit_tests:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -43,11 +43,11 @@ jobs:
           repository: ipdk-io/networking-recipe
           path: recipe
 
-      - name: Check out SAI repository
-        uses: actions/checkout@v3
-        with:
-          repository: opencomputeproject/SAI
-          path: SAI
+      - name: Fetch krnlmon and SAI submodules
+        working-directory: recipe
+        run: |
+          git submodule update --init krnlmon/krnlmon
+          git submodule update --init krnlmon/SAI
 
       - name: Install dpdk-sde
         uses: robinraju/release-downloader@v1.8
@@ -94,11 +94,11 @@ jobs:
           repository: ipdk-io/networking-recipe
           path: recipe
 
-      - name: Check out SAI repository
-        uses: actions/checkout@v3
-        with:
-          repository: opencomputeproject/SAI
-          path: SAI
+      - name: Fetch krnlmon and SAI submodules
+        working-directory: recipe
+        run: |
+          git submodule update --init krnlmon/krnlmon
+          git submodule update --init krnlmon/SAI
 
       - name: Install dpdk-sde
         uses: robinraju/release-downloader@v1.8

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -37,10 +37,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out krnlmon repository
+      - name: Check out networking-recipe
         uses: actions/checkout@v3
         with:
-          path: krnlmon
+          repository: ipdk-io/networking-recipe
+          path: recipe
 
       - name: Check out SAI repository
         uses: actions/checkout@v3
@@ -48,52 +49,37 @@ jobs:
           repository: opencomputeproject/SAI
           path: SAI
 
-      - name: Check out networking-recipe
-        uses: actions/checkout@v3
-        with:
-          repository: ipdk-io/networking-recipe
-          path: recipe
-
-      - name: Install prerequisites
-        run: |
-          sudo apt install $PREREQS
-
-      - name: Install DPDK SDE
+      - name: Install dpdk-sde
         uses: robinraju/release-downloader@v1.8
         with:
           repository: ${{ env.SDE_REPOSITORY }}
           tag: ${{ env.SDE_TAG }}
           fileName: ${{ env.SDE_FILENAME }}
-
       - run: |
           sudo tar -xzf $SDE_FILENAME -C /
           rm $SDE_FILENAME
 
-      - name: Install stratum dependencies
+      - name: Install stratum-deps
         uses: robinraju/release-downloader@v1.8
         with:
           repository: ${{ env.DEPS_REPOSITORY }}
           tag: ${{ env.DEPS_TAG }}
           fileName: ${{ env.DEPS_FILENAME }}
-
       - run: |
           sudo tar -xzf $DEPS_FILENAME -C /
           rm $DEPS_FILENAME
 
-      - name: Create pipeline.cmake file
-        working-directory: krnlmon
+      - name: Install prerequisites
         run: |
-          echo "set(CMAKE_MODULE_PATH \"$GITHUB_WORKSPACE/recipe/cmake\" CACHE PATH \"\")" > pipeline.cmake
-          echo "set(CMAKE_PREFIX_PATH \"$GITHUB_WORKSPACE/krnlmon/install\" CACHE PATH \"\")" > pipeline.cmake
-          echo "set(SAI_SOURCE_DIR \"$GITHUB_WORKSPACE/SAI\" CACHE PATH \"\")" >> pipeline.cmake
+          sudo apt install $PREREQS
 
-      - name: Run unit tests
+      - name: Build krnlmon
         working-directory: krnlmon
         run: |
           export DEPEND_INSTALL=$DEPS_INSTALL_DIR
           export SDE_INSTALL=$SDE_INSTALL_DIR
-          cmake -S . -B build -C pipeline.cmake -DTDI_TARGET=DPDK
-          cmake --build build -j4 --target install
+          ./make-all.sh --target=dpdk --rpath --no-build
+          cmake --build build -j4 --target krnlmon
 
   #---------------------------------------------------------------------
   # 2 - dpdk_unit_tests
@@ -102,10 +88,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out krnlmon repository
+      - name: Check out networking-recipe
         uses: actions/checkout@v3
         with:
-          path: krnlmon
+          repository: ipdk-io/networking-recipe
+          path: recipe
 
       - name: Check out SAI repository
         uses: actions/checkout@v3
@@ -113,48 +100,34 @@ jobs:
           repository: opencomputeproject/SAI
           path: SAI
 
-      - name: Check out networking-recipe
-        uses: actions/checkout@v3
-        with:
-          repository: ipdk-io/networking-recipe
-          path: recipe
-
-      - name: Install prerequisites
-        run: |
-          sudo apt install $PREREQS
-
-      - name: Install DPDK SDE
+      - name: Install dpdk-sde
         uses: robinraju/release-downloader@v1.8
         with:
           repository: ${{ env.SDE_REPOSITORY }}
           tag: ${{ env.SDE_TAG }}
           fileName: ${{ env.SDE_FILENAME }}
-
       - run: |
           sudo tar -xzf $SDE_FILENAME -C /
           rm $SDE_FILENAME
 
-      - name: Install stratum dependencies
+      - name: Install stratum-deps
         uses: robinraju/release-downloader@v1.8
         with:
           repository: ${{ env.DEPS_REPOSITORY }}
           tag: ${{ env.DEPS_TAG }}
           fileName: ${{ env.DEPS_FILENAME }}
-
       - run: |
           sudo tar -xzf $DEPS_FILENAME -C /
           rm $DEPS_FILENAME
 
-      - name: Create pipeline.cmake file
-        working-directory: krnlmon
+      - name: Install prerequisites
         run: |
-          echo "set(CMAKE_MODULE_PATH \"$GITHUB_WORKSPACE/recipe/cmake\" CACHE PATH \"\")" > pipeline.cmake
-          echo "set(SAI_SOURCE_DIR \"$GITHUB_WORKSPACE/SAI\" CACHE PATH \"\")" >> pipeline.cmake
+          sudo apt install $PREREQS
 
-      - name: Run unit tests
+      - name: Run dpdk unit tests
         working-directory: krnlmon
         run: |
           export DEPEND_INSTALL=$DEPS_INSTALL_DIR
           export SDE_INSTALL=$SDE_INSTALL_DIR
-          cmake -S . -B build -C pipeline.cmake -DTDI_TARGET=DPDK
+          ./make-all.sh --target=dpdk --no-build
           cmake --build build --target krnlmon-test

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -74,7 +74,7 @@ jobs:
           sudo apt install $PREREQS
 
       - name: Build krnlmon
-        working-directory: krnlmon
+        working-directory: recipe
         run: |
           export DEPEND_INSTALL=$DEPS_INSTALL_DIR
           export SDE_INSTALL=$SDE_INSTALL_DIR
@@ -125,7 +125,7 @@ jobs:
           sudo apt install $PREREQS
 
       - name: Run dpdk unit tests
-        working-directory: krnlmon
+        working-directory: recipe
         run: |
           export DEPEND_INSTALL=$DEPS_INSTALL_DIR
           export SDE_INSTALL=$SDE_INSTALL_DIR

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           export DEPEND_INSTALL=$DEPS_INSTALL_DIR
           export SDE_INSTALL=$SDE_INSTALL_DIR
-          ./make-all.sh --target=dpdk --rpath --no-build
+          ./make-all.sh --target=dpdk --rpath --no-ovs --no-build
           cmake --build build -j4 --target krnlmon
 
   #---------------------------------------------------------------------
@@ -129,5 +129,5 @@ jobs:
         run: |
           export DEPEND_INSTALL=$DEPS_INSTALL_DIR
           export SDE_INSTALL=$SDE_INSTALL_DIR
-          ./make-all.sh --target=dpdk --no-build
+          ./make-all.sh --target=dpdk --no-ovs --no-build
           cmake --build build --target krnlmon-test

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -41,13 +41,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ipdk-io/networking-recipe
+          submodules: recursive
           path: recipe
-
-      - name: Fetch krnlmon and SAI submodules
-        working-directory: recipe
-        run: |
-          git submodule update --init krnlmon/krnlmon
-          git submodule update --init krnlmon/SAI
 
       - name: Install dpdk-sde
         uses: robinraju/release-downloader@v1.8
@@ -92,13 +87,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ipdk-io/networking-recipe
+          submodules: recursive
           path: recipe
-
-      - name: Fetch krnlmon and SAI submodules
-        working-directory: recipe
-        run: |
-          git submodule update --init krnlmon/krnlmon
-          git submodule update --init krnlmon/SAI
 
       - name: Install dpdk-sde
         uses: robinraju/release-downloader@v1.8


### PR DESCRIPTION
- Do a DPDK build check in addition to running the DPDK unit tests.
- Perform both checks in the context of networking-recipe instead of using standalone mode.

GitHub reports that "some checks haven't completed yet" because I renamed `check_krnlmon_dpdk` to `dpdk_unit_tests`. This issue will go away once I update the list of required checks (after merging this PR).