### PR TITLE
Refine Bazel buildsystem

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,27 @@
+# //BUILD.bazel
+
+# Copyright 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+config_setting(
+    name = "dpdk_target",
+    define_values = {
+        "target": "dpdk",
+    },
+)
+
+config_setting(
+    name = "es2k_target",
+    define_values = {
+        "target": "es2k",
+    },
+)
+
+config_setting(
+    name = "tofino_target",
+    define_values = {
+        "target": "tofino",
+    },
+)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -18,10 +18,3 @@ config_setting(
         "target": "es2k",
     },
 )
-
-config_setting(
-    name = "tofino_target",
-    define_values = {
-        "target": "tofino",
-    },
-)

--- a/bazel/external/dpdk.BUILD
+++ b/bazel/external/dpdk.BUILD
@@ -69,7 +69,7 @@ cc_library(
         "-lm",
         "-ldl",
     ],
-    strip_include_prefix = "dpdk-bin/include/target-sys",
+    strip_include_prefix = "dpdk-bin/include",
 )
 
 cc_library(

--- a/switchapi/switch_base_types.h
+++ b/switchapi/switch_base_types.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,14 +21,14 @@
 /**
  * Third party includes
  */
-#include "bf_sal/bf_sys_mem.h"
-#include "bf_sal/bf_sys_timer.h"
 #include "judy-1.0.5/src/Judy.h"
+#include "target-sys/bf_sal/bf_sys_mem.h"
+#include "target-sys/bf_sal/bf_sys_timer.h"
 #include "tommyds/tommyhashtbl.h"
 #include "tommyds/tommylist.h"
 #ifdef STATIC_LINK_LIB
 #include "bf_switchd/bf_switchd.h"
-#endif  // STATIC_LINK_LIB
+#endif
 
 /**
  * standard includes
@@ -40,7 +40,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif /* __cplusplus */
+#endif
 
 /***************************************************************************
  * DEFINES

--- a/switchlink/CMakeLists.txt
+++ b/switchlink/CMakeLists.txt
@@ -41,7 +41,7 @@ target_include_directories(switchlink_o PRIVATE
     ${SDE_INSTALL_DIR}/include/target-utils/third-party  # judy
     ${SDE_INSTALL_DIR}/include/target-utils/third-party/tommyds
     ${SDE_INSTALL_DIR}/include/target-utils/third-party/xxHash
-    ${SDE_INSTALL_DIR}/include/target-sys
+    ${SDE_INSTALL_DIR}/include
     ${SAI_INCLUDE_DIR}
 )
 

--- a/switchutils/CMakeLists.txt
+++ b/switchutils/CMakeLists.txt
@@ -9,5 +9,5 @@ add_library(switchutils_o OBJECT
 )
 
 target_include_directories(switchutils_o PRIVATE
-    ${SDE_INSTALL_DIR}/include/target-sys # zlog
+    ${SDE_INSTALL_DIR}/include
 )

--- a/switchutils/switch_log.h
+++ b/switchutils/switch_log.h
@@ -18,8 +18,7 @@
 #ifndef __KRNLMON_LOG_H__
 #define __KRNLMON_LOG_H__
 
-#include "bf_sal/bf_sys_intf.h"
-#include "bf_sal/bf_sys_log.h"
+#include "target-sys/bf_sal/bf_sys_log.h"
 
 #define krnlmon_log_critical(...) \
   bf_sys_log_and_trace(KRNLMON, BF_LOG_CRIT, __VA_ARGS__)


### PR DESCRIPTION
- Defined Bazel config settings for the DPDK and ES2K targets.

- Added `target-sys/` prefix to #includes for target-sys header
  files, to fix a problem in the Bazel build. Updated dpdk.BUILD and
  the CMakeLists.txt files to reflect the change.

NOTE: This PR is based on PR https://github.com/ipdk-io/krnlmon/pull/91.