### PR TITLE
Implement P4 SDE Abstraction Layer (switchsde)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -2,9 +2,12 @@ name: "Krnlmon CI Pipeline"
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - bazelize-*
   pull_request:
-    branches: [main]
+    branches:
+      - main
 
   workflow_dispatch:
 

--- a/bazel/external/dpdk.BUILD
+++ b/bazel/external/dpdk.BUILD
@@ -61,6 +61,14 @@ cc_library(
 )
 
 cc_library(
+    name = "judy_hdrs",
+    hdrs = glob([
+        "dpdk-bin/include/target-utils/third-party/judy-1.0.5/src/*.h",
+    ]),
+    strip_include_prefix = "dpdk-bin/include/target-utils/third-party/",
+)
+
+cc_library(
     name = "target_sys",
     srcs = glob(["dpdk-bin/lib/libtarget_sys.so"]),
     hdrs = glob(["dpdk-bin/include/target-sys/**/*.h"]),
@@ -83,14 +91,6 @@ cc_library(
     ],
     strip_include_prefix = "dpdk-bin/include/target-utils",
     deps = [":target_sys"],
-)
-
-cc_library(
-    name = "judy_hdrs",
-    hdrs = glob([
-        "dpdk-bin/include/target-utils/third-party/judy-1.0.5/src/*.h",
-    ]),
-    strip_include_prefix = "dpdk-bin/include/target-utils/third-party/",
 )
 
 cc_library(

--- a/dpdk.cmake
+++ b/dpdk.cmake
@@ -1,0 +1,2 @@
+# CMake build configuration for DPDK target
+set(TDI_TARGET "dpdk" CACHE STRING "config: TDI target type")

--- a/switchapi/BUILD.bazel
+++ b/switchapi/BUILD.bazel
@@ -1,0 +1,19 @@
+# //switchapi/BUILD.bazel
+
+# Copyright 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "switch_base_types",
+    hdrs = ["switch_base_types.h"],
+    deps = [
+        "@local_dpdk_bin//:dpdk_sde",
+        "@local_dpdk_bin//:judy_hdrs",
+        "@local_dpdk_bin//:target_sys",
+        "@local_dpdk_bin//:tommyds_hdrs",
+    ],
+)

