### PR TITLE
"bf_" name change in krnlmon

### DIFF
--- a/switchapi/es2k/switch_lag.c
+++ b/switchapi/es2k/switch_lag.c
@@ -16,7 +16,7 @@
 
 #include "switchapi/switch_lag.h"
 
-#include "bf_types.h"
+#include "tdi_types/tdi_types.h"
 #include "switch_pd_utils.h"
 #include "switchapi/es2k/switch_pd_lag.h"
 #include "switchapi/switch_base_types.h"

--- a/switchapi/es2k/switch_lag.c
+++ b/switchapi/es2k/switch_lag.c
@@ -16,13 +16,13 @@
 
 #include "switchapi/switch_lag.h"
 
-#include "tdi_types/tdi_types.h"
 #include "switch_pd_utils.h"
 #include "switchapi/es2k/switch_pd_lag.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_device.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_status.h"
+#include "tdi_types/tdi_types.h"
 
 /**
  * Routine Description:

--- a/switchapi/es2k/switch_lag.c
+++ b/switchapi/es2k/switch_lag.c
@@ -16,13 +16,13 @@
 
 #include "switchapi/switch_lag.h"
 
+#include "ipu_types/ipu_types.h"
 #include "switch_pd_utils.h"
 #include "switchapi/es2k/switch_pd_lag.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_device.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_status.h"
-#include "tdi_types/tdi_types.h"
 
 /**
  * Routine Description:

--- a/switchapi/es2k/switch_pd_fdb.c
+++ b/switchapi/es2k/switch_pd_fdb.c
@@ -17,7 +17,6 @@
 
 #include "switch_pd_fdb.h"
 
-#include "tdi_types/tdi_types.h"
 #include "port_mgr/dpdk/dpdk_port_if.h"
 #include "switch_pd_p4_name_mapping.h"
 #include "switch_pd_utils.h"
@@ -25,6 +24,7 @@
 #include "switchapi/switch_fdb.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_rif_int.h"
+#include "tdi_types/tdi_types.h"
 
 switch_status_t switch_pd_l2_tx_forward_table_entry(
     switch_device_t device, const switch_api_l2_info_t* api_l2_tx_info,

--- a/switchapi/es2k/switch_pd_fdb.c
+++ b/switchapi/es2k/switch_pd_fdb.c
@@ -18,7 +18,6 @@
 #include "switch_pd_fdb.h"
 
 #include "ipu_types/ipu_types.h"
-#include "port_mgr/dpdk/dpdk_port_if.h"
 #include "switch_pd_p4_name_mapping.h"
 #include "switch_pd_utils.h"
 #include "switchapi/switch_base_types.h"

--- a/switchapi/es2k/switch_pd_fdb.c
+++ b/switchapi/es2k/switch_pd_fdb.c
@@ -17,6 +17,7 @@
 
 #include "switch_pd_fdb.h"
 
+#include "ipu_types/ipu_types.h"
 #include "port_mgr/dpdk/dpdk_port_if.h"
 #include "switch_pd_p4_name_mapping.h"
 #include "switch_pd_utils.h"
@@ -24,7 +25,6 @@
 #include "switchapi/switch_fdb.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_rif_int.h"
-#include "tdi_types/tdi_types.h"
 
 switch_status_t switch_pd_l2_tx_forward_table_entry(
     switch_device_t device, const switch_api_l2_info_t* api_l2_tx_info,

--- a/switchapi/es2k/switch_pd_fdb.c
+++ b/switchapi/es2k/switch_pd_fdb.c
@@ -17,8 +17,8 @@
 
 #include "switch_pd_fdb.h"
 
-#include "bf_types.h"
-#include "port_mgr/dpdk/bf_dpdk_port_if.h"
+#include "tdi_types/tdi_types.h"
+#include "port_mgr/dpdk/dpdk_port_if.h"
 #include "switch_pd_p4_name_mapping.h"
 #include "switch_pd_utils.h"
 #include "switchapi/switch_base_types.h"

--- a/switchapi/es2k/switch_pd_routing.c
+++ b/switchapi/es2k/switch_pd_routing.c
@@ -17,7 +17,6 @@
 
 #include "switch_pd_routing.h"
 
-#include "port_mgr/dpdk/dpdk_port_if.h"
 #include "switch_pd_p4_name_mapping.h"
 #include "switch_pd_utils.h"
 #include "switchapi/switch_base_types.h"

--- a/switchapi/es2k/switch_pd_routing.c
+++ b/switchapi/es2k/switch_pd_routing.c
@@ -17,7 +17,7 @@
 
 #include "switch_pd_routing.h"
 
-#include "port_mgr/dpdk/bf_dpdk_port_if.h"
+#include "port_mgr/dpdk/dpdk_port_if.h"
 #include "switch_pd_p4_name_mapping.h"
 #include "switch_pd_utils.h"
 #include "switchapi/switch_base_types.h"

--- a/switchapi/es2k/switch_pd_utils.c
+++ b/switchapi/es2k/switch_pd_utils.c
@@ -19,9 +19,9 @@
 
 #include <net/if.h>
 
-#include "bf_rt/bf_rt_common.h"
-#include "bf_types.h"
-#include "port_mgr/dpdk/bf_dpdk_port_if.h"
+#include "tdi_rt/tdi_rt_common.h"
+#include "tdi_types/tdi_types.h"
+#include "port_mgr/dpdk/dpdk_port_if.h"
 #include "switch_pd_p4_name_mapping.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_internal.h"
@@ -371,14 +371,14 @@ void switch_pd_to_get_port_id(switch_api_rif_info_t* port_rif_info) {
   switch_rmac_info_t* rmac_info = NULL;
   switch_rmac_entry_t* rmac_entry = NULL;
   switch_node_t* node = NULL;
-  bf_dev_id_t bf_dev_id = 0;
+  tdi_dev_id_t tdi_dev_id = 0;
   static char mac_str[SWITCH_PD_MAC_STR_LENGTH];
-  bf_status_t bf_status;
+  tdi_status_t tdi_status;
   uint32_t port_id = 0;
 
   /*rmac_handle will have source mac info. get rmac_info from rmac_handle */
   rmac_handle = port_rif_info->rmac_handle;
