### PR TITLE
Update switchlink to support Bazel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/bazel-*
+.vscode

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,20 @@
+# //BUILD.bazel
+
+# Copyright 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+config_setting(
+    name = "dpdk_target",
+    define_values = {
+        "target": "dpdk",
+    },
+)
+
+config_setting(
+    name = "es2k_target",
+    define_values = {
+        "target": "es2k",
+    },
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake build file for Kernel Monitor
 #
-# Copyright 2022-2023 Intel Corporation
+# Copyright 2022-2024 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
 
@@ -28,6 +28,7 @@ endif()
 # Find netlink libraries
 pkg_check_modules(nl3 REQUIRED IMPORTED_TARGET libnl-3.0)
 pkg_check_modules(nl3-route REQUIRED IMPORTED_TARGET libnl-route-3.0)
+include_directories(${nl3_INCLUDE_DIRS})
 
 add_compile_options(-Werror)
 

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,0 +1,40 @@
+# WORKSPACE.bazel
+
+# Copyright 2023-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+workspace(name = "io_ipdk_krnlmon")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
+    ],
+)
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+bazel_skylib_workspace()
+
+http_archive(
+    name = "com_google_absl",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20220623.0.tar.gz"],
+    strip_prefix = "abseil-cpp-20220623.0",
+    sha256 = "4208129b49006089ba1d6710845a45e31c59b0ab6bff9e5788a87f55c5abd602",
+)
+
+http_archive(
+    name = "com_google_googletest",
+    sha256 = "d3d307a240e129bb57da8aae64f3b0099bf1b8efff7249df993b619b8641ec77",
+    strip_prefix = "googletest-a3460d1aeeaa43fdf137a6adefef10ba0b59fe4b",
+    urls = ["https://github.com/google/googletest/archive/a3460d1aeeaa43fdf137a6adefef10ba0b59fe4b.zip"],
+)
+
+load("//bazel:dpdk.bzl", "dpdk_configure")
+dpdk_configure(name = "local_dpdk_bin")
+
+# TODO:
+# - sai

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,6 +1,6 @@
 # WORKSPACE.bazel
 
-# Copyright 2023-2024 Intel Corporation
+# Copyright 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 workspace(name = "io_ipdk_krnlmon")
@@ -51,4 +51,10 @@ load("//bazel:dpdk.bzl", "dpdk_configure")
 dpdk_configure(name = "local_dpdk_bin")
 
 # TODO:
