### PR TITLE
Create proxy switch_pd_lag.h file

### DIFF
--- a/switchapi/es2k/CMakeLists.txt
+++ b/switchapi/es2k/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(switchapi_o PRIVATE
   switch_neighbor.c
   switch_nhop.c
   switch_pd_fdb.c
+  switch_pd_lag.h
   switch_pd_p4_name_mapping.h
   switch_pd_tunnel.c
   switch_pd_utils.c

--- a/switchapi/es2k/switch_lag.c
+++ b/switchapi/es2k/switch_lag.c
@@ -17,12 +17,8 @@
 
 #include "switchapi/switch_lag.h"
 
+#include "switch_pd_lag.h"
 #include "switch_pd_utils.h"
-#ifdef LNW_V2
-#include "lnw_v2/switch_pd_lag.h"
-#else
-#include "lnw_v3/switch_pd_lag.h"
-#endif
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_device.h"
 #include "switchapi/switch_internal.h"

--- a/switchapi/es2k/switch_pd_lag.h
+++ b/switchapi/es2k/switch_pd_lag.h
@@ -30,6 +30,8 @@
 #include "lnw_v2/switch_pd_lag.h"
 #elif defined(LNW_V3)
 #include "lnw_v3/switch_pd_lag.h"
+#else
+#error "Undefined or missing LNW conditional!"
 #endif
 
 #endif  // __SWITCH_PD_LAG_WRAPPER_H__

--- a/switchapi/es2k/switch_pd_lag.h
+++ b/switchapi/es2k/switch_pd_lag.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Intel Corporation.
+ * SPDX-License_Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Proxy for the version-specific switch_pd_lag.h files.
+//
+// This header file encapsulates the knowledge that there are different
+// versions of the header file.
+//
+// Note that it must use a different include guard than the files it
+// includes.
+
+#ifndef __SWITCH_PD_LAG_WRAPPER_H__
+#define __SWITCH_PD_LAG_WRAPPER_H__
+
+#if defined(LNW_V2)
+#include "lnw_v2/switch_pd_lag.h"
+#elif defined(LNW_V3)
+#include "lnw_v3/switch_pd_lag.h"
+#endif
+
+#endif  // __SWITCH_PD_LAG_WRAPPER_H__


### PR DESCRIPTION
- Created `switchapi/es2k/switch_pd_lag.h` to act as a proxy for the version-specific `switch_pd_lag.h` files. It encapsulates the knowledge that there is more than one version of the header file.