### PR TITLE
Implement LAG_OPTION conditional

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -32,6 +32,11 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "krnlmon_options",
+    srcs = ["krnlmon_options.h"],
+)
+
 cc_binary(
     name = "dummy_krnlmon",
     srcs = [

--- a/switchapi/es2k/lnw_v2/switch_pd_lag.c
+++ b/switchapi/es2k/lnw_v2/switch_pd_lag.c
@@ -17,15 +17,16 @@
 
 #include "switch_pd_lag.h"
 
-#include "switch_pd_p4_name_mapping.h"
-#include "switch_pd_utils.h"
+#include "switchapi/es2k/switch_pd_p4_name_mapping.h"
+#include "switchapi/es2k/switch_pd_utils.h"
 #include "switchapi/switch_internal.h"
 #include "switchapi/switch_lag.h"
 #include "switchapi/switch_tdi.h"
+#include "switchutils/switch_log.h"
 
 /**
  * Routine Description:
- *   @brief Program tx_lag_table in MEV-TS
+ *   @brief Program tx_lag_table in ES2K
  *
  * Arguments:
  *   @param[in] device - device

--- a/switchlink/BUILD.bazel
+++ b/switchlink/BUILD.bazel
@@ -75,6 +75,7 @@ target_cc_library(
     deps = [
         ":switchlink_db",
         ":switchlink_types",
+        "//:krnlmon_options",
         "@nl-3",
     ],
 )
@@ -94,6 +95,7 @@ target_cc_library(
         ":switchlink_int",
         ":switchlink_link_types",
         ":switchlink_types",
+        "//:krnlmon_options",
         "//switchutils:switch_log",
     ],
 )
@@ -106,6 +108,7 @@ cc_test(
         ":switchlink_globals",
         ":switchlink_handlers",
         ":switchlink_link",
+        "//:krnlmon_options",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/switchlink/sai/BUILD.bazel
+++ b/switchlink/sai/BUILD.bazel
@@ -90,6 +90,7 @@ target_cc_library(
     srcs = ["switchlink_init_sai.c"],
     hdrs = ["switchlink_init_sai.h"],
     deps = [
+        "//:krnlmon_options",
         "//switchlink:switchlink_db",
         "//switchlink:switchlink_types",
         "//switchlink:switchlink_utils",

--- a/switchlink/sai/switchlink_init_sai.c
+++ b/switchlink/sai/switchlink_init_sai.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +18,7 @@
 
 #include "switchlink_init_sai.h"
 
+#include "krnlmon_options.h"
 #include "sai.h"
 
 extern sai_status_t sai_initialize(void);
@@ -54,7 +56,7 @@ void switchlink_init_api(void) {
   krnlmon_assert(status == SAI_STATUS_SUCCESS);
   status = sai_init_nhop_group_api();
   krnlmon_assert(status == SAI_STATUS_SUCCESS);
-#ifdef ES2K_TARGET
+#ifdef LAG_OPTION
   status = sai_init_lag_api();
   krnlmon_assert(status == SAI_STATUS_SUCCESS);
 #endif

--- a/switchlink/sai/switchlink_init_sai.h
+++ b/switchlink/sai/switchlink_init_sai.h
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +22,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "krnlmon_options.h"
 #include "sai.h"
 #include "switchlink/switchlink.h"
 #include "switchlink/switchlink_db.h"
@@ -37,7 +39,7 @@ sai_status_t sai_init_neigh_api();
 sai_status_t sai_init_route_api();
 sai_status_t sai_init_nhop_api();
 sai_status_t sai_init_nhop_group_api();
-#ifdef ES2K_TARGET
+#ifdef LAG_OPTION
 sai_status_t sai_init_lag_api();
 #endif
 
@@ -46,8 +48,8 @@ void switchlink_create_tunnel_interface(
     switchlink_db_tunnel_interface_info_t* tnl_intf);
 void switchlink_delete_tunnel_interface(uint32_t ifindex);
 
+#ifdef LAG_OPTION
 // SWITCHLINK_LINK_TYPE_BOND handlers
-#ifdef ES2K_TARGET
 void switchlink_create_lag(switchlink_db_interface_info_t* lag_intf);
 void switchlink_delete_lag(uint32_t ifindex);
 void switchlink_create_lag_member(

--- a/switchlink/switchlink_handlers.h
+++ b/switchlink/switchlink_handlers.h
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
  * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +22,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "krnlmon_options.h"
 #include "switchlink/switchlink.h"
 #include "switchlink/switchlink_db.h"
 
@@ -31,8 +33,8 @@ extern void switchlink_create_tunnel_interface(
     switchlink_db_tunnel_interface_info_t* tnl_intf);
 extern void switchlink_delete_tunnel_interface(uint32_t ifindex);
 
+#ifdef LAG_OPTION
 // SWITCHLINK_LINK_TYPE_BOND handlers
-#ifdef ES2K_TARGET
 extern void switchlink_create_lag(switchlink_db_interface_info_t* lag_info);
 extern void switchlink_delete_lag(uint32_t ifindex);
 extern void switchlink_create_lag_member(

--- a/switchlink/switchlink_link.c
+++ b/switchlink/switchlink_link.c
@@ -22,6 +22,7 @@
 #include <netlink/msg.h>
 #include <netlink/netlink.h>
 
+#include "krnlmon_options.h"
 #include "switchlink.h"
 #include "switchlink_globals.h"
 #include "switchlink_handlers.h"
@@ -217,7 +218,7 @@ void switchlink_process_link_msg(const struct nlmsghdr* nlmsg, int msgtype) {
   switchlink_db_interface_info_t intf_info = {0};
   switchlink_db_tunnel_interface_info_t tnl_intf_info = {0};
   struct link_attrs attrs = {0};
-#ifdef ES2K_TARGET
+#ifdef LAG_OPTION
   bool create_lag_member = false;
 #endif
 
@@ -272,7 +273,7 @@ void switchlink_process_link_msg(const struct nlmsghdr* nlmsg, int msgtype) {
               break;
             case IFLA_INFO_SLAVE_DATA:
               if (slave_link_type == SWITCHLINK_LINK_TYPE_BOND) {
-#ifdef ES2K_TARGET
+#ifdef LAG_OPTION
                 create_lag_member = true;
 #endif
                 nla_for_each_nested(infoslavedata, linkinfo, attrlen) {
@@ -310,7 +311,7 @@ void switchlink_process_link_msg(const struct nlmsghdr* nlmsg, int msgtype) {
       case SWITCHLINK_LINK_TYPE_TEAM:
         krnlmon_log_info("LAG via teaming driver isn't supported\n");
         break;
-#ifdef ES2K_TARGET
+#ifdef LAG_OPTION
       case SWITCHLINK_LINK_TYPE_BOND:
         snprintf(intf_info.ifname, sizeof(intf_info.ifname), "%s",
                  attrs.ifname);
@@ -380,7 +381,7 @@ void switchlink_process_link_msg(const struct nlmsghdr* nlmsg, int msgtype) {
         break;
     }
     switch (slave_link_type) {
-#ifdef ES2K_TARGET
+#ifdef LAG_OPTION
       case SWITCHLINK_LINK_TYPE_BOND: {
         switchlink_db_lag_member_info_t lag_member_info = {0};
         snprintf(lag_member_info.ifname, sizeof(lag_member_info.ifname), "%s",
@@ -418,7 +419,7 @@ void switchlink_process_link_msg(const struct nlmsghdr* nlmsg, int msgtype) {
     } else {
       krnlmon_log_debug("Unhandled link type");
     }
-#ifdef ES2K_TARGET
+#ifdef LAG_OPTION
     if (link_type == SWITCHLINK_LINK_TYPE_BOND) {
       switchlink_delete_lag(ifmsg->ifi_index);
       return;

--- a/switchlink/switchlink_link_test.cc
+++ b/switchlink/switchlink_link_test.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 
 extern "C" {
+#include "krnlmon_options.h"
 #include "switchlink_globals.h"
 #include "switchlink_handlers.h"
 #include "switchlink_int.h"
@@ -73,15 +74,16 @@ std::vector<test_results> results(2);
 // Test doubles (dummy functions)
 //----------------------------------------------------------------------
 
-#ifdef ES2K_TARGET
+#ifdef LAG_OPTION
 void switchlink_create_lag(switchlink_db_interface_info_t* lag_info) {}
 void switchlink_delete_lag(uint32_t ifindex) {}
 void switchlink_create_lag_member(
     switchlink_db_lag_member_info_t* lag_member_info) {}
 void switchlink_delete_lag_member(uint32_t ifindex) {}
+#endif
 
+#if defined(ES2K_TARGET)
 bool switchlink_validate_driver(const char* ifname) { return true; }
-
 #endif
 
 void switchlink_create_interface(switchlink_db_interface_info_t* intf) {

--- a/switchsai/BUILD.bazel
+++ b/switchsai/BUILD.bazel
@@ -20,6 +20,7 @@ target_cc_library(
     srcs = ["sai.c"],
     deps = [
         ":saiinternal",
+        "//:krnlmon_options",
         "//switchapi:switch_device",
         "//switchapi:switch_handle",
         "//switchapi:switch_nhop",

--- a/switchsai/sai.c
+++ b/switchsai/sai.c
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+#include "krnlmon_options.h"
 #include "saiinternal.h"
 #include "switchapi/switch_device.h"
 #include "switchapi/switch_handle.h"
@@ -441,7 +442,7 @@ sai_status_t sai_initialize(void) {
   sai_virtual_router_initialize(&sai_api_service);
   sai_neighbor_initialize(&sai_api_service);
   sai_tunnel_initialize(&sai_api_service);
-#if defined(ES2K_TARGET)
+#ifdef LAG_OPTION
   sai_lag_initialize(&sai_api_service);
 #endif
 


### PR DESCRIPTION
Conditionalizing code with `DPDK_TARGET` and `ES2K_TARGET` is a convenient way of making target-specific changes, but it harms the maintainability of the codebase.

1. The process does not scale well as we add new targets, or as the P4 programs for the targets continue to diverge.
2. It makes the code harder to understand, because only the original author knows _why_ a particular piece of code was enabled or disabled. It's a form of technical debt, and it hurts our ability to change the code.

The purpose of this CL is to begin replacing `#ifdef xxxx_TARGET` conditionals, where possible, with finer-grained conditionals (such as `LAG_OPTION`), associating each set of changes with the underlying feature or characteristic that was the reason for conditionalizing the code.

The `krnlmon_options.h` file is used to #define the conditionals that are appropriate for each supported target.

This commit reconditionalizes the code associated with LAG support.