-# - sai
+# - SAI (https://github.com/opencomputeproject/SAI)
+#   - version in use:   8e1fb379cc8eab2654632265c8f7d3ac9cb00f7a
+#   - date: 26-Aug-2021
+#   - prior release:    7cd3a7ed84db3fc9cec13496a5339b6fe1888bb7 (v1.8.1)
+#   - date: 5-Apr-2021
+#   - next release:     2ebde24c1de6d930c5bbc20e7eb89d9f0867d4bc (v1.9.0)
+#   - date: 20-Sep-2021

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -17,13 +17,14 @@ http_archive(
 )
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
 bazel_skylib_workspace()
 
 http_archive(
     name = "com_google_absl",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20220623.0.tar.gz"],
-    strip_prefix = "abseil-cpp-20220623.0",
     sha256 = "4208129b49006089ba1d6710845a45e31c59b0ab6bff9e5788a87f55c5abd602",
+    strip_prefix = "abseil-cpp-20220623.0",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20220623.0.tar.gz"],
 )
 
 http_archive(
@@ -33,7 +34,20 @@ http_archive(
     urls = ["https://github.com/google/googletest/archive/a3460d1aeeaa43fdf137a6adefef10ba0b59fe4b.zip"],
 )
 
+new_local_repository(
+    name = "nl-3",
+    build_file = "//bazel:external/nl-3.BUILD",
+    path = "/usr",
+)
+
+new_local_repository(
+    name = "nl-route-3",
+    build_file = "//bazel:external/nl-route-3.BUILD",
+    path = "/usr",
+)
+
 load("//bazel:dpdk.bzl", "dpdk_configure")
+
 dpdk_configure(name = "local_dpdk_bin")
 
 # TODO:

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -7,6 +7,9 @@ workspace(name = "io_ipdk_krnlmon")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# ---------------------------------------------------------------------------
+#       Skylib
+# ---------------------------------------------------------------------------
 http_archive(
     name = "bazel_skylib",
     sha256 = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
@@ -20,6 +23,9 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
+# ---------------------------------------------------------------------------
+#       Abseil
+# ---------------------------------------------------------------------------
 http_archive(
     name = "com_google_absl",
     sha256 = "4208129b49006089ba1d6710845a45e31c59b0ab6bff9e5788a87f55c5abd602",
@@ -27,6 +33,9 @@ http_archive(
     urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20220623.0.tar.gz"],
 )
 
+# ---------------------------------------------------------------------------
+#       GoogleTest
+# ---------------------------------------------------------------------------
 http_archive(
     name = "com_google_googletest",
     sha256 = "d3d307a240e129bb57da8aae64f3b0099bf1b8efff7249df993b619b8641ec77",
@@ -34,6 +43,19 @@ http_archive(
     urls = ["https://github.com/google/googletest/archive/a3460d1aeeaa43fdf137a6adefef10ba0b59fe4b.zip"],
 )
 
+# ---------------------------------------------------------------------------
+#       Switch Abstraction Interface (SAI)
+# ---------------------------------------------------------------------------
+http_archive(
+    name = "sai",
+    strip_prefix = "SAI-1.9.0",
+    urls = ["https://github.com/opencomputeproject/SAI/archive/refs/tags/v1.9.0.zip"],
+    build_file = "//bazel:external/sai.BUILD",
+)
+
+# ---------------------------------------------------------------------------
+#       Netlink libraries
+# ---------------------------------------------------------------------------
 new_local_repository(
     name = "nl-3",
     build_file = "//bazel:external/nl-3.BUILD",
@@ -46,15 +68,9 @@ new_local_repository(
     path = "/usr",
 )
 
+# ---------------------------------------------------------------------------
+#       DPDK SDE
+# ---------------------------------------------------------------------------
 load("//bazel:dpdk.bzl", "dpdk_configure")
 
 dpdk_configure(name = "local_dpdk_bin")
-
-# TODO:
-# - SAI (https://github.com/opencomputeproject/SAI)
-#   - version in use:   8e1fb379cc8eab2654632265c8f7d3ac9cb00f7a
-#   - date: 26-Aug-2021
-#   - prior release:    7cd3a7ed84db3fc9cec13496a5339b6fe1888bb7 (v1.8.1)
-#   - date: 5-Apr-2021
-#   - next release:     2ebde24c1de6d930c5bbc20e7eb89d9f0867d4bc (v1.9.0)
-#   - date: 20-Sep-2021

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -1,0 +1,3 @@
+# //bazel/BUILD.bazel
+
+package(default_visibility = ["//visibility:public"])

--- a/bazel/dpdk.bzl
+++ b/bazel/dpdk.bzl
@@ -1,0 +1,24 @@
+# Copyright 2018-present Open Networking Foundation
+# Copyright 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# This Starlark rule imports the DPDK SDE shared libraries and headers.
+# The DPDK_INSTALL environment variable needs to be set; otherwise,
+# Kernel Monitor for DPDK platforms cannot be built.
+
+def _impl(repository_ctx):
+    if "DPDK_INSTALL" in repository_ctx.os.environ:
+        dpdk_sde_path = repository_ctx.os.environ["DPDK_INSTALL"]
+    elif "SDE_INSTALL" in repository_ctx.os.environ:
+        dpdk_sde_path = repository_ctx.os.environ["SDE_INSTALL"]
+    else:
+        repository_ctx.file("BUILD", "")
+        return
+    repository_ctx.symlink(dpdk_sde_path, "dpdk-bin")
+    repository_ctx.symlink(Label("@//bazel:external/dpdk.BUILD"), "BUILD")
+
+dpdk_configure = repository_rule(
+    implementation = _impl,
+    local = True,
+    environ = ["DPDK_INSTALL", "SDE_INSTALL"],
+)

--- a/bazel/external/dpdk.BUILD
+++ b/bazel/external/dpdk.BUILD
@@ -1,0 +1,102 @@
+# //bazel/external/dpdk.BUILD
+
+# Copyright 2020-present Open Networking Foundation
+# Copyright 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "dpdk_libs",
+    srcs = glob([
+        "dpdk-bin/lib/libbf_switchd_lib.so*",
+        "dpdk-bin/lib/libclish.so",
+        "dpdk-bin/lib/libdriver.so",
+        "dpdk-bin/lib/libtdi.so*",
+        "dpdk-bin/lib/libtdi_json_parser.so*",
+    ]),
+    linkopts = [
+        "-lpthread",
+        "-lm",
+        "-ldl",
+    ],
+)
+
+cc_library(
+    name = "dpdk_hdrs",
+    hdrs = glob([
+        "dpdk-bin/include/bf_pal/*.h",
+        "dpdk-bin/include/bf_rt/**/*.h",
+        "dpdk-bin/include/bf_switchd/**/*.h",
+        "dpdk-bin/include/bf_types/*.h",
+        "dpdk-bin/include/cjson/*.h",
+        "dpdk-bin/include/dvm/*.h",
+        "dpdk-bin/include/lld/*.h",
+        "dpdk-bin/include/osdep/*.h",
+        "dpdk-bin/include/pipe_mgr/*.h",
+        "dpdk-bin/include/port_mgr/**/*.h",
+        "dpdk-bin/include/tdi/**/*.h",
+        "dpdk-bin/include/tdi/**/*.hpp",
+        "dpdk-bin/include/tdi_rt/**/*.h",
+        "dpdk-bin/include/tdi_rt/**/*.hpp",
+    ]),
+    strip_include_prefix = "dpdk-bin/include",
+)
+
+cc_library(
+    name = "dpdk_sde",
+    deps = [
+        ":dpdk_hdrs",
+        ":dpdk_libs",
+    ],
+)
+
+cc_library(
+    name = "dpdk_rte",
+    srcs = glob(["dpdk-bin/lib/x86_64-linux-gnu/*.so*"]),
+)
+
+cc_library(
+    name = "target_sys",
+    srcs = glob(["dpdk-bin/lib/libtarget_sys.so"]),
+    hdrs = glob(["dpdk-bin/include/target-sys/**/*.h"]),
+    linkopts = [
+        "-lpthread",
+        "-lm",
+        "-ldl",
+    ],
+    strip_include_prefix = "dpdk-bin/include/target-sys",
+)
+
+cc_library(
+    name = "target_utils",
+    srcs = glob(["dpdk-bin/lib/libtarget_utils.so"]),
+    hdrs = glob(["dpdk-bin/include/target-utils/**/*.h"]),
+    deps = [":target_sys"],
+    linkopts = [
+        "-lpthread",
+        "-lm",
+        "-ldl",
+    ],
+    strip_include_prefix = "dpdk-bin/include/target-utils",
+)
+
+cc_library(
+    name = "tommyds_hdrs",
+    hdrs = glob([
+        "dpdk-bin/include/target-utils/third-party/tommyds/tommyds/*.h",
+    ]),
+    strip_include_prefix = "dpdk-bin/include/target-utils/third-party/tommyds",
+)
+
+cc_library(
+    name = "xxhash_hdrs",
+    hdrs = glob([
+        "dpdk-bin/include/target-utils/third-party/xxHash/xxHash/*.h",
+    ]),
+    strip_include_prefix = "dpdk-bin/include/target-utils/third-party/xxHash",
+)

--- a/bazel/external/dpdk.BUILD
+++ b/bazel/external/dpdk.BUILD
@@ -86,6 +86,14 @@ cc_library(
 )
 
 cc_library(
+    name = "judy_hdrs",
+    hdrs = glob([
+        "dpdk-bin/include/target-utils/third-party/judy-1.0.5/src/*.h",
+    ]),
+    strip_include_prefix = "dpdk-bin/include/target-utils/third-party/",
+)
+
+cc_library(
     name = "tommyds_hdrs",
     hdrs = glob([
         "dpdk-bin/include/target-utils/third-party/tommyds/tommyds/*.h",

--- a/bazel/external/dpdk.BUILD
+++ b/bazel/external/dpdk.BUILD
@@ -76,13 +76,13 @@ cc_library(
     name = "target_utils",
     srcs = glob(["dpdk-bin/lib/libtarget_utils.so"]),
     hdrs = glob(["dpdk-bin/include/target-utils/**/*.h"]),
-    deps = [":target_sys"],
     linkopts = [
         "-lpthread",
         "-lm",
         "-ldl",
     ],
     strip_include_prefix = "dpdk-bin/include/target-utils",
+    deps = [":target_sys"],
 )
 
 cc_library(

--- a/bazel/external/dpdk.BUILD
+++ b/bazel/external/dpdk.BUILD
@@ -69,7 +69,7 @@ cc_library(
         "-lm",
         "-ldl",
     ],
-    strip_include_prefix = "dpdk-bin/include/target-sys",
+    strip_include_prefix = "dpdk-bin/include",
 )
 
 cc_library(

--- a/bazel/external/nl-3.BUILD
+++ b/bazel/external/nl-3.BUILD
@@ -1,0 +1,14 @@
+# //bazel/external/nl-route-3.BUILD
+
+# Copyright 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_cc//cc:defs.bzl", "cc_import")
+
+cc_import(
+    name = "nl-route-3",
+    hdrs = glob(["netlink/**/*.h"]),
+    includes = ["/usr/include/libnl3"],
+    system_provided = 1,
+    visibility = ["//visibility:public"],
+)

--- a/bazel/external/nl-3.BUILD
+++ b/bazel/external/nl-3.BUILD
@@ -1,4 +1,4 @@
-# //bazel/external/nl-route-3.BUILD
+# //bazel/external/nl-3.BUILD
 
 # Copyright 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
@@ -6,7 +6,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_import")
 
 cc_import(
-    name = "nl-route-3",
+    name = "nl-3",
     hdrs = glob(["netlink/**/*.h"]),
     includes = ["/usr/include/libnl3"],
     system_provided = 1,

--- a/bazel/external/nl-route-3.BUILD
+++ b/bazel/external/nl-route-3.BUILD
@@ -1,0 +1,17 @@
+# //bazel/external/nl-3.BUILD
+
+# Copyright 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_cc//cc:defs.bzl", "cc_import")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+cc_import(
+    name = "nl-3",
+    hdrs = glob(["netlink/**/*.h"]),
+    includes = ["/usr/include/libnl3"],
+    system_provided = 1,
+)

--- a/bazel/external/nl-route-3.BUILD
+++ b/bazel/external/nl-route-3.BUILD
@@ -1,17 +1,14 @@
-# //bazel/external/nl-3.BUILD
+# //bazel/external/nl-route-3.BUILD
 
 # Copyright 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_cc//cc:defs.bzl", "cc_import")
 
-package(
-    default_visibility = ["//visibility:public"],
-)
-
 cc_import(
-    name = "nl-3",
+    name = "nl-route-3",
     hdrs = glob(["netlink/**/*.h"]),
     includes = ["/usr/include/libnl3"],
     system_provided = 1,
+    visibility = ["//visibility:public"],
 )

--- a/bazel/external/sai.BUILD
+++ b/bazel/external/sai.BUILD
@@ -1,0 +1,16 @@
+# //bazel/external/sai.BUILD
+
+# Copyright 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "sai_hdrs",
+    hdrs = glob(["inc/*.h"]),
+    strip_include_prefix = "inc/",
+)

--- a/switchapi/dpdk/switch_config.c
+++ b/switchapi/dpdk/switch_config.c
@@ -20,7 +20,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif /* __cplusplus */
+#endif
 
 #define __FILE_ID__ SWITCH_CONFIG
 switch_config_info_t config_info;
@@ -122,5 +122,5 @@ switch_status_t switch_config_table_sizes_get(switch_device_t device,
 }
 
 #ifdef __cplusplus
-}
+}  // extern "C"
 #endif

--- a/switchapi/switch_base_types.h
+++ b/switchapi/switch_base_types.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,14 +21,14 @@
 /**
  * Third party includes
  */
-#include "bf_sal/bf_sys_mem.h"
-#include "bf_sal/bf_sys_timer.h"
 #include "judy-1.0.5/src/Judy.h"
+#include "target-sys/bf_sal/bf_sys_mem.h"
+#include "target-sys/bf_sal/bf_sys_timer.h"
 #include "tommyds/tommyhashtbl.h"
 #include "tommyds/tommylist.h"
 #ifdef STATIC_LINK_LIB
 #include "bf_switchd/bf_switchd.h"
-#endif  // STATIC_LINK_LIB
+#endif
 
 /**
  * standard includes
@@ -40,7 +40,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif /* __cplusplus */
+#endif
 
 /***************************************************************************
  * DEFINES

--- a/switchapi/switch_internal.h
+++ b/switchapi/switch_internal.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 #include "switchapi/switch_device_int.h"
 #include "switchapi/switch_handle_int.h"
 #include "switchapi/switch_status.h"
+#include "switchutils/switch_log.h"
 #include "switchutils/switch_utils.h"
 #include "tdi/common/tdi_defs.h"
 

--- a/switchapi/switch_internal.h
+++ b/switchapi/switch_internal.h
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
  * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +30,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif /* __cplusplus */
+#endif
 
 #define SWITCH_API_BUFFER_SIZE 512
 
@@ -218,7 +219,7 @@ char* switch_handle_type_to_string(switch_handle_type_t handle_type);
 #define IPV4_TABLE_SIZE 1024
 
 #ifdef __cplusplus
-}
+}  // extern "C"
 #endif
 
 #endif /* _switch_internal_h_ */

--- a/switchlink/BUILD.bazel
+++ b/switchlink/BUILD.bazel
@@ -64,12 +64,12 @@ cc_library(
 cc_library(
     name = "switchlink_handlers",
     srcs = ["switchlink_handlers.h"],
+    linkopts = ["-lnl-3"],
     deps = [
-        "@nl-3",
         ":switchlink_db",
         ":switchlink_types",
+        "@nl-3",
     ],
-    linkopts = ["-lnl-3"],
 )
 
 cc_library(
@@ -112,14 +112,14 @@ cc_library(
         "switchlink_main.c",
         "switchlink_main.h",
     ],
+    linkopts = ["-lnl-3"],
     deps = [
-        "@nl-3",
         ":switchlink_int",
         ":switchlink_types",
         "//switchutils:switch_log",
         "@local_dpdk_bin//:target_sys",
+        "@nl-3",
     ],
-    linkopts = ["-lnl-3"],
 )
 
 cc_library(
@@ -138,8 +138,8 @@ cc_test(
     name = "switchlink_neigh_test",
     srcs = ["switchlink_neigh_test.cc"],
     deps = [
-        ":switchlink_neigh",
         ":switchlink_globals",
+        ":switchlink_neigh",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -159,8 +159,8 @@ cc_test(
     name = "switchlink_route_test",
     srcs = ["switchlink_route_test.cc"],
     deps = [
-        ":switchlink_route",
         ":switchlink_globals",
+        ":switchlink_route",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/switchlink/BUILD.bazel
+++ b/switchlink/BUILD.bazel
@@ -1,0 +1,189 @@
+# //switchlink/BUILD.bazel
+
+# Copyright 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_import(
+    name = "nl-3",
+    hdrs = glob(["netlink/**/*.h"]),
+    includes = ["/usr/include/libnl3"],
+    system_provided = 1,
+)
+
+cc_import(
+    name = "nl-route-3",
+    hdrs = glob(["netlink/**/*.h"]),
+    includes = ["/usr/include/libnl3"],
+    system_provided = 1,
+)
+
+cc_library(
+    name = "switchlink_address",
+    srcs = ["switchlink_address.c"],
+    deps = [
+        ":switchlink_globals",
+        ":switchlink_handlers",
+        ":switchlink_int",
+        "//switchutils:switch_log",
+        "@local_dpdk_bin//:target_sys",
+    ],
+)
+
+cc_test(
+    name = "switchlink_address_test",
+    srcs = ["switchlink_address_test.cc"],
+    deps = [
+        ":switchlink_address",
+        ":switchlink_globals",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "switchlink_db",
+    srcs = [
+        "switchlink_db.c",
+        "switchlink_db.h",
+        "switchlink_db_int.h",
+    ],
+    deps = [
+        ":switchlink_int",
+        ":switchlink_link_types",
+        ":switchlink_types",
+        "@local_dpdk_bin//:target_utils",
+        "@local_dpdk_bin//:tommyds_hdrs",
+        "@local_dpdk_bin//:xxhash_hdrs",
+    ],
+)
+
+cc_library(
+    name = "switchlink_globals",
+    srcs = ["switchlink_globals.c"],
+    hdrs = ["switchlink_globals.h"],
+    deps = [":switchlink_types"],
+)
+
+cc_library(
+    name = "switchlink_types",
+    srcs = ["switchlink.h"],  # rename
+    deps = [
+        "//switchutils:switch_utils",
+    ],
+)
+
+cc_library(
+    name = "switchlink_handlers",
+    srcs = ["switchlink_handlers.h"],
+    deps = [
+        ":nl-3",
+        ":switchlink_db",
+        ":switchlink_types",
+    ],
+    linkopts = ["-lnl-3"],
+)
+
+cc_library(
+    name = "switchlink_int",
+    srcs = ["switchlink_int.h"],
+)
+
+cc_library(
+    name = "switchlink_link",
+    srcs = ["switchlink_link.c"],
+    deps = [
+        ":switchlink_globals",
+        ":switchlink_handlers",
+        ":switchlink_int",
+        ":switchlink_link_types",
+        ":switchlink_types",
+        "//switchutils:switch_log",
+    ],
+)
+
+cc_test(
+    name = "switchlink_link_test",
+    srcs = ["switchlink_link_test.cc"],
+    deps = [
+        ":switchlink_globals",
+        ":switchlink_handlers",
+        ":switchlink_link",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "switchlink_link_types",
+    srcs = ["switchlink_link_types.h"],
+)
+
+cc_library(
+    name = "switchlink_main",
+    srcs = [
+        "switchlink_main.c",
+        "switchlink_main.h",
+    ],
+    deps = [
+        ":nl-3",
+        ":switchlink_int",
+        ":switchlink_types",
+        "//switchutils:switch_log",
+        "@local_dpdk_bin//:target_sys",
+    ],
+    linkopts = ["-lnl-3"],
+)
+
+cc_library(
+    name = "switchlink_neigh",
+    srcs = ["switchlink_neigh.c"],
+    deps = [
+        ":switchlink_globals",
+        ":switchlink_handlers",
+        ":switchlink_int",
+        ":switchlink_types",
+        "//switchutils:switch_log",
+    ],
+)
+
+cc_test(
+    name = "switchlink_neigh_test",
+    srcs = ["switchlink_neigh_test.cc"],
+    deps = [
+        ":switchlink_neigh",
+        ":switchlink_globals",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "switchlink_route",
+    srcs = ["switchlink_route.c"],
+    deps = [
+        ":switchlink_globals",
+        ":switchlink_handlers",
+        ":switchlink_int",
+        "//switchutils:switch_log",
+    ],
+)
+
+cc_test(
+    name = "switchlink_route_test",
+    srcs = ["switchlink_route_test.cc"],
+    deps = [
+        ":switchlink_route",
+        ":switchlink_globals",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "switchlink_utils",
+    srcs = ["switchlink_utils.c"],
+    hdrs = ["switchlink_utils.h"],
+    deps = [
+        "//switchutils:switch_utils",
+    ],
+)

--- a/switchlink/BUILD.bazel
+++ b/switchlink/BUILD.bazel
@@ -7,20 +7,6 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_import(
-    name = "nl-3",
-    hdrs = glob(["netlink/**/*.h"]),
-    includes = ["/usr/include/libnl3"],
-    system_provided = 1,
-)
-
-cc_import(
-    name = "nl-route-3",
-    hdrs = glob(["netlink/**/*.h"]),
-    includes = ["/usr/include/libnl3"],
-    system_provided = 1,
-)
-
 cc_library(
     name = "switchlink_address",
     srcs = ["switchlink_address.c"],
@@ -79,7 +65,7 @@ cc_library(
     name = "switchlink_handlers",
     srcs = ["switchlink_handlers.h"],
     deps = [
-        ":nl-3",
+        "@nl-3",
         ":switchlink_db",
         ":switchlink_types",
     ],
@@ -127,7 +113,7 @@ cc_library(
         "switchlink_main.h",
     ],
     deps = [
-        ":nl-3",
+        "@nl-3",
         ":switchlink_int",
         ":switchlink_types",
         "//switchutils:switch_log",

--- a/switchlink/CMakeLists.txt
+++ b/switchlink/CMakeLists.txt
@@ -23,9 +23,7 @@ add_library(switchlink_o OBJECT
     switchlink_main.c
     switchlink_main.h
     switchlink_neigh.c
-    switchlink_neigh.h
     switchlink_route.c
-    switchlink_route.h
     switchlink_utils.c
     switchlink_utils.h
     $<TARGET_OBJECTS:switchlink_sai_o>

--- a/switchlink/CMakeLists.txt
+++ b/switchlink/CMakeLists.txt
@@ -41,7 +41,7 @@ target_include_directories(switchlink_o PRIVATE
     ${SDE_INSTALL_DIR}/include/target-utils/third-party  # judy
     ${SDE_INSTALL_DIR}/include/target-utils/third-party/tommyds
     ${SDE_INSTALL_DIR}/include/target-utils/third-party/xxHash
-    ${SDE_INSTALL_DIR}/include/target-sys
+    ${SDE_INSTALL_DIR}/include
     ${SAI_INCLUDE_DIR}
 )
 

--- a/switchlink/switchlink_address.c
+++ b/switchlink/switchlink_address.c
@@ -21,6 +21,7 @@
 #include "switchlink_globals.h"
 #include "switchlink_handlers.h"
 #include "switchlink_int.h"
+#include "switchutils/switch_log.h"
 
 /*
  * Routine Description:

--- a/switchlink/switchlink_address_test.cc
+++ b/switchlink/switchlink_address_test.cc
@@ -1,5 +1,19 @@
-// Copyright 2023-2024 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright 2023-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <arpa/inet.h>
 #include <linux/if_arp.h>
@@ -13,7 +27,6 @@
 extern "C" {
 #include "switchlink_handlers.h"
 #include "switchlink_int.h"
-#include "switchlink_route.h"
 }
 
 using namespace std;
@@ -173,7 +186,7 @@ TEST_F(SwitchlinkAddressTest, addIpv4Address) {
 
   // Assert
   EXPECT_EQ(results.size(), 2);
-  for (int i = 0; i < results.size(); i++) {
+  for (size_t i = 0; i < results.size(); i++) {
     EXPECT_EQ(results[i].num_handler_calls, 1);
     EXPECT_EQ(results[i].opType, ADD_ADDRESS);
     EXPECT_EQ(results[i].addr.family, AF_INET);
@@ -220,7 +233,7 @@ TEST_F(SwitchlinkAddressTest, deleteIpv4Address) {
 
   // Assert
   EXPECT_EQ(results.size(), 2);
-  for (int i = 0; i < results.size(); i++) {
+  for (size_t i = 0; i < results.size(); i++) {
     EXPECT_EQ(results[i].num_handler_calls, 1);
     EXPECT_EQ(results[i].opType, DELETE_ADDRESS);
     EXPECT_EQ(results[i].addr.family, AF_INET);
@@ -270,7 +283,7 @@ TEST_F(SwitchlinkAddressTest, addIpv6Address) {
 
   // Assert
   EXPECT_EQ(results.size(), 2);
-  for (int i = 0; i < results.size(); i++) {
+  for (size_t i = 0; i < results.size(); i++) {
     EXPECT_EQ(results[i].num_handler_calls, 1);
     EXPECT_EQ(results[i].opType, ADD_ADDRESS);
     EXPECT_EQ(results[i].addr.family, AF_INET6);
@@ -323,7 +336,7 @@ TEST_F(SwitchlinkAddressTest, deleteIpv6Address) {
 
   // Assert
   EXPECT_EQ(results.size(), 2);
-  for (int i = 0; i < results.size(); i++) {
+  for (size_t i = 0; i < results.size(); i++) {
     EXPECT_EQ(results[i].num_handler_calls, 1);
     EXPECT_EQ(results[i].opType, DELETE_ADDRESS);
     EXPECT_EQ(results[i].addr.family, AF_INET6);

--- a/switchlink/switchlink_db.c
+++ b/switchlink/switchlink_db.c
@@ -1,7 +1,7 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
  * Copyright 2022-2024 Intel Corporation.
- * SPDX-License-Identifier: Apache 2.0
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchlink/switchlink_db_int.h
+++ b/switchlink/switchlink_db_int.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchlink/switchlink_int.h
+++ b/switchlink/switchlink_int.h
@@ -21,6 +21,7 @@
 #define __SWITCHLINK_INT_H__
 
 struct nlmsghdr;
+
 extern void switchlink_init_db(void);
 extern void switchlink_init_api(void);
 extern void switchlink_init_link(void);

--- a/switchlink/switchlink_link.c
+++ b/switchlink/switchlink_link.c
@@ -1,7 +1,7 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
  * Copyright 2022-2024 Intel Corporation.
- * SPDX-License-Identifier: Apache 2.0
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@
 #include "switchlink_handlers.h"
 #include "switchlink_int.h"
 #include "switchlink_link_types.h"
-#include "switchlink_utils.h"
+#include "switchutils/switch_log.h"
 
 #if defined(ES2K_TARGET)
 // ES2K creates netdevs from idpf driver/SR-IOVs.

--- a/switchlink/switchlink_main.c
+++ b/switchlink/switchlink_main.c
@@ -38,6 +38,7 @@
 
 #include "switchlink.h"
 #include "switchlink_int.h"
+#include "switchutils/switch_log.h"
 
 static struct nl_sock* g_nlsk = NULL;
 static pthread_t switchlink_thread;

--- a/switchlink/switchlink_neigh.c
+++ b/switchlink/switchlink_neigh.c
@@ -24,6 +24,7 @@
 #include "switchlink_globals.h"
 #include "switchlink_handlers.h"
 #include "switchlink_int.h"
+#include "switchutils/switch_log.h"
 
 /*
  * Routine Description:

--- a/switchlink/switchlink_neigh_test.cc
+++ b/switchlink/switchlink_neigh_test.cc
@@ -1,5 +1,19 @@
-// Copyright 2023-2024 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright 2023-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <arpa/inet.h>
 #include <memory.h>

--- a/switchlink/switchlink_route.c
+++ b/switchlink/switchlink_route.c
@@ -23,6 +23,7 @@
 #include "switchlink_globals.h"
 #include "switchlink_handlers.h"
 #include "switchlink_int.h"
+#include "switchutils/switch_log.h"
 
 /*
  * Routine Description:
@@ -137,7 +138,6 @@ void switchlink_process_route_msg(const struct nlmsghdr* nlmsg, int msgtype) {
   int hdrlen, attrlen;
   struct nlattr* attr;
   struct rtmsg* rmsg;
-  bool src_valid = false;
   bool dst_valid = false;
   bool gateway_valid = false;
   switchlink_handle_t ecmp_h = 0;
@@ -149,9 +149,6 @@ void switchlink_process_route_msg(const struct nlmsghdr* nlmsg, int msgtype) {
   uint8_t af = AF_UNSPEC;
   bool oif_valid = false;
   uint32_t oif = 0;
-
-  bool iif_valid = false;
-  uint32_t iif = 0;
 
   krnlmon_assert((msgtype == RTM_NEWROUTE) || (msgtype == RTM_DELROUTE));
   rmsg = nlmsg_data(nlmsg);
@@ -188,7 +185,6 @@ void switchlink_process_route_msg(const struct nlmsghdr* nlmsg, int msgtype) {
     int attr_type = nla_type(attr);
     switch (attr_type) {
       case RTA_SRC:
-        src_valid = true;
         memset(&src_addr, 0, sizeof(switchlink_ip_addr_t));
         src_addr.family = af;
         src_addr.prefix_len = rmsg->rtm_src_len;
@@ -227,10 +223,6 @@ void switchlink_process_route_msg(const struct nlmsghdr* nlmsg, int msgtype) {
       case RTA_OIF:
         oif_valid = true;
         oif = nla_get_u32(attr);
-        break;
-      case RTA_IIF:
-        iif_valid = true;
-        iif = nla_get_u32(attr);
         break;
       default:
         break;

--- a/switchlink/switchlink_route_test.cc
+++ b/switchlink/switchlink_route_test.cc
@@ -1,5 +1,19 @@
-// Copyright 2023-2024 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright 2023-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <arpa/inet.h>
 #include <memory.h>
@@ -596,9 +610,9 @@ TEST_F(SwitchlinkRouteTest, deleteIPv6Route) {
 
   inet_pton(AF_INET6, "2001::1", &gateway_addr6);
   // Word 0 of IPv6 address.
-  const uint16_t GATEWAY_V6ADDR_0 = htons(0x2001);
+  // const uint16_t GATEWAY_V6ADDR_0 = htons(0x2001);
   // Word 7 of IPv6 address.
-  const uint16_t GATEWAY_V6ADDR_7 = htons(0x0001);
+  // const uint16_t GATEWAY_V6ADDR_7 = htons(0x0001);
 
   inet_pton(AF_INET6, "2001::2", &dst_addr6);
   // Word 0 of IPv6 address.
@@ -665,7 +679,7 @@ TEST_F(SwitchlinkRouteTest, processEcmpUpdatev4Nexthop) {
   };
 
   const uint32_t gateway_addr1 = IPV4_ADDR(20, 20, 20, 1);
-  const uint32_t oifindex = 1;
+  // const uint32_t oifindex = 1;
 
   // Arrange
   nlmsg_ = nlmsg_alloc_size(1024);
@@ -723,7 +737,7 @@ TEST_F(SwitchlinkRouteTest, processEcmpCreatev4Nexthop) {
   };
 
   const uint32_t gateway_addr1 = IPV4_ADDR(20, 20, 20, 1);
-  const uint32_t oifindex = 1;
+  // const uint32_t oifindex = 1;
 
   // Arrange
   nlmsg_ = nlmsg_alloc_size(1024);

--- a/switchlink/testing.cmake
+++ b/switchlink/testing.cmake
@@ -41,6 +41,7 @@ endfunction()
 add_executable(switchlink_link_test
     switchlink_link_test.cc
     switchlink_globals.c
+    switchlink_int.h
     switchlink_link.c
     switchlink_link_types.h
 )
@@ -66,8 +67,8 @@ define_switchlink_test(switchlink_address_test)
 add_executable(switchlink_neighbor_test
     switchlink_neigh_test.cc
     switchlink_globals.c
+    switchlink_int.h
     switchlink_neigh.c
-    switchlink_neigh.h
 )
 
 define_switchlink_test(switchlink_neighbor_test)
@@ -79,7 +80,7 @@ define_switchlink_test(switchlink_neighbor_test)
 add_executable(switchlink_route_test
     switchlink_route_test.cc
     switchlink_route.c
-    switchlink_route.h
+    switchlink_int.h
 )
 
 define_switchlink_test(switchlink_route_test)

--- a/switchsai/saiinternal.h
+++ b/switchsai/saiinternal.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@
 #include "sai.h"
 #include "saitypes.h"
 #include "switchapi/switch_base_types.h"
+#include "switchutils/switch_log.h"
 #include "switchutils/switch_utils.h"
 
 #ifndef __SAIINTERNAL_H_

--- a/switchsai/saiinternal.h
+++ b/switchsai/saiinternal.h
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
  * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchutils/BUILD.bazel
+++ b/switchutils/BUILD.bazel
@@ -13,7 +13,6 @@ cc_library(
     deps = [
         "@local_dpdk_bin//:target_sys",
     ],
-
 )
 
 cc_library(

--- a/switchutils/BUILD.bazel
+++ b/switchutils/BUILD.bazel
@@ -1,0 +1,22 @@
+# //switchutils/BUILD.bazel
+
+# Copyright 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "switch_log",
+    hdrs = ["switch_log.h"],
+    deps = [
+        "@local_dpdk_bin//:target_sys",
+    ],
+
+)
+
+cc_library(
+    name = "switch_utils",
+    hdrs = ["switch_utils.h"],
+)

--- a/switchutils/CMakeLists.txt
+++ b/switchutils/CMakeLists.txt
@@ -9,5 +9,5 @@ add_library(switchutils_o OBJECT
 )
 
 target_include_directories(switchutils_o PRIVATE
-    ${SDE_INSTALL_DIR}/include/target-sys # zlog
+    ${SDE_INSTALL_DIR}/include
 )

--- a/switchutils/switch_log.h
+++ b/switchutils/switch_log.h
@@ -18,8 +18,7 @@
 #ifndef __KRNLMON_LOG_H__
 #define __KRNLMON_LOG_H__
 
-#include "bf_sal/bf_sys_intf.h"
-#include "bf_sal/bf_sys_log.h"
+#include "target-sys/bf_sal/bf_sys_log.h"
 
 #define krnlmon_log_critical(...) \
   bf_sys_log_and_trace(KRNLMON, BF_LOG_CRIT, __VA_ARGS__)

--- a/switchutils/switch_log.h
+++ b/switchutils/switch_log.h
@@ -1,5 +1,22 @@
-#ifndef KRNLMON_LOG_INCLUDED
-#define KRNLMON_LOG_INCLUDED
+/*
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __KRNLMON_LOG_H__
+#define __KRNLMON_LOG_H__
 
 #include "bf_sal/bf_sys_intf.h"
 #include "bf_sal/bf_sys_log.h"
@@ -21,4 +38,4 @@
 
 #define krnlmon_log krnlmon_log_debug
 
-#endif  // KRNLMON_LOG_INCUDED
+#endif  // __KRNLMON_LOG_H__

--- a/switchutils/switch_utils.h
+++ b/switchutils/switch_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,8 +19,6 @@
 #define __KRNLMON_UTILS_H__
 
 #include <assert.h>
-
-#include "switch_log.h"
 
 #define krnlmon_assert assert
 #define krnlmon_snprintf snprintf


### PR DESCRIPTION
- Implemented a Bazel buildsystem to build `switchlink` and run its unit tests.

- Removed switchlink_route.h in favor of switchlink_int.h.

- Separated switch_log.h from switch_utils.h by removing the #include for the former from the latter. Updated source files to include either one or both files, depending on their needs.

- Removed or commented out dead code. Addressed compiler warnings.