### PR TITLE
Remove unnecessary #includes

### DIFF
--- a/switchapi/dpdk/switch_pd_fdb.c
+++ b/switchapi/dpdk/switch_pd_fdb.c
@@ -18,8 +18,6 @@
 
 #include "switch_pd_fdb.h"
 
-#include "bf_types/bf_types.h"
-#include "port_mgr/dpdk/bf_dpdk_port_if.h"
 #include "switch_pd_p4_name_mapping.h"
 #include "switch_pd_utils.h"
 #include "switchapi/switch_base_types.h"

--- a/switchapi/dpdk/switch_pd_utils.h
+++ b/switchapi/dpdk/switch_pd_utils.h
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +20,6 @@
 #define __SWITCH_PD_UTILS_H__
 
 #include "bf_pal/bf_pal_port_intf.h"
-#include "bf_rt/bf_rt_common.h"
-#include "bf_types/bf_types.h"
-#include "port_mgr/dpdk/bf_dpdk_port_if.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_handle.h"
 #include "switchapi/switch_rif.h"

--- a/switchapi/dpdk/switch_rif.c
+++ b/switchapi/dpdk/switch_rif.c
@@ -18,8 +18,6 @@
 
 #include <net/if.h>
 
-/* Local header includes */
-#include "bf_types/bf_types.h"
 #include "switch_pd_utils.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_device.h"

--- a/switchapi/dpdk/switch_rif.c
+++ b/switchapi/dpdk/switch_rif.c
@@ -16,8 +16,8 @@
  * limitations under the License.
  */
 
-// We have to disable format checking for this file because of a bug in
-// clang-format that causes it to fail (without explanation) with:
+// We disable format checking for this file because of a bug in clang-format
+// that causes it to fail (without explanation) with:
 //   error: code should be clang-formatted [-Wclang-format-violations]
 // The file was clang-formatted before being pushed.
 

--- a/switchapi/dpdk/switch_rif.c
+++ b/switchapi/dpdk/switch_rif.c
@@ -16,6 +16,13 @@
  * limitations under the License.
  */
 
+// We have to disable format checking for this file because of a bug in
+// clang-format that causes it to fail (without explanation) with:
+//   error: code should be clang-formatted [-Wclang-format-violations]
+// The file was clang-formatted before being pushed.
+
+// clang-format off
+
 #include <net/if.h>
 
 #include "switch_pd_utils.h"

--- a/switchapi/es2k/switch_lag.c
+++ b/switchapi/es2k/switch_lag.c
@@ -1,5 +1,6 @@
 /*
- * Copyright 2023 Intel Corporation.
+ * Copyright 2023-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +17,6 @@
 
 #include "switchapi/switch_lag.h"
 
-#include "ipu_types/ipu_types.h"
 #include "switch_pd_utils.h"
 #include "switchapi/es2k/switch_pd_lag.h"
 #include "switchapi/switch_base_types.h"

--- a/switchapi/es2k/switch_pd_fdb.c
+++ b/switchapi/es2k/switch_pd_fdb.c
@@ -18,7 +18,6 @@
 
 #include "switch_pd_fdb.h"
 
-#include "ipu_types/ipu_types.h"
 #include "switch_pd_p4_name_mapping.h"
 #include "switch_pd_utils.h"
 #include "switchapi/switch_base_types.h"

--- a/switchapi/es2k/switch_pd_utils.c
+++ b/switchapi/es2k/switch_pd_utils.c
@@ -20,6 +20,7 @@
 
 #include <net/if.h>
 
+#include "ipu_pal/port_intf.h"
 #include "ipu_types/ipu_types.h"
 #include "switch_pd_p4_name_mapping.h"
 #include "switchapi/switch_base_types.h"

--- a/switchapi/es2k/switch_pd_utils.h
+++ b/switchapi/es2k/switch_pd_utils.h
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +19,6 @@
 #ifndef __SWITCH_PD_UTILS_H__
 #define __SWITCH_PD_UTILS_H__
 
-#include "ipu_pal/port_intf.h"
 #include "ipu_types/ipu_types.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_handle.h"

--- a/switchapi/es2k/switch_rif.c
+++ b/switchapi/es2k/switch_rif.c
@@ -16,6 +16,13 @@
  * limitations under the License.
  */
 
+// We disable format checking for this file because of a bug in clang-format
+// that causes it to fail (without explanation) with:
+//   error: code should be clang-formatted [-Wclang-format-violations]
+// The file was clang-formatted before being pushed.
+
+// clang-format off
+
 #include <net/if.h>
 
 #include "switch_pd_utils.h"

--- a/switchapi/es2k/switch_rif.c
+++ b/switchapi/es2k/switch_rif.c
@@ -18,8 +18,6 @@
 
 #include <net/if.h>
 
-/* Local header includes */
-#include "ipu_types/ipu_types.h"
 #include "switch_pd_utils.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_device.h"


### PR DESCRIPTION
- Removed unnecessary #includes for SDE-specific header files.
- Disabled clang-format checking to work around a bug in clang-format.