-  status = switch_rmac_get(bf_dev_id, rmac_handle, &rmac_info);
+  status = switch_rmac_get(tdi_dev_id, rmac_handle, &rmac_info);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error("Cannot get rmac info for handle 0x%x, error: %d",
                       rmac_handle, status);
@@ -399,8 +399,8 @@ void switch_pd_to_get_port_id(switch_api_rif_info_t* port_rif_info) {
            rmac_entry->mac.mac_addr[4], rmac_entry->mac.mac_addr[5]);
   mac_str[SWITCH_PD_MAC_STR_LENGTH - 1] = '\0';
 
-  bf_status = bf_pal_get_port_id_from_mac(bf_dev_id, mac_str, &port_id);
-  if (bf_status != BF_SUCCESS) {
+  tdi_status = ipu_pal_get_port_id_from_mac(tdi_dev_id, mac_str, &port_id);
+  if (tdi_status != TDI_SUCCESS) {
     // First SWITCH_PD_TARGET_VPORT_OFFSET entries are reserved for
     // MEV h/w ports. Hence VSI ID/Port ID should be offset with
     // SWITCH_PD_TARGET_VPORT_OFFSET
@@ -413,7 +413,7 @@ void switch_pd_to_get_port_id(switch_api_rif_info_t* port_rif_info) {
         "Failed to get the port ID, error: %d, Deriving "
         "port ID from second byte of MAC address: "
         "%s",
-        bf_status, mac_str);
+        tdi_status, mac_str);
   }
 
   port_rif_info->port_id = port_id;

--- a/switchapi/es2k/switch_pd_utils.c
+++ b/switchapi/es2k/switch_pd_utils.c
@@ -19,13 +19,13 @@
 
 #include <net/if.h>
 
-#include "tdi_rt/tdi_rt_common.h"
-#include "tdi_types/tdi_types.h"
 #include "port_mgr/dpdk/dpdk_port_if.h"
 #include "switch_pd_p4_name_mapping.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_rmac_int.h"