--- a/switchapi/CMakeLists.txt
+++ b/switchapi/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(switchapi_o OBJECT
   switch_lag.h
   switch_neighbor.h
   switch_neighbor_int.h
+  switch_pd_routing.h
   switch_nhop.h
   switch_nhop_int.h
   switch_port_int.h

--- a/switchapi/dpdk/switch_config.c
+++ b/switchapi/dpdk/switch_config.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 
 #include "switchapi/switch_config_int.h"
 #include "switchapi/switch_internal.h"
+#include "switchutils/switch_log.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/switchapi/dpdk/switch_device.c
+++ b/switchapi/dpdk/switch_device.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,13 +26,14 @@
 #include "switchapi/switch_rmac_int.h"
 #include "switchapi/switch_table.h"
 #include "switchapi/switch_vrf.h"
+#include "switchutils/switch_log.h"
 
 #undef __MODULE__
 #define __MODULE__ SWITCH_API_TYPE_DEVICE
 
 #ifdef __cplusplus
 extern "C" {
-#endif /* __cplusplus */
+#endif
 
 #define __FILE_ID__ SWITCH_DEVICE
 
@@ -620,7 +621,7 @@ switch_status_t switch_api_device_tunnel_dmac_get(switch_device_t device,
   return status;
 }
 #ifdef __cplusplus
-}
+}  // extern "C"
 #endif
 
 switch_status_t switch_api_device_remove(switch_device_t device) {

--- a/switchapi/dpdk/switch_fdb.c
+++ b/switchapi/dpdk/switch_fdb.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache 2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +24,7 @@
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_rif_int.h"
 #include "switchapi/switch_status.h"
+#include "switchutils/switch_log.h"
 
 switch_status_t switch_l2_hash_key_init(void* args, switch_uint8_t* key,
                                         switch_uint32_t* len) {

--- a/switchapi/dpdk/switch_handle.c
+++ b/switchapi/dpdk/switch_handle.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache 2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +21,7 @@
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_nhop_int.h"
 #include "switchapi/switch_status.h"
-
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
+#include "switchutils/switch_log.h"
 
 #define __FILE_ID__ SWITCH_HANDLE
 
@@ -477,7 +475,3 @@ switch_status_t switch_api_handle_count_get(switch_device_t device,
 
   return status;
 }
-
-#ifdef __cplusplus
-}
-#endif

--- a/switchapi/dpdk/switch_id.c
+++ b/switchapi/dpdk/switch_id.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache 2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +19,7 @@
 #include "switchapi/switch_id.h"
 
 #include "switchapi/switch_internal.h"
-
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
+#include "switchutils/switch_log.h"
 
 #define __FILE_ID__ SWITCH_ID
 

--- a/switchapi/dpdk/switch_l3.c
+++ b/switchapi/dpdk/switch_l3.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache 2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +22,7 @@
 #include "switchapi/switch_device.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_nhop_int.h"
+#include "switchutils/switch_log.h"
 
 switch_status_t switch_route_table_entry_key_init(void* args,
                                                   switch_uint8_t* key,

--- a/switchapi/dpdk/switch_neighbor.c
+++ b/switchapi/dpdk/switch_neighbor.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache 2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +27,7 @@
 #include "switchapi/switch_nhop_int.h"
 #include "switchapi/switch_rif_int.h"
 #include "switchapi/switch_rmac_int.h"
+#include "switchutils/switch_log.h"
 
 switch_status_t switch_neighbor_init(switch_device_t device) {
   switch_neighbor_context_t* neighbor_ctx = NULL;

--- a/switchapi/dpdk/switch_nhop.c
+++ b/switchapi/dpdk/switch_nhop.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache 2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +25,7 @@
 #include "switchapi/switch_nhop_int.h"
 #include "switchapi/switch_rif.h"
 #include "switchapi/switch_rif_int.h"
+#include "switchutils/switch_log.h"
 
 // add corresponding delete functions
 

--- a/switchapi/dpdk/switch_pd_fdb.c
+++ b/switchapi/dpdk/switch_pd_fdb.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache 2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +26,7 @@
 #include "switchapi/switch_fdb.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_rif_int.h"
+#include "switchutils/switch_log.h"
 
 switch_status_t switch_pd_l2_tx_forward_table_entry(
     switch_device_t device, const switch_api_l2_info_t* api_l2_tx_info,

--- a/switchapi/dpdk/switch_pd_routing.c
+++ b/switchapi/dpdk/switch_pd_routing.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache 2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +24,7 @@
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_nhop_int.h"
+#include "switchutils/switch_log.h"
 
 switch_status_t switch_routing_table_entry(
     switch_device_t device, const switch_pd_routing_info_t* api_routing_info,

--- a/switchapi/dpdk/switch_pd_tunnel.c
+++ b/switchapi/dpdk/switch_pd_tunnel.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache 2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +22,7 @@
 #include "switch_pd_utils.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_tunnel.h"
+#include "switchutils/switch_log.h"
 
 switch_status_t switch_pd_tunnel_entry(
     switch_device_t device, const switch_api_tunnel_info_t* api_tunnel_info_t,

--- a/switchapi/dpdk/switch_pd_utils.c
+++ b/switchapi/dpdk/switch_pd_utils.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache 2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +25,7 @@
 #include "port_mgr/dpdk/bf_dpdk_port_if.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_internal.h"
+#include "switchutils/switch_log.h"
 
 void switch_pd_to_get_port_id(switch_api_rif_info_t* port_rif_info) {
   char if_name[16] = {0};

--- a/switchapi/dpdk/switch_rif.c
+++ b/switchapi/dpdk/switch_rif.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache 2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +27,7 @@
 #include "switchapi/switch_rif.h"
 #include "switchapi/switch_rif_int.h"
 #include "switchapi/switch_status.h"
+#include "switchutils/switch_log.h"
 
 /*
  * Routine Description:

--- a/switchapi/dpdk/switch_rmac.c
+++ b/switchapi/dpdk/switch_rmac.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache 2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +21,7 @@
 #include "switch_pd_routing.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_rmac_int.h"
+#include "switchutils/switch_log.h"
 
 /*
  * Routine Description:

--- a/switchapi/switch_neighbor.h
+++ b/switchapi/switch_neighbor.h
@@ -24,7 +24,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif /* __cplusplus */
+#endif
 
 typedef enum switch_neighbor_type_s {
   SWITCH_NEIGHBOR_TYPE_IP = 0x0,

--- a/switchapi/switch_neighbor_int.h
+++ b/switchapi/switch_neighbor_int.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,16 +19,11 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif /* __cplusplus */
+#endif
 
+#include "switch_pd_routing.h"
 #include "switch_rif.h"
 #include "switch_types_int.h"
-
-#if defined(DPDK_TARGET)
-#include "dpdk/switch_pd_routing.h"
-#elif defined(ES2K_TARGET)
-#include "es2k/switch_pd_routing.h"
-#endif
 
 #define switch_neighbor_handle_create(_device)               \
   switch_handle_create(_device, SWITCH_HANDLE_TYPE_NEIGHBOR, \
@@ -70,4 +65,4 @@ switch_status_t switch_neighbor_default_entries_delete(switch_device_t device);
 }
 #endif
 
-#endif /* _switch_neighbor_int_h_ */
+#endif  // __SWITCH_NEIGHBOR_INT_H__

--- a/switchapi/switch_pd_routing.h
+++ b/switchapi/switch_pd_routing.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache 2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Proxy for the target-specific switch_pd_routing header file.
+//
+// We use a unique include guard to avoid aliasing the ones in the
+// target-specific header files (which would cause their contents
+// to be ignored).
+
+#ifndef __SWITCHAPI_PD_ROUTING_H__
+#define __SWITCHAPI_PD_ROUTING_H__
+
+#if defined(DPDK_TARGET)
+#include "dpdk/switch_pd_routing.h"
+#elif defined(ES2K_TARGET)
+#include "es2k/switch_pd_routing.h"
+#endif
+
+#endif  // __SWITCHAPI_PD_ROUTING_H__

--- a/switchapi/switch_table.h
+++ b/switchapi/switch_table.h
@@ -1,7 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
- *
+ * Copyright 2022-2024 Intel Corporation.
  * SPDX-License-Identifier: Apache 2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +20,7 @@
 #define __SWITCH_TABLE_H__
 
 #include "switch_base_types.h"
+#include "switchutils/switch_log.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/switchlink/BUILD.bazel
+++ b/switchlink/BUILD.bazel
@@ -7,6 +7,13 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
+TARGET_DEFINES = select(
+    {
+        "//:dpdk_target": ["DPDK_TARGET"],
+        "//:es2k_target": ["ES2K_TARGET"],
+    },
+)
+
 cc_library(
     name = "switchlink_address",
     srcs = ["switchlink_address.c"],
@@ -36,6 +43,7 @@ cc_library(
         "switchlink_db.h",
         "switchlink_db_int.h",
     ],
+    defines = TARGET_DEFINES,
     deps = [
         ":switchlink_int",
         ":switchlink_link_types",

--- a/switchlink/sai/BUILD.bazel
+++ b/switchlink/sai/BUILD.bazel
@@ -7,6 +7,13 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
+TARGET_DEFINES = select(
+    {
+        "//:dpdk_target": ["DPDK_TARGET"],
+        "//:es2k_target": ["ES2K_TARGET"],
+    },
+)
+
 cc_library(
     name = "switchlink_handle_ecmp",
     srcs = ["switchlink_handle_ecmp.c"],
@@ -40,8 +47,9 @@ cc_library(
 )
 
 cc_library(
-    name ="switchlink_handle_neigh",
+    name = "switchlink_handle_neigh",
     srcs = ["switchlink_handle_neigh.c"],
+    defines = TARGET_DEFINES,
     deps = [
         ":switchlink_init_sai",
         "//switchlink:switchlink_globals",
@@ -52,6 +60,7 @@ cc_library(
 cc_library(
     name = "switchlink_handle_nexthop",
     srcs = ["switchlink_handle_nexthop.c"],
+    defines = TARGET_DEFINES,
     deps = [
         ":switchlink_init_sai",
         "//switchlink:switchlink_handlers",
@@ -82,8 +91,8 @@ cc_library(
     srcs = ["switchlink_init_sai.c"],
     hdrs = ["switchlink_init_sai.h"],
     deps = [
-        "//switchlink:switchlink_types",
         "//switchlink:switchlink_db",
+        "//switchlink:switchlink_types",
         "//switchlink:switchlink_utils",
         "//switchsai:saiinternal",
     ],

--- a/switchlink/sai/BUILD.bazel
+++ b/switchlink/sai/BUILD.bazel
@@ -1,0 +1,90 @@
+# //switchlink/sai/BUILD.bazel
+
+# Copyright 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "switchlink_handle_ecmp",
+    srcs = ["switchlink_handle_ecmp.c"],
+    deps = [
+        ":switchlink_init_sai",
+        "//switchlink:switchlink_db",
+        "//switchlink:switchlink_handlers",
+        "//switchlink:switchlink_types",
+    ],
+)
+
+cc_library(
+    name = "switchlink_handle_lag",
+    srcs = ["switchlink_handle_lag.c"],
+    deps = [
+        ":switchlink_init_sai",
+        "//switchsde:sde_port_intf",
+        "//switchsde:sde_status",
+        "//switchsde:sde_types",
+        "@local_dpdk_bin//:dpdk_sde",
+    ],
+)
+
+cc_library(
+    name = "switchlink_handle_link",
+    srcs = ["switchlink_handle_link.c"],
+    deps = [
+        ":switchlink_init_sai",
+        "//switchlink:switchlink_handlers",
+    ],
+)
+
+cc_library(
+    name ="switchlink_handle_neigh",
+    srcs = ["switchlink_handle_neigh.c"],
+    deps = [
+        ":switchlink_init_sai",
+        "//switchlink:switchlink_globals",
+        "//switchlink:switchlink_handlers",
+    ],
+)
+
+cc_library(
+    name = "switchlink_handle_nexthop",
+    srcs = ["switchlink_handle_nexthop.c"],
+    deps = [
+        ":switchlink_init_sai",
+        "//switchlink:switchlink_handlers",
+    ],
+)
+
+cc_library(
+    name = "switchlink_handle_route",
+    srcs = ["switchlink_handle_route.c"],
+    deps = [
+        ":switchlink_init_sai",
+        "//switchlink:switchlink_globals",
+        "//switchlink:switchlink_handlers",
+    ],
+)
+
+cc_library(
+    name = "switchlink_handle_tunnel",
+    srcs = ["switchlink_handle_tunnel.c"],
+    deps = [
+        ":switchlink_init_sai",
+        "//switchlink:switchlink_handlers",
+    ],
+)
+
+cc_library(
+    name = "switchlink_init_sai",
+    srcs = ["switchlink_init_sai.c"],
+    hdrs = ["switchlink_init_sai.h"],
+    deps = [
+        "//switchlink:switchlink_types",
+        "//switchlink:switchlink_db",
+        "//switchlink:switchlink_utils",
+        "//switchsai:saiinternal",
+    ],
+)

--- a/switchlink/sai/switchlink_handle_lag.c
+++ b/switchlink/sai/switchlink_handle_lag.c
@@ -17,9 +17,10 @@
 
 #include <linux/if.h>
 
-#include "ipu_pal/port_intf.h"
-#include "ipu_types/ipu_types.h"
 #include "switchlink_init_sai.h"
+#include "switchsde/sde_port_intf.h"
+#include "switchsde/sde_status.h"
+#include "switchsde/sde_types.h"
 
 #define SWITCH_PD_MAC_STR_LENGTH 18
 #define SWITCH_PD_TARGET_VPORT_OFFSET 16
@@ -170,9 +171,9 @@ static int create_lag_member(
     switchlink_handle_t* lag_member_h) {
   sai_attribute_t attr_list[5];
   int ac = 0;
-  ipu_status_t ipu_status;
+  sde_status_t sde_status;
   uint32_t port_id = 0;
-  ipu_dev_id_t ipu_dev_id = 0;
+  sde_dev_id_t sde_dev_id = 0;
   static char mac_str[SWITCH_PD_MAC_STR_LENGTH];
 
   snprintf(mac_str, sizeof(mac_str), "%02x:%02x:%02x:%02x:%02x:%02x",
@@ -181,14 +182,14 @@ static int create_lag_member(
            lag_member_intf->perm_hwaddr[4], lag_member_intf->perm_hwaddr[5]);
   mac_str[SWITCH_PD_MAC_STR_LENGTH - 1] = '\0';
 
-  ipu_status = ipu_pal_get_port_id_from_mac(ipu_dev_id, mac_str, &port_id);
-  if (ipu_status != IPU_SUCCESS) {
+  sde_status = sde_pal_get_port_id_from_mac(sde_dev_id, mac_str, &port_id);
+  if (sde_status != SDE_SUCCESS) {
     port_id = lag_member_intf->perm_hwaddr[1] + SWITCH_PD_TARGET_VPORT_OFFSET;
     krnlmon_log_info(
         "Failed to get the port ID, error: %d, Deriving "
         "port ID from second byte of MAC address: "
         "%s",
-        ipu_status, mac_str);
+        sde_status, mac_str);
   }
 
   memset(attr_list, 0, sizeof(attr_list));

--- a/switchlink/switchlink_route.c
+++ b/switchlink/switchlink_route.c
@@ -20,6 +20,7 @@
 #include <netlink/msg.h>
 #include <netlink/netlink.h>
 
+#include "switchlink.h"
 #include "switchlink_globals.h"
 #include "switchlink_handlers.h"
 #include "switchlink_int.h"

--- a/switchsai/BUILD.bazel
+++ b/switchsai/BUILD.bazel
@@ -1,0 +1,18 @@
+# //switchsai/BUILD.bazel
+
+# Copyright 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "saiinternal",
+    srcs = ["saiinternal.h"],
+    deps = [
+        "//switchapi:switch_base_types",
+        "//switchutils:switch_log",
+        "@sai//:sai_hdrs",
+    ],
+)

--- a/switchsai/saiinternal.h
+++ b/switchsai/saiinternal.h
@@ -16,6 +16,9 @@
  * limitations under the License.
  */
 
+#ifndef __SAIINTERNAL_H_
+#define __SAIINTERNAL_H_
+
 #include <arpa/inet.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -27,9 +30,6 @@
 #include "switchapi/switch_base_types.h"
 #include "switchutils/switch_log.h"
 #include "switchutils/switch_utils.h"
-
-#ifndef __SAIINTERNAL_H_
-#define __SAIINTERNAL_H_
 
 #define SAI_MAX_ENTRY_STRING_LEN 200
 

--- a/switchsde/BUILD.bazel
+++ b/switchsde/BUILD.bazel
@@ -1,0 +1,43 @@
+# //switchsde/BUILD.bazel
+
+# Copyright 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+SDE_PORT_INTF_SRCS = select(
+    {
+        "//:dpdk_target": ["sde_legacy_port_intf.c"],
+        "//:es2k_target": ["sde_es2k_port_intf.c"],
+    }
+)
+
+cc_library(
+    name = "sde_port_intf",
+    srcs = SDE_PORT_INTF_SRCS,
+    hdrs = ["sde_port_intf.h"],
+    deps = [
+        ":sde_types",
+        "@local_dpdk_bin//:dpdk_hdrs",
+        "@local_dpdk_bin//:target_sys",
+    ],
+)
+
+cc_library(
+    name = "sde_status",
+    hdrs = ["sde_status.h"],
+)
+
+cc_library(
+    name = "sde_status_o",
+    srcs = ["sde_status.c"],
+    deps = [":sde_status"],
+)
+
+cc_library(
+    name = "sde_types",
+    hdrs = ["sde_types.h"],
+)
+

--- a/switchsde/BUILD.bazel
+++ b/switchsde/BUILD.bazel
@@ -11,7 +11,7 @@ SDE_PORT_INTF_SRCS = select(
     {
         "//:dpdk_target": ["sde_legacy_port_intf.c"],
         "//:es2k_target": ["sde_es2k_port_intf.c"],
-    }
+    },
 )
 
 cc_library(
@@ -40,4 +40,3 @@ cc_library(
     name = "sde_types",
     hdrs = ["sde_types.h"],
 )
-

--- a/switchsde/sde_legacy_port_intf.c
+++ b/switchsde/sde_legacy_port_intf.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bf_pal/bf_pal_port_intf.h"
+#include "sde_port_intf.h"
+
+sde_status_t sde_pal_get_port_id_from_mac(sde_dev_id_t dev_id, char* mac,
+                                          uint32_t* port_id) {
+  return bf_pal_get_port_id_from_mac(dev_id, mac, port_id);
+}
+
+sde_status_t sde_pal_port_info_get(sde_dev_id_t dev_id, sde_dev_port_t dev_port,
+                                   struct port_info_t** port_info) {
+  return bf_pal_port_info_get(dev_id, dev_port, port_info);
+}

--- a/switchsde/sde_port_intf.h
+++ b/switchsde/sde_port_intf.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __SDE_PORT_INTF_H__
+#define __SDE_PORT_INTF_H__
+
+#include <stdint.h>
+
+#include "bf_pal/bf_pal_port_intf.h"
+#include "sde_types.h"
+
+struct port_info_t;
+
+sde_status_t sde_pal_get_port_id_from_mac(sde_dev_id_t dev_id, char* mac,
+                                          uint32_t* port_id);
+
+sde_status_t sde_pal_port_info_get(sde_dev_id_t dev_id, sde_dev_port_t dev_port,
+                                   struct port_info_t** port_info);
+
+#endif  // __SDE_PORT_INTF_H__

--- a/switchsde/sde_status.c
+++ b/switchsde/sde_status.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "sde_status.h"
+
+static const char* sde_err_strings[SDE_STS_MAX + 1] = {
+#define SDE_STATUS_(x, y) y
+    SDE_STATUS_VALUES, "Unknown error"
+#undef SDE_STATUS_
+};
+
+const char* sde_err_str(sde_status_t sts) {
+  if (sts > SDE_STS_MAX || sts < 0) {
+    return sde_err_strings[SDE_STS_MAX];
+  } else {
+    return sde_err_strings[sts];
+  }
+}

--- a/switchsde/sde_status.h
+++ b/switchsde/sde_status.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __SDE_STATUS_H__
+#define __SDE_STATUS_H__
+
+#ifndef SDE_STATUS_DEFINED
+/** Specifies an error status code. */
+typedef int sde_status_t;
+#define SDE_STATUS_DEFINED
+#endif
+
+#define SDE_STATUS_VALUES                                                    \
+  SDE_STATUS_(SDE_SUCCESS, "Success"),                                       \
+      SDE_STATUS_(SDE_NOT_READY, "Not ready"),                               \
+      SDE_STATUS_(SDE_NO_SYS_RESOURCES, "No system resources"),              \
+      SDE_STATUS_(SDE_INVALID_ARG, "Invalid arguments"),                     \
+      SDE_STATUS_(SDE_ALREADY_EXISTS, "Already exists"),                     \
+      SDE_STATUS_(SDE_HW_COMM_FAIL, "HW access fails"),                      \
+      SDE_STATUS_(SDE_OBJECT_NOT_FOUND, "Object not found"),                 \
+      SDE_STATUS_(SDE_MAX_SESSIONS_EXCEEDED, "Max sessions exceeded"),       \
+      SDE_STATUS_(SDE_SESSION_NOT_FOUND, "Session not found"),               \
+      SDE_STATUS_(SDE_NO_SPACE, "Not enough space"),                         \
+      SDE_STATUS_(SDE_EAGAIN,                                                \
+                  "Resource temporarily not available, try again later"),    \
+      SDE_STATUS_(SDE_INIT_ERROR, "Initialization error"),                   \
+      SDE_STATUS_(SDE_TXN_NOT_SUPPORTED, "Not supported in transaction"),    \
+      SDE_STATUS_(SDE_TABLE_LOCKED, "Resource held by another session"),     \
+      SDE_STATUS_(SDE_IO, "IO error"),                                       \
+      SDE_STATUS_(SDE_UNEXPECTED, "Unexpected error"),                       \
+      SDE_STATUS_(SDE_ENTRY_REFERENCES_EXIST,                                \
+                  "Action data entry is being referenced by match entries"), \
+      SDE_STATUS_(SDE_NOT_SUPPORTED, "Operation not supported"),             \
+      SDE_STATUS_(SDE_HW_UPDATE_FAILED, "Updating hardware failed"),         \
+      SDE_STATUS_(SDE_NO_LEARN_CLIENTS, "No learning clients registered"),   \
+      SDE_STATUS_(SDE_IDLE_UPDATE_IN_PROGRESS,                               \
+                  "Idle time update state already in progress"),             \
+      SDE_STATUS_(SDE_DEVICE_LOCKED, "Device locked"),                       \
+      SDE_STATUS_(SDE_INTERNAL_ERROR, "Internal error"),                     \
+      SDE_STATUS_(SDE_TABLE_NOT_FOUND, "Table not found"),                   \
+      SDE_STATUS_(SDE_IN_USE, "In use"),                                     \
+      SDE_STATUS_(SDE_NOT_IMPLEMENTED, "Object not implemented")
+
+/** Defines the status code values. */
+enum sde_status_enum {
+#define SDE_STATUS_(x, y) x
+  SDE_STATUS_VALUES,
+  SDE_STS_MAX
+#undef SDE_STATUS_
+};
+
+/** Returns the error string for a status code. */
+extern const char* sde_err_str(sde_status_t sts);
+
+#endif /* __SDE_STATUS_H__ */

--- a/switchsde/sde_types.h
+++ b/switchsde/sde_types.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __SDE_TYPES_H__
+#define __SDE_TYPES_H__
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/*! Specifies an ASIC in the system. */
+typedef int sde_dev_id_t;
+
+/** Specifies a port on an ASIC. This is a 9-bit value where the upper two
+ *  bits specify the pipeline and the lower 7 bits specify the port number
+ *  local to that pipeline. The valid range for the lower 7 bits is 0-71. */
+typedef int sde_dev_port_t;
+
+#ifndef SDE_STATUS_DEFINED
+/** Specifies an error status code. */
+typedef int sde_status_t;
+#define SDE_STATUS_DEFINED
+#endif
+
+#endif /* __SDE_TYPES_H__ */


### PR DESCRIPTION
Recent changes to the ES2K SDE made it source-incompatible with the legacy interface used by the DPDK and Tofino SDEs. `switchsde` provides an abstract interface that allows krnlmon to communicate transparently with both the legacy SDEs and the ES2K SDE.

The initial implementation is fairly simple. It provides only the features that are needed to support krnlmon; and it takes advantage of the fact that the symbols have simply been renamed, so no data conversions are necessary (yet).