### PR TITLE
Move tdi #includes to a dedicated header file

### DIFF
--- a/switchapi/BUILD.bazel
+++ b/switchapi/BUILD.bazel
@@ -261,6 +261,11 @@ target_cc_library(
 )
 
 target_cc_library(
+    name = "switch_tdi",
+    hdrs = ["switch_tdi.h"],
+)
+
+target_cc_library(
     name = "switch_tunnel",
     hdrs = ["switch_tunnel.h"],
     deps = [

--- a/switchapi/dpdk/BUILD.bazel
+++ b/switchapi/dpdk/BUILD.bazel
@@ -156,6 +156,7 @@ target_cc_library(
         "//switchapi:switch_nhop",
         "//switchapi:switch_nhop_int",
         "//switchapi:switch_rmac_int",
+        "//switchapi:switch_tdi",
         "@local_dpdk_bin//:sde_hdrs",
     ],
 )
@@ -169,6 +170,7 @@ target_cc_library(
         ":switch_pd_utils",
         "//switchapi:switch_base_types",
         "//switchapi:switch_handle",
+        "//switchapi:switch_tdi",
         "//switchapi:switch_tunnel",
     ],
 )
@@ -184,6 +186,7 @@ target_cc_library(
         "//switchapi:switch_internal",
         "//switchapi:switch_rif",
         "//switchapi:switch_table",
+        "//switchapi:switch_tdi",
         "@local_dpdk_bin//:sde_hdrs",
         "@local_dpdk_bin//:tdi",
         "@target_sys",

--- a/switchapi/dpdk/switch_pd_fdb.c
+++ b/switchapi/dpdk/switch_pd_fdb.c
@@ -24,6 +24,7 @@
 #include "switchapi/switch_fdb.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_rif_int.h"
+#include "switchapi/switch_tdi.h"
 #include "switchutils/switch_log.h"
 
 switch_status_t switch_pd_l2_tx_forward_table_entry(

--- a/switchapi/dpdk/switch_pd_routing.c
+++ b/switchapi/dpdk/switch_pd_routing.c
@@ -24,6 +24,7 @@
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_nhop_int.h"
+#include "switchapi/switch_tdi.h"
 #include "switchutils/switch_log.h"
 
 switch_status_t switch_routing_table_entry(

--- a/switchapi/dpdk/switch_pd_tunnel.c
+++ b/switchapi/dpdk/switch_pd_tunnel.c
@@ -21,6 +21,7 @@
 #include "switch_pd_p4_name_mapping.h"
 #include "switch_pd_utils.h"
 #include "switchapi/switch_internal.h"
+#include "switchapi/switch_tdi.h"
 #include "switchapi/switch_tunnel.h"
 #include "switchutils/switch_log.h"
 

--- a/switchapi/dpdk/switch_pd_utils.c
+++ b/switchapi/dpdk/switch_pd_utils.c
@@ -25,6 +25,7 @@
 #include "port_mgr/dpdk/bf_dpdk_port_if.h"
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_internal.h"
+#include "switchapi/switch_tdi.h"
 #include "switchutils/switch_log.h"
 
 void switch_pd_to_get_port_id(switch_api_rif_info_t* port_rif_info) {

--- a/switchapi/dpdk/switch_pd_utils.h
+++ b/switchapi/dpdk/switch_pd_utils.h
@@ -23,17 +23,7 @@
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_handle.h"
 #include "switchapi/switch_rif.h"
-
-// clang-format off
-// tdi_info.h does not include the header files it depends on,
-// so we force tdi_defs.h to precede it.
 #include "tdi/common/tdi_defs.h"
-#include "tdi/common/c_frontend/tdi_info.h"
-#include "tdi/common/c_frontend/tdi_init.h"
-#include "tdi/common/c_frontend/tdi_session.h"
-#include "tdi/common/c_frontend/tdi_table.h"
-#include "tdi/common/c_frontend/tdi_table_info.h"
-// clang-format on
 
 #ifdef __cplusplus
 extern "C" {

--- a/switchapi/es2k/BUILD.bazel
+++ b/switchapi/es2k/BUILD.bazel
@@ -208,6 +208,7 @@ target_cc_library(
         "//switchapi:switch_rif",
         "//switchapi:switch_rmac_int",
         "//switchapi:switch_table",
+        "//switchapi:switch_tdi",
         "@local_es2k_bin//:sde_hdrs",
         "@local_es2k_bin//:tdi",
         "@target_sys",

--- a/switchapi/es2k/switch_pd_fdb.c
+++ b/switchapi/es2k/switch_pd_fdb.c
@@ -24,6 +24,7 @@
 #include "switchapi/switch_fdb.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_rif_int.h"
+#include "switchapi/switch_tdi.h"
 #include "switchutils/switch_log.h"
 
 switch_status_t switch_pd_l2_tx_forward_table_entry(

--- a/switchapi/es2k/switch_pd_lag.c
+++ b/switchapi/es2k/switch_pd_lag.c
@@ -1,5 +1,6 @@
 /*
- * Copyright 2023 Intel Corporation.
+ * Copyright 2023-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +21,7 @@
 #include "switch_pd_utils.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_lag.h"
+#include "switchapi/switch_tdi.h"
 
 /**
  * Routine Description:

--- a/switchapi/es2k/switch_pd_routing.c
+++ b/switchapi/es2k/switch_pd_routing.c
@@ -23,6 +23,7 @@
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_nhop_int.h"
+#include "switchapi/switch_tdi.h"
 #include "switchutils/switch_log.h"
 
 // Table match type definitions.

--- a/switchapi/es2k/switch_pd_tunnel.c
+++ b/switchapi/es2k/switch_pd_tunnel.c
@@ -21,6 +21,7 @@
 #include "switch_pd_p4_name_mapping.h"
 #include "switch_pd_utils.h"
 #include "switchapi/switch_internal.h"
+#include "switchapi/switch_tdi.h"
 #include "switchapi/switch_tunnel.h"
 #include "switchutils/switch_log.h"
 

--- a/switchapi/es2k/switch_pd_utils.c
+++ b/switchapi/es2k/switch_pd_utils.c
@@ -26,6 +26,7 @@
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_rmac_int.h"
+#include "switchapi/switch_tdi.h"
 #include "switchutils/switch_log.h"
 
 switch_status_t switch_pd_get_physical_port_id(switch_device_t device,

--- a/switchapi/es2k/switch_pd_utils.h
+++ b/switchapi/es2k/switch_pd_utils.h
@@ -23,17 +23,7 @@
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_handle.h"
 #include "switchapi/switch_rif.h"
-
-// clang-format off
-// tdi_info.h does not include the header files it depends on,
-// so we force tdi_defs.h to precede it.
 #include "tdi/common/tdi_defs.h"
-#include "tdi/common/c_frontend/tdi_info.h"
-#include "tdi/common/c_frontend/tdi_init.h"
-#include "tdi/common/c_frontend/tdi_session.h"
-#include "tdi/common/c_frontend/tdi_table.h"
-#include "tdi/common/c_frontend/tdi_table_info.h"
-// clang-format on
 
 #ifdef __cplusplus
 extern "C" {
@@ -93,7 +83,7 @@ tdi_status_t tdi_deallocate_table_key(tdi_table_key_hdl* key_hdl);
 tdi_status_t tdi_deallocate_session(tdi_session_hdl* session);
 
 #ifdef __cplusplus
-}
+}  // extern "C"
 #endif
 
-#endif
+#endif  // __SWITCH_PD_UTILS_H__

--- a/switchapi/switch_tdi.h
+++ b/switchapi/switch_tdi.h
@@ -18,8 +18,9 @@
 #ifndef __SWITCH_TDI_H__
 #define __SWITCH_TDI_H__
 
-// tdi_info.h does not include the header files it depends on,
-// so we force tdi_defs.h to precede it.
+// Disable clang-format so it doesn't alphabetize the #includes.
+// tdi_defs.h must precede the other header files because one or
+// more of them depend on tdi_defs.h but don't include it.
 // clang-format off
 #include "tdi/common/tdi_defs.h"
 #include "tdi/common/c_frontend/tdi_info.h"

--- a/switchapi/switch_tdi.h
+++ b/switchapi/switch_tdi.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __SWITCH_TDI_H__
+#define __SWITCH_TDI_H__
+
+// tdi_info.h does not include the header files it depends on,
+// so we force tdi_defs.h to precede it.
+// clang-format off
+#include "tdi/common/tdi_defs.h"
+#include "tdi/common/c_frontend/tdi_info.h"
+#include "tdi/common/c_frontend/tdi_init.h"
+#include "tdi/common/c_frontend/tdi_session.h"
+#include "tdi/common/c_frontend/tdi_table.h"
+#include "tdi/common/c_frontend/tdi_table_info.h"
+// clang-format on
+
+#endif  // __SWITCH_TDI_H__


### PR DESCRIPTION
- Moved the #includes for the TDI header files from the target-specific `switch_pd_utils.h` header files to a target-neutral `switchapi/switch_tdi.h` file, and included it explicitly in the .c files that need to use the TDI interface.

  Source files that only require `tdi_defs.h` (for `tdi_status_t`) include that file directly.