### PR TITLE
Fix broken es2k switchlink_link_test

### DIFF
--- a/switchlink/CMakeLists.txt
+++ b/switchlink/CMakeLists.txt
@@ -29,6 +29,13 @@ add_library(switchlink_o OBJECT
     $<TARGET_OBJECTS:switchlink_sai_o>
 )
 
+if(ES2K_TARGET)
+    target_sources(switchlink_o PRIVATE
+      switchlink_es2k_utils.c
+      switchlink_es2k_utils.h
+    )
+endif()
+
 target_compile_options(switchlink_o PRIVATE -DHAVE_NLA_BITFIELD32)
 
 if(WITH_OVSP4RT)

--- a/switchlink/switchlink_es2k_utils.c
+++ b/switchlink/switchlink_es2k_utils.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache 2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "switchlink_es2k_utils.h"
+
+#include <linux/errno.h>
+#include <linux/ethtool.h>
+#include <linux/if.h>
+#include <linux/sockios.h>
+#include <stdbool.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+/*
+ * Routine Description:
+ *    Check if the interface driver is valid for our use case
+ *
+ * Arguments:
+ *    [in] ifname - Interface name
+ *
+ * Return Values:
+ *    boolean
+ */
+bool switchlink_validate_driver(const char* ifname) {
+  struct ethtool_drvinfo drv = {0};
+  char drvname[32] = {0};
+  struct ifreq ifr = {0};
+  int fd, r = 0;
+
+  fd = socket(AF_INET, SOCK_DGRAM, 0);
+  if (fd < 0) {
+    return false;
+  }
+
+  drv.cmd = ETHTOOL_GDRVINFO;
+  strncpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
+  ifr.ifr_data = (void*)&drv;
+
+  r = ioctl(fd, SIOCETHTOOL, &ifr);
+  if (r) {
+    goto end;
+  }
+
+  strncpy(drvname, drv.driver, sizeof(drvname));
+
+  if (!memcmp(drvname, "openvswitch", strlen(drvname)) ||
+      !memcmp(drvname, "idpf", strlen(drvname))) {
+    close(fd);
+    return true;
+  }
+end:
+  close(fd);
+  return false;
+}

--- a/switchlink/switchlink_es2k_utils.h
+++ b/switchlink/switchlink_es2k_utils.h
@@ -1,6 +1,5 @@
 /*
- * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2024 Intel Corporation.
  * SPDX-License-Identifier: Apache 2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,17 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#ifndef __SWITCHLINK_ES2K_UTILS__
+#define __SWITCHLINK_ES2K_UTILS__
 
-#ifndef __SWITCHLINK_UTILS_H__
-#define __SWITCHLINK_UTILS_H__
-
-#include <netinet/in.h>
 #include <stdbool.h>
-#include <stdint.h>
 
-#include "switchutils/switch_utils.h"
+bool switchlink_validate_driver(const char* ifname);
 
-uint32_t ipv4_prefix_len_to_mask(uint32_t prefix_len);
-struct in6_addr ipv6_prefix_len_to_mask(uint32_t prefix_len);
-
-#endif /* __SWITCHLINK_UTILS_H__ */
+#endif  // __SWITCHLINK_ES2K_UTILS__

--- a/switchlink/switchlink_link.c
+++ b/switchlink/switchlink_link.c
@@ -17,16 +17,12 @@
  */
 
 #include <fcntl.h>
-#include <linux/errno.h>
-#include <linux/ethtool.h>
 #include <linux/if.h>
 #include <linux/if_bridge.h>
-#include <linux/sockios.h>
 #include <linux/version.h>
 #include <netlink/attr.h>
 #include <netlink/msg.h>
 #include <netlink/netlink.h>
-#include <sys/ioctl.h>
 #include <unistd.h>
 
 #include "switchlink.h"
@@ -34,7 +30,11 @@
 #include "switchlink_handlers.h"
 #include "switchlink_int.h"
 #include "switchlink_link_types.h"
-#include "switchlink_utils.h"
+#include "switchutils/switch_log.h"
+
+#ifdef ES2K_TARGET
+#include "switchlink_es2k_utils.h"
+#endif
 
 #if defined(ES2K_TARGET)
 // ES2K creates netdevs from idpf driver/SR-IOVs.
@@ -92,50 +92,6 @@ static switchlink_link_type_t get_link_type(const char* info_kind) {
 
   return link_type;
 }
-
-#if defined(ES2K_TARGET)
-/*
- * Routine Description:
- *    Check if the interface driver is valid for our use case
- *
- * Arguments:
- *    [in] ifname - Interface name
- *
- * Return Values:
- *    boolean
- */
-bool validate_driver_name(char* ifname) {
-  struct ethtool_drvinfo drv = {0};
-  char drvname[32] = {0};
-  struct ifreq ifr = {0};
-  int fd, r = 0;
-
-  fd = socket(AF_INET, SOCK_DGRAM, 0);
-  if (fd < 0) {
-    return false;
-  }
-
-  drv.cmd = ETHTOOL_GDRVINFO;
-  strncpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
-  ifr.ifr_data = (void*)&drv;
-
-  r = ioctl(fd, SIOCETHTOOL, &ifr);
-  if (r) {
-    goto end;
-  }
-
-  strncpy(drvname, drv.driver, sizeof(drvname));
-
-  if (!memcmp(drvname, "openvswitch", strlen(drvname)) ||
-      !memcmp(drvname, "idpf", strlen(drvname))) {
-    close(fd);
-    return true;
-  }
-end:
-  close(fd);
-  return false;
-}
-#endif
 
 /*
  * Routine Description:
@@ -407,7 +363,7 @@ void switchlink_process_link_msg(const struct nlmsghdr* nlmsg, int msgtype) {
         }
 
 #if defined(ES2K_TARGET)
-        if (!validate_driver_name(attrs.ifname)) {
+        if (!switchlink_validate_driver(attrs.ifname)) {
           krnlmon_log_info(
               "Ignoring interface: %s which is not created"
               " by openvswitch or idpf driver",

--- a/switchlink/switchlink_link_test.cc
+++ b/switchlink/switchlink_link_test.cc
@@ -14,6 +14,9 @@ extern "C" {
 #include "switchlink_handlers.h"
 #include "switchlink_int.h"
 #include "switchlink_link_types.h"
+#ifdef ES2K_TARGET
+#include "switchlink_es2k_utils.h"
+#endif
 }
 
 #define IPV4_ADDR(a, b, c, d) (((a) << 24) | ((b) << 16) | ((c) << 8) | (d))
@@ -79,6 +82,9 @@ void switchlink_delete_lag(uint32_t ifindex) {}
 void switchlink_create_lag_member(
     switchlink_db_lag_member_info_t* lag_member_info) {}
 void switchlink_delete_lag_member(uint32_t ifindex) {}
+
+bool switchlink_validate_driver(const char* ifname) { return true; }
+
 #endif
 
 void switchlink_create_interface(switchlink_db_interface_info_t* intf) {


### PR DESCRIPTION
When switchlink was modified for Linux Networking 2.0, a function was added that breaks switchlink_link_test when it is built for ES2K. This CL moves the function to a separate file, allowing the unit test to provide a test dummy.