### PR TITLE
Remove bazel support branches from github workflow

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - bazel-support-*
   pull_request:
     branches:
       - main


### PR DESCRIPTION
The branches were only needed during Bazel development, and are now surplus to requirements.