### PR TITLE
Fix bug in krnlmon-test target

### DIFF
--- a/cmake/testing.cmake
+++ b/cmake/testing.cmake
@@ -63,9 +63,9 @@ endif()
 add_custom_target(krnlmon-test
   COMMAND
     ctest ${test_options}
+    --output-on-failure
   DEPENDS
     ${test_targets}
-    --output-on-failure
   WORKING_DIRECTORY
     ${CMAKE_BINARY_DIR}
 )


### PR DESCRIPTION
- Moved the `--output-on-failure` flag to the COMMAND clause.

----

The error occurs in a local build with cmake 3.16.3.

```text
dfoster@dgfoster-mobl1:~/work/latest/krnlmon/krnlmon$ cmake --build build --target krnlmon-test
-- Standalone krnlmon build
-- WITH_OVSP4RT="ON"
Building ES2K_TARGET
-- Found Abseil version 20220623
-- Configuring done
-- Generating done
-- Build files have been written to: /home/dfoster/work/latest/krnlmon/krnlmon/build
[ 11%] Built target switchsde_es2k_test
[ 35%] Built target switchlink_neighbor_test
[ 52%] Built target switchlink_route_test
[ 76%] Built target switchlink_address_test
[100%] Built target switchlink_link_test
make[3]: *** No rule to make target '../--output-on-failure', needed by 'CMakeFiles/krnlmon-test'.  Stop.
make[2]: *** [CMakeFiles/Makefile2:1124: CMakeFiles/krnlmon-test.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:1131: CMakeFiles/krnlmon-test.dir/rule] Error 2
make: *** [Makefile:578: krnlmon-test] Error 2
```

The CI check succeeds. I'm guessing that version of cmake on the GitHub runner is more tolerant about argument placement than my local version.