### PR TITLE
Fix IPv6 ECMP and l2_fwd_rx table population

### DIFF
--- a/switchlink/sai/switchlink_handle_neigh.c
+++ b/switchlink/sai/switchlink_handle_neigh.c
@@ -200,9 +200,23 @@ static int delete_neighbor(const switchlink_db_neigh_info_t* neigh_info) {
   sai_neighbor_entry_t neighbor_entry;
   memset(&neighbor_entry, 0, sizeof(neighbor_entry));
   neighbor_entry.rif_id = neigh_info->intf_h;
-  neighbor_entry.ip_address.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
-  neighbor_entry.ip_address.addr.ip4 =
-      htonl(neigh_info->ip_addr.ip.v4addr.s_addr);
+
+  if (neigh_info->ip_addr.family == AF_INET) {
+    neighbor_entry.ip_address.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+    neighbor_entry.ip_address.addr.ip4 =
+        htonl(neigh_info->ip_addr.ip.v4addr.s_addr);
+    krnlmon_log_info("Delete a neighbor entry: 0x%x",
+                     neigh_info->ip_addr.ip.v4addr.s_addr);
+  } else {
+    neighbor_entry.ip_address.addr_family = SAI_IP_ADDR_FAMILY_IPV6;
+    memcpy(neighbor_entry.ip_address.addr.ip6, &(neigh_info->ip_addr.ip.v6addr),
+           sizeof(sai_ip6_t));
+    krnlmon_log_info("Delete a neighbor entry: 0x%x:0x%x:0x%x:0x%x",
+                     neigh_info->ip_addr.ip.v6addr.__in6_u.__u6_addr32[0],
+                     neigh_info->ip_addr.ip.v6addr.__in6_u.__u6_addr32[1],
+                     neigh_info->ip_addr.ip.v6addr.__in6_u.__u6_addr32[2],
+                     neigh_info->ip_addr.ip.v6addr.__in6_u.__u6_addr32[3]);
+  }
 
   status = sai_neigh_api->remove_neighbor_entry(&neighbor_entry);
   return ((status == SAI_STATUS_SUCCESS) ? 0 : -1);

--- a/switchlink/switchlink_neigh.c
+++ b/switchlink/switchlink_neigh.c
@@ -90,9 +90,13 @@ void switchlink_process_neigh_msg(const struct nlmsghdr* nlmsg, int msgtype) {
           if (nbh->ndm_family == AF_INET) {
             ipaddr.ip.v4addr.s_addr = ntohl(nla_get_u32(attr));
             ipaddr.prefix_len = 32;
-          } else {
+          } else if (nbh->ndm_family == AF_INET6) {
             memcpy(&(ipaddr.ip.v6addr), nla_data(attr), nla_len(attr));
             ipaddr.prefix_len = 128;
+          } else {
+            krnlmon_log_error("Invalid NDM family type, for attribute %d\n",
+                              attr_type);
+            return;
           }
         } else {
           krnlmon_log_debug(

--- a/switchlink/switchlink_route.c
+++ b/switchlink/switchlink_route.c
@@ -60,7 +60,7 @@ static switchlink_handle_t process_ecmp(uint8_t family, struct nlattr* attr,
         gateway.ip.v4addr.s_addr = ntohl(*((uint32_t*)RTA_DATA(rta)));
         gateway.prefix_len = 32;
       } else {
-        memcpy(&(gateway.ip.v6addr), (struct in6_addr *) RTA_DATA(rta),
+        memcpy(&(gateway.ip.v6addr), (struct in6_addr*)RTA_DATA(rta),
                sizeof(struct in6_addr));
         gateway.prefix_len = 128;
       }

--- a/switchlink/switchlink_route.c
+++ b/switchlink/switchlink_route.c
@@ -60,6 +60,8 @@ static switchlink_handle_t process_ecmp(uint8_t family, struct nlattr* attr,
         gateway.ip.v4addr.s_addr = ntohl(*((uint32_t*)RTA_DATA(rta)));
         gateway.prefix_len = 32;
       } else {
+        memcpy(&(gateway.ip.v6addr), (struct in6_addr *) RTA_DATA(rta),
+               sizeof(struct in6_addr));
         gateway.prefix_len = 128;
       }
 


### PR DESCRIPTION
This code changes
- Fixes missing IPv6 details for nexthop, which fails ECMP traffic when a nexthop route is learned before nexthop neighbor.
- Fix missing l2_fwd_rx entry with these changes.
- Delete IPv6 neighbor during cleanup