### PR TITLE
Revise check_clang_format workflow to report all errors

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -133,7 +133,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Get list of changed Files
-        id: changes
+        id: changed
         uses: tj-actions/changed-files@v42
         with:
           files: |
@@ -142,7 +142,6 @@ jobs:
             **.cc
 
       - name: Check for formatting errors
+        if: steps.changed.outputs.any_changed == 'true'
         run: |
-          for file in ${{ steps.changes.outputs.all_changed_files }}; do
-            clang-format --dry-run -Werror $file
-          done
+          clang-format -n -Werror ${{ steps.changed.outputs.all_changed_files }}


### PR DESCRIPTION
The clang-format checker processes changed files one at a time. It fails after processing a file that has format errors, leaving any subsequent files unchecked. This means that it takes multiple commits to find and fix all the errors.

This CL updates the workflow to process all the changed files in a single invocation of clang-format, which should solve the problem.