+#include "tdi_rt/tdi_rt_common.h"
+#include "tdi_types/tdi_types.h"
 
 switch_status_t switch_pd_get_physical_port_id(switch_device_t device,
                                                uint32_t netdev_port_id,

--- a/switchapi/es2k/switch_pd_utils.c
+++ b/switchapi/es2k/switch_pd_utils.c
@@ -20,7 +20,6 @@
 #include <net/if.h>
 
 #include "ipu_types/ipu_types.h"
-#include "port_mgr/dpdk/dpdk_port_if.h"
 #include "switch_pd_p4_name_mapping.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_internal.h"

--- a/switchapi/es2k/switch_pd_utils.c
+++ b/switchapi/es2k/switch_pd_utils.c
@@ -19,13 +19,12 @@
 
 #include <net/if.h>
 
+#include "ipu_types/ipu_types.h"
 #include "port_mgr/dpdk/dpdk_port_if.h"
 #include "switch_pd_p4_name_mapping.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_rmac_int.h"
-#include "tdi_rt/tdi_rt_common.h"
-#include "tdi_types/tdi_types.h"
 
 switch_status_t switch_pd_get_physical_port_id(switch_device_t device,
                                                uint32_t netdev_port_id,
@@ -371,14 +370,14 @@ void switch_pd_to_get_port_id(switch_api_rif_info_t* port_rif_info) {
   switch_rmac_info_t* rmac_info = NULL;
   switch_rmac_entry_t* rmac_entry = NULL;
   switch_node_t* node = NULL;
-  tdi_dev_id_t tdi_dev_id = 0;
+  ipu_dev_id_t ipu_dev_id = 0;
   static char mac_str[SWITCH_PD_MAC_STR_LENGTH];
-  tdi_status_t tdi_status;
+  ipu_status_t ipu_status;
   uint32_t port_id = 0;
 
   /*rmac_handle will have source mac info. get rmac_info from rmac_handle */
   rmac_handle = port_rif_info->rmac_handle;
-  status = switch_rmac_get(tdi_dev_id, rmac_handle, &rmac_info);
+  status = switch_rmac_get(ipu_dev_id, rmac_handle, &rmac_info);
   if (status != SWITCH_STATUS_SUCCESS) {
     krnlmon_log_error("Cannot get rmac info for handle 0x%x, error: %d",
                       rmac_handle, status);
@@ -399,8 +398,8 @@ void switch_pd_to_get_port_id(switch_api_rif_info_t* port_rif_info) {
            rmac_entry->mac.mac_addr[4], rmac_entry->mac.mac_addr[5]);
   mac_str[SWITCH_PD_MAC_STR_LENGTH - 1] = '\0';
 
-  tdi_status = ipu_pal_get_port_id_from_mac(tdi_dev_id, mac_str, &port_id);
-  if (tdi_status != TDI_SUCCESS) {
+  ipu_status = ipu_pal_get_port_id_from_mac(ipu_dev_id, mac_str, &port_id);
+  if (ipu_status != TDI_SUCCESS) {
     // First SWITCH_PD_TARGET_VPORT_OFFSET entries are reserved for
     // MEV h/w ports. Hence VSI ID/Port ID should be offset with
     // SWITCH_PD_TARGET_VPORT_OFFSET
@@ -413,7 +412,7 @@ void switch_pd_to_get_port_id(switch_api_rif_info_t* port_rif_info) {
         "Failed to get the port ID, error: %d, Deriving "
         "port ID from second byte of MAC address: "
         "%s",
-        tdi_status, mac_str);
+        ipu_status, mac_str);
   }
 
   port_rif_info->port_id = port_id;

--- a/switchapi/es2k/switch_pd_utils.h
+++ b/switchapi/es2k/switch_pd_utils.h
@@ -20,7 +20,6 @@
 
 #include "ipu_pal/port_intf.h"
 #include "ipu_types/ipu_types.h"
-#include "port_mgr/dpdk/dpdk_port_if.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_handle.h"
 #include "switchapi/switch_rif.h"

--- a/switchapi/es2k/switch_pd_utils.h
+++ b/switchapi/es2k/switch_pd_utils.h
@@ -19,12 +19,11 @@
 #define __SWITCH_PD_UTILS_H__
 
 #include "ipu_pal/port_intf.h"
+#include "ipu_types/ipu_types.h"
 #include "port_mgr/dpdk/dpdk_port_if.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_handle.h"
 #include "switchapi/switch_rif.h"
-#include "tdi_rt/tdi_rt_common.h"
-#include "tdi_types/tdi_types.h"
 
 // clang-format off
 // tdi_info.h does not include the header files it depends on,
@@ -63,13 +62,15 @@ tdi_status_t switch_pd_get_bridge_id(switch_device_t device,
                                      uint8_t physical_port_id,
                                      uint8_t* bridge_id);
 
-tdi_status_t switch_pd_allocate_handle_session(
-    const tdi_dev_id_t device_id, const char* pipeline_name,
-    tdi_rt_info_hdl** bfrt_info_hdl_t, tdi_rt_session_hdl** session_t);
+ipu_status_t switch_pd_allocate_handle_session(const ipu_dev_id_t device_id,
+                                               const char* pipeline_name,
+                                               tdi_info_hdl** bfrt_info_hdl_t,
+                                               tdi_session_hdl** session_t);
 
-tdi_status_t switch_pd_deallocate_handle_session(
-    tdi_rt_table_key_hdl* key_hdl_t, tdi_rt_table_data_hdl* data_hdl_t,
-    tdi_rt_session_hdl* session_t, bool entry_type);
+ipu_status_t switch_pd_deallocate_handle_session(tdi_table_key_hdl* key_hdl_t,
+                                                 tdi_table_data_hdl* data_hdl_t,
+                                                 tdi_session_hdl* session_t,
+                                                 bool entry_type);
 
 void switch_pd_to_get_port_id(switch_api_rif_info_t* port_rif_info);
 

--- a/switchapi/es2k/switch_pd_utils.h
+++ b/switchapi/es2k/switch_pd_utils.h
@@ -19,12 +19,12 @@
 #define __SWITCH_PD_UTILS_H__
 
 #include "ipu_pal/port_intf.h"
-#include "tdi_rt/tdi_rt_common.h"
-#include "tdi_types/tdi_types.h"
 #include "port_mgr/dpdk/dpdk_port_if.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_handle.h"
 #include "switchapi/switch_rif.h"
+#include "tdi_rt/tdi_rt_common.h"
+#include "tdi_types/tdi_types.h"
 
 // clang-format off
 // tdi_info.h does not include the header files it depends on,
@@ -63,10 +63,9 @@ tdi_status_t switch_pd_get_bridge_id(switch_device_t device,
                                      uint8_t physical_port_id,
                                      uint8_t* bridge_id);
 
-tdi_status_t switch_pd_allocate_handle_session(const tdi_dev_id_t device_id,
-                                              const char* pipeline_name,
-                                              tdi_rt_info_hdl** bfrt_info_hdl_t,
-                                              tdi_rt_session_hdl** session_t);
+tdi_status_t switch_pd_allocate_handle_session(
+    const tdi_dev_id_t device_id, const char* pipeline_name,
+    tdi_rt_info_hdl** bfrt_info_hdl_t, tdi_rt_session_hdl** session_t);
 
 tdi_status_t switch_pd_deallocate_handle_session(
     tdi_rt_table_key_hdl* key_hdl_t, tdi_rt_table_data_hdl* data_hdl_t,

--- a/switchapi/es2k/switch_pd_utils.h
+++ b/switchapi/es2k/switch_pd_utils.h
@@ -18,10 +18,10 @@
 #ifndef __SWITCH_PD_UTILS_H__
 #define __SWITCH_PD_UTILS_H__
 
-#include "bf_pal/bf_pal_port_intf.h"
-#include "bf_rt/bf_rt_common.h"
-#include "bf_types.h"
-#include "port_mgr/dpdk/bf_dpdk_port_if.h"
+#include "ipu_pal/port_intf.h"
+#include "tdi_rt/tdi_rt_common.h"
+#include "tdi_types/tdi_types.h"
+#include "port_mgr/dpdk/dpdk_port_if.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_handle.h"
 #include "switchapi/switch_rif.h"
@@ -63,14 +63,14 @@ tdi_status_t switch_pd_get_bridge_id(switch_device_t device,
                                      uint8_t physical_port_id,
                                      uint8_t* bridge_id);
 
-bf_status_t switch_pd_allocate_handle_session(const bf_dev_id_t device_id,
+tdi_status_t switch_pd_allocate_handle_session(const tdi_dev_id_t device_id,
                                               const char* pipeline_name,
-                                              bf_rt_info_hdl** bfrt_info_hdl_t,
-                                              bf_rt_session_hdl** session_t);
+                                              tdi_rt_info_hdl** bfrt_info_hdl_t,
+                                              tdi_rt_session_hdl** session_t);
 
-bf_status_t switch_pd_deallocate_handle_session(
-    bf_rt_table_key_hdl* key_hdl_t, bf_rt_table_data_hdl* data_hdl_t,
-    bf_rt_session_hdl* session_t, bool entry_type);
+tdi_status_t switch_pd_deallocate_handle_session(
+    tdi_rt_table_key_hdl* key_hdl_t, tdi_rt_table_data_hdl* data_hdl_t,
+    tdi_rt_session_hdl* session_t, bool entry_type);
 
 void switch_pd_to_get_port_id(switch_api_rif_info_t* port_rif_info);
 

--- a/switchapi/es2k/switch_rif.c
+++ b/switchapi/es2k/switch_rif.c
@@ -18,6 +18,7 @@
 #include <net/if.h>
 
 /* Local header includes */
+#include "ipu_types/ipu_types.h"
 #include "switch_pd_utils.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_device.h"
@@ -25,7 +26,6 @@
 #include "switchapi/switch_rif.h"
 #include "switchapi/switch_rif_int.h"
 #include "switchapi/switch_status.h"
-#include "tdi_types/tdi_types.h"
 
 /*
  * Routine Description:

--- a/switchapi/es2k/switch_rif.c
+++ b/switchapi/es2k/switch_rif.c
@@ -18,7 +18,6 @@
 #include <net/if.h>
 
 /* Local header includes */
-#include "tdi_types/tdi_types.h"
 #include "switch_pd_utils.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_device.h"
@@ -26,6 +25,7 @@
 #include "switchapi/switch_rif.h"
 #include "switchapi/switch_rif_int.h"
 #include "switchapi/switch_status.h"
+#include "tdi_types/tdi_types.h"
 
 /*
  * Routine Description:

--- a/switchapi/es2k/switch_rif.c
+++ b/switchapi/es2k/switch_rif.c
@@ -18,7 +18,7 @@
 #include <net/if.h>
 
 /* Local header includes */
-#include "bf_types.h"
+#include "tdi_types/tdi_types.h"
 #include "switch_pd_utils.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_device.h"

--- a/switchapi/es2k/switchapi_utils.c
+++ b/switchapi/es2k/switchapi_utils.c
@@ -564,7 +564,7 @@ switch_status_t switch_pd_status_to_status(bf_status_t pd_status) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   switch (pd_status) {
-    case BF_SUCCESS:
+    case TDI_SUCCESS:
       status = SWITCH_STATUS_SUCCESS;
       break;
 

--- a/switchapi/es2k/switchapi_utils.c
+++ b/switchapi/es2k/switchapi_utils.c
@@ -564,7 +564,7 @@ switch_status_t switch_pd_status_to_status(bf_status_t pd_status) {
   switch_status_t status = SWITCH_STATUS_SUCCESS;
 
   switch (pd_status) {
-    case TDI_SUCCESS:
+    case IPU_SUCCESS:
       status = SWITCH_STATUS_SUCCESS;
       break;
 

--- a/switchapi/switch_internal.h
+++ b/switchapi/switch_internal.h
@@ -23,7 +23,6 @@
 #include "switchapi/switch_device_int.h"
 #include "switchapi/switch_handle_int.h"
 #include "switchapi/switch_status.h"
-//#include "bf_types.h"
 #include "switchutils/switch_utils.h"
 #include "tdi/common/tdi_defs.h"
 

--- a/switchlink/sai/CMakeLists.txt
+++ b/switchlink/sai/CMakeLists.txt
@@ -5,7 +5,6 @@
 
 add_library(switchlink_sai_o OBJECT
    switchlink_handle_ecmp.c
-   switchlink_handle_lag.c
    switchlink_handle_link.c
    switchlink_handle_neigh.c
    switchlink_handle_nexthop.c
@@ -14,6 +13,10 @@ add_library(switchlink_sai_o OBJECT
    switchlink_init_sai.c
    switchlink_init_sai.h
 )
+
+if(ES2K_TARGET)
+  target_sources(switchlink_sai_o PRIVATE switchlink_handle_lag.c)
+endif()
 
 target_include_directories(switchlink_sai_o PRIVATE
     ${SDE_INSTALL_DIR}/include

--- a/switchlink/sai/switchlink_handle_lag.c
+++ b/switchlink/sai/switchlink_handle_lag.c
@@ -17,10 +17,10 @@
 #include <linux/if.h>
 
 #include "ipu_pal/port_intf.h"
-#include "tdi_rt/tdi_rt_common.h"
-#include "tdi_types/tdi_types.h"
 #include "port_mgr/dpdk/dpdk_port_if.h"
 #include "switchlink_init_sai.h"
+#include "tdi_rt/tdi_rt_common.h"
+#include "tdi_types/tdi_types.h"
 
 #define SWITCH_PD_MAC_STR_LENGTH 18
 #define SWITCH_PD_TARGET_VPORT_OFFSET 16

--- a/switchlink/sai/switchlink_handle_lag.c
+++ b/switchlink/sai/switchlink_handle_lag.c
@@ -18,7 +18,6 @@
 
 #include "ipu_pal/port_intf.h"
 #include "ipu_types/ipu_types.h"
-#include "port_mgr/dpdk/dpdk_port_if.h"
 #include "switchlink_init_sai.h"
 
 #define SWITCH_PD_MAC_STR_LENGTH 18

--- a/switchlink/sai/switchlink_handle_lag.c
+++ b/switchlink/sai/switchlink_handle_lag.c
@@ -17,10 +17,9 @@
 #include <linux/if.h>
 
 #include "ipu_pal/port_intf.h"
+#include "ipu_types/ipu_types.h"
 #include "port_mgr/dpdk/dpdk_port_if.h"
 #include "switchlink_init_sai.h"
-#include "tdi_rt/tdi_rt_common.h"
-#include "tdi_types/tdi_types.h"
 
 #define SWITCH_PD_MAC_STR_LENGTH 18
 #define SWITCH_PD_TARGET_VPORT_OFFSET 16
@@ -171,9 +170,9 @@ static int create_lag_member(
     switchlink_handle_t* lag_member_h) {
   sai_attribute_t attr_list[5];
   int ac = 0;
-  tdi_status_t tdi_status;
+  ipu_status_t ipu_status;
   uint32_t port_id = 0;
-  tdi_dev_id_t bf_dev_id = 0;
+  ipu_dev_id_t ipu_dev_id = 0;
   static char mac_str[SWITCH_PD_MAC_STR_LENGTH];
 
   snprintf(mac_str, sizeof(mac_str), "%02x:%02x:%02x:%02x:%02x:%02x",
@@ -182,14 +181,14 @@ static int create_lag_member(
            lag_member_intf->perm_hwaddr[4], lag_member_intf->perm_hwaddr[5]);
   mac_str[SWITCH_PD_MAC_STR_LENGTH - 1] = '\0';
 
-  tdi_status = ipu_pal_get_port_id_from_mac(bf_dev_id, mac_str, &port_id);
-  if (tdi_status != TDI_SUCCESS) {
+  ipu_status = ipu_pal_get_port_id_from_mac(ipu_dev_id, mac_str, &port_id);
+  if (ipu_status != IPU_SUCCESS) {
     port_id = lag_member_intf->perm_hwaddr[1] + SWITCH_PD_TARGET_VPORT_OFFSET;
     krnlmon_log_info(
         "Failed to get the port ID, error: %d, Deriving "
         "port ID from second byte of MAC address: "
         "%s",
-        tdi_status, mac_str);
+        ipu_status, mac_str);
   }
 
   memset(attr_list, 0, sizeof(attr_list));

--- a/switchlink/sai/switchlink_handle_lag.c
+++ b/switchlink/sai/switchlink_handle_lag.c
@@ -16,10 +16,10 @@
 
 #include <linux/if.h>
 
-#include "bf_pal/bf_pal_port_intf.h"
-#include "bf_rt/bf_rt_common.h"
-#include "bf_types.h"
-#include "port_mgr/dpdk/bf_dpdk_port_if.h"
+#include "ipu_pal/port_intf.h"
+#include "tdi_rt/tdi_rt_common.h"
+#include "tdi_types/tdi_types.h"
+#include "port_mgr/dpdk/dpdk_port_if.h"
 #include "switchlink_init_sai.h"
 
 #define SWITCH_PD_MAC_STR_LENGTH 18
@@ -171,9 +171,9 @@ static int create_lag_member(
     switchlink_handle_t* lag_member_h) {
   sai_attribute_t attr_list[5];
   int ac = 0;
-  bf_status_t bf_status;
+  tdi_status_t tdi_status;
   uint32_t port_id = 0;
-  bf_dev_id_t bf_dev_id = 0;
+  tdi_dev_id_t bf_dev_id = 0;
   static char mac_str[SWITCH_PD_MAC_STR_LENGTH];
 
   snprintf(mac_str, sizeof(mac_str), "%02x:%02x:%02x:%02x:%02x:%02x",
@@ -182,14 +182,14 @@ static int create_lag_member(
            lag_member_intf->perm_hwaddr[4], lag_member_intf->perm_hwaddr[5]);
   mac_str[SWITCH_PD_MAC_STR_LENGTH - 1] = '\0';
 
-  bf_status = bf_pal_get_port_id_from_mac(bf_dev_id, mac_str, &port_id);
-  if (bf_status != BF_SUCCESS) {
+  tdi_status = ipu_pal_get_port_id_from_mac(bf_dev_id, mac_str, &port_id);
+  if (tdi_status != TDI_SUCCESS) {
     port_id = lag_member_intf->perm_hwaddr[1] + SWITCH_PD_TARGET_VPORT_OFFSET;
     krnlmon_log_info(
         "Failed to get the port ID, error: %d, Deriving "
         "port ID from second byte of MAC address: "
         "%s",
-        bf_status, mac_str);
+        tdi_status, mac_str);
   }
 
   memset(attr_list, 0, sizeof(attr_list));

--- a/switchlink/sai/switchlink_init_sai.c
+++ b/switchlink/sai/switchlink_init_sai.c
@@ -54,7 +54,9 @@ void switchlink_init_api(void) {
   krnlmon_assert(status == SAI_STATUS_SUCCESS);
   status = sai_init_nhop_group_api();
   krnlmon_assert(status == SAI_STATUS_SUCCESS);
+#ifdef ES2K_TARGET
   status = sai_init_lag_api();
   krnlmon_assert(status == SAI_STATUS_SUCCESS);
+#endif
   return;
 }

--- a/switchlink/sai/switchlink_init_sai.h
+++ b/switchlink/sai/switchlink_init_sai.h
@@ -37,7 +37,9 @@ sai_status_t sai_init_neigh_api();
 sai_status_t sai_init_route_api();
 sai_status_t sai_init_nhop_api();
 sai_status_t sai_init_nhop_group_api();
+#ifdef ES2K_TARGET
 sai_status_t sai_init_lag_api();
+#endif
 
 // SWITCHLINK_LINK_TYPE_VXLAN handlers
 void switchlink_create_tunnel_interface(
@@ -45,11 +47,13 @@ void switchlink_create_tunnel_interface(
 void switchlink_delete_tunnel_interface(uint32_t ifindex);
 
 // SWITCHLINK_LINK_TYPE_BOND handlers
+#ifdef ES2K_TARGET
 void switchlink_create_lag(switchlink_db_interface_info_t* lag_intf);
 void switchlink_delete_lag(uint32_t ifindex);
 void switchlink_create_lag_member(
     switchlink_db_lag_member_info_t* lag_member_info);
 void switchlink_delete_lag_member(uint32_t ifindex);
+#endif
 
 // SWITCHLINK_LINK_TYPE_TUN handlers
 void switchlink_create_interface(switchlink_db_interface_info_t* intf);

--- a/switchlink/switchlink_handle.h
+++ b/switchlink/switchlink_handle.h
@@ -32,11 +32,13 @@ extern void switchlink_create_tunnel_interface(
 extern void switchlink_delete_tunnel_interface(uint32_t ifindex);
 
 // SWITCHLINK_LINK_TYPE_BOND handlers
+#ifdef ES2K_TARGET
 extern void switchlink_create_lag(switchlink_db_interface_info_t* lag_info);
 extern void switchlink_delete_lag(uint32_t ifindex);
 extern void switchlink_create_lag_member(
     switchlink_db_lag_member_info_t* lag_member_info);
 extern void switchlink_delete_lag_member(uint32_t ifindex);
+#endif
 
 // SWITCHLINK_LINK_TYPE_TUN handlers
 extern void switchlink_create_interface(switchlink_db_interface_info_t* intf);

--- a/switchlink/switchlink_link.c
+++ b/switchlink/switchlink_link.c
@@ -359,6 +359,7 @@ void switchlink_process_link_msg(const struct nlmsghdr* nlmsg, int msgtype) {
       case SWITCHLINK_LINK_TYPE_TEAM:
         krnlmon_log_info("LAG via teaming driver isn't supported\n");
         break;
+#ifdef ES2K_TARGET
       case SWITCHLINK_LINK_TYPE_BOND:
         snprintf(intf_info.ifname, sizeof(intf_info.ifname), "%s",
                  attrs.ifname);
@@ -376,6 +377,7 @@ void switchlink_process_link_msg(const struct nlmsghdr* nlmsg, int msgtype) {
                             intf_info.bond_mode);
         }
         break;
+#endif
       case SWITCHLINK_LINK_TYPE_ETH:
         break;
 
@@ -427,6 +429,7 @@ void switchlink_process_link_msg(const struct nlmsghdr* nlmsg, int msgtype) {
         break;
     }
     switch (slave_link_type) {
+#ifdef ES2K_TARGET
       case SWITCHLINK_LINK_TYPE_BOND:
         snprintf(lag_member_info.ifname, sizeof(lag_member_info.ifname), "%s",
                  attrs.ifname);
@@ -442,6 +445,7 @@ void switchlink_process_link_msg(const struct nlmsghdr* nlmsg, int msgtype) {
           switchlink_create_lag_member(&lag_member_info);
         }
         break;
+#endif
       default:
         break;
     }
@@ -461,7 +465,7 @@ void switchlink_process_link_msg(const struct nlmsghdr* nlmsg, int msgtype) {
     } else {
       krnlmon_log_debug("Unhandled link type");
     }
-
+#ifdef ES2K_TARGET
     if (link_type == SWITCHLINK_LINK_TYPE_BOND) {
       switchlink_delete_lag(ifmsg->ifi_index);
       return;
@@ -471,6 +475,7 @@ void switchlink_process_link_msg(const struct nlmsghdr* nlmsg, int msgtype) {
       switchlink_delete_lag_member(ifmsg->ifi_index);
       return;
     }
+#endif
   }
   return;
 }

--- a/switchlink/switchlink_link_test.cc
+++ b/switchlink/switchlink_link_test.cc
@@ -72,11 +72,13 @@ std::vector<test_results> results(2);
 // Test doubles (dummy functions)
 //----------------------------------------------------------------------
 
+#ifdef ES2K_TARGET
 void switchlink_create_lag(switchlink_db_interface_info_t* lag_info) {}
 void switchlink_delete_lag(uint32_t ifindex) {}
 void switchlink_create_lag_member(
     switchlink_db_lag_member_info_t* lag_member_info) {}
 void switchlink_delete_lag_member(uint32_t ifindex) {}
+#endif
 
 void switchlink_create_interface(switchlink_db_interface_info_t* intf) {
   struct test_results temp = {0};


### PR DESCRIPTION
This underlying P4SDE for ES2K target is renaming bf_swtichd to ipu_p4d.
The P4SDE changes are:
https://github.com/intel-innersource/networking.ethernet.acceleration.vswitch.p4-sde.p4-driver/tree/rename-bf

This PR contains the changes required in the krnlmon module to build ES2K target with the underlying P4SDE change.
Since, some of the files that are impacted with the P4SDE change are common to the compilation of both dpdk and es2k targets, hence I have introduced target specific macro check to avoid it's compilation for the other target.

Note:
The related changes are expected in stratum modules, krnlmon module and the main networking recipe repo.
