### PR TITLE
Fix broken es2k bazel build

### DIFF
--- a/krnlmon_options.h
+++ b/krnlmon_options.h
@@ -26,7 +26,7 @@
 #define LAG_OPTION 1
 
 #else
-#error "Krnlmon only supports DPDK and ES2K"
+#error "ASSERT: Unknown TARGET type!"
 #endif
 
 #endif  // KRNLMON_OPTIONS_H_

--- a/switchapi/BUILD.bazel
+++ b/switchapi/BUILD.bazel
@@ -10,7 +10,7 @@ load("//bazel:sde.bzl", "TARGET_SDE")
 
 package(default_visibility = ["//visibility:public"])
 
-PD_ROUTING_DEPS = select(
+SWITCH_PD_ROUTING_HDR = select(
     {
         "//flags:dpdk_target": ["//switchapi/dpdk:switch_pd_routing_hdr"],
         "//flags:es2k_target": ["//switchapi/es2k:switch_pd_routing_hdr"],
@@ -196,7 +196,7 @@ krnlmon_cc_library(
 krnlmon_cc_library(
     name = "switch_pd_routing",
     hdrs = ["switch_pd_routing.h"],
-    deps = PD_ROUTING_DEPS,
+    deps = SWITCH_PD_ROUTING_HDR,
 )
 
 krnlmon_cc_library(

--- a/switchapi/es2k/BUILD.bazel
+++ b/switchapi/es2k/BUILD.bazel
@@ -8,6 +8,26 @@ load("//bazel:rules.bzl", "krnlmon_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
+SWITCH_PD_LAG = select({
+    "//flags:lnw_v2": ["//switchapi/es2k/lnw_v2:switch_pd_lag"],
+    "//flags:lnw_v3": ["//switchapi/es2k/lnw_v3:switch_pd_lag"],
+})
+
+SWITCH_PD_LAG_HDR = select({
+    "//flags:lnw_v2": ["//switchapi/es2k/lnw_v2:switch_pd_lag_hdr"],
+    "//flags:lnw_v3": ["//switchapi/es2k/lnw_v3:switch_pd_lag_hdr"],
+})
+
+SWITCH_PD_P4_NAME_ROUTING = select({
+    "//flags:lnw_v2": ["//switchapi/es2k/lnw_v2:switch_pd_p4_name_routing"],
+    "//flags:lnw_v3": ["//switchapi/es2k/lnw_v3:switch_pd_p4_name_routing"],
+})
+
+SWITCH_PD_ROUTING = select({
+    "//flags:lnw_v2": ["//switchapi/es2k/lnw_v2:switch_pd_routing"],
+    "//flags:lnw_v3": ["//switchapi/es2k/lnw_v3:switch_pd_routing"],
+})
+
 krnlmon_cc_library(
     name = "switch_config",
     srcs = ["switch_config.c"],
@@ -55,11 +75,10 @@ krnlmon_cc_library(
         "//switchapi:switch_internal",
         "//switchapi:switch_l3",
         "//switchapi:switch_nhop_int",
-        "//switchapi:switch_pd_routing",
         "//switchapi:switch_rmac_int",
         "//switchapi:switch_table",
         "//switchapi:switch_types_int",
-    ],
+    ] + SWITCH_PD_ROUTING,
 )
 
 krnlmon_cc_library(
@@ -82,19 +101,18 @@ krnlmon_cc_library(
         "//switchapi:switch_internal",
         "//switchapi:switch_l3",
         "//switchapi:switch_nhop_int",
-        "//switchapi:switch_pd_routing",
         "//switchapi:switch_rmac_int",
         "//switchapi:switch_table",
-    ],
+    ] + SWITCH_PD_ROUTING,
 )
 
 krnlmon_cc_library(
     name = "switch_lag",
     srcs = ["switch_lag.c"],
     deps = [
-        ":switch_pd_lag",
+        ":switch_pd_lag_hdr",
         "//switchapi:switch_lag",
-    ],
+    ] + SWITCH_PD_LAG,
 )
 
 krnlmon_cc_library(
@@ -109,10 +127,15 @@ krnlmon_cc_library(
 )
 
 krnlmon_cc_library(
+    name = "switch_pd_lag_hdr",
+    hdrs = ["switch_pd_lag.h"],
+    deps = SWITCH_PD_LAG_HDR,
+)
+
+krnlmon_cc_library(
     name = "switch_nhop",
     srcs = ["switch_nhop.c"],
     deps = [
-        ":switch_pd_routing",
         "//switchapi:switch_device",
         "//switchapi:switch_handle_int",
         "//switchapi:switch_internal",
@@ -121,7 +144,7 @@ krnlmon_cc_library(
         "//switchapi:switch_nhop_int",
         "//switchapi:switch_rif_int",
         "//switchapi:switch_table",
-    ],
+    ] + SWITCH_PD_ROUTING,
 )
 
 krnlmon_cc_library(
@@ -142,21 +165,6 @@ krnlmon_cc_library(
 )
 
 krnlmon_cc_library(
-    name = "switch_pd_lag",
-    srcs = ["switch_pd_lag.c"],
-    hdrs = ["switch_pd_lag.h"],
-    deps = [
-        ":switch_pd_p4_name_mapping",
-        ":switch_pd_utils",
-        "//switchapi:switch_device",
-        "//switchapi:switch_handle",
-        "//switchapi:switch_internal",
-        "//switchapi:switch_lag",
-        "@local_es2k_bin//:sde_hdrs",
-    ],
-)
-
-krnlmon_cc_library(
     name = "switch_pd_p4_name_mapping",
     hdrs = ["switch_pd_p4_name_mapping.h"],
 )
@@ -164,22 +172,7 @@ krnlmon_cc_library(
 krnlmon_cc_library(
     name = "switch_pd_routing_hdr",
     hdrs = ["switch_pd_routing.h"],
-)
-
-krnlmon_cc_library(
-    name = "switch_pd_routing",
-    srcs = ["switch_pd_routing.c"],
-    deps = [
-        ":switch_pd_p4_name_mapping",
-        ":switch_pd_routing_hdr",
-        ":switch_pd_utils",
-        "//switchapi:switch_base_types",
-        "//switchapi:switch_handle",
-        "//switchapi:switch_l3",
-        "//switchapi:switch_nhop",
-        "//switchapi:switch_nhop_int",
-        "//switchapi:switch_rmac_int",
-    ],
+    deps = SWITCH_PD_P4_NAME_ROUTING,
 )
 
 krnlmon_cc_library(
@@ -229,12 +222,11 @@ krnlmon_cc_library(
     name = "switch_rmac",
     srcs = ["switch_rmac.c"],
     deps = [
-        ":switch_pd_routing",
         "//switchapi:switch_device",
         "//switchapi:switch_internal",
         "//switchapi:switch_rmac",
         "//switchapi:switch_table",
-    ],
+    ] + SWITCH_PD_ROUTING,
 )
 
 krnlmon_cc_library(
@@ -297,8 +289,6 @@ cc_library(
         ":switch_neighbor",
         ":switch_nhop",
         ":switch_pd_fdb",
-        ":switch_pd_lag",
-        ":switch_pd_routing",
         ":switch_pd_tunnel",
         ":switch_pd_utils",
         ":switch_rif",
@@ -307,5 +297,5 @@ cc_library(
         ":switch_tunnel",
         ":switch_vrf",
         ":switchapi_utils",
-    ],
+    ] + SWITCH_PD_LAG + SWITCH_PD_ROUTING,
 )

--- a/switchapi/es2k/lnw_v2/BUILD.bazel
+++ b/switchapi/es2k/lnw_v2/BUILD.bazel
@@ -1,0 +1,49 @@
+# //switchapi/es2k/lnw_v2/BUILD.bazel
+
+# Copyright 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+load("//bazel:rules.bzl", "krnlmon_cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+krnlmon_cc_library(
+    name = "switch_pd_lag_hdr",
+    hdrs = ["switch_pd_lag.h"],
+)
+
+krnlmon_cc_library(
+    name = "switch_pd_lag",
+    srcs = ["switch_pd_lag.c"],
+    deps = [
+        ":switch_pd_lag_hdr",
+        "//switchapi:switch_device",
+        "//switchapi:switch_handle",
+        "//switchapi:switch_internal",
+        "//switchapi:switch_lag",
+        "//switchapi/es2k:switch_pd_utils",
+        "//switchapi/es2k:switch_pd_p4_name_mapping",
+        "@local_es2k_bin//:sde_hdrs",
+    ],
+)
+
+krnlmon_cc_library(
+    name = "switch_pd_p4_name_routing",
+    hdrs = ["switch_pd_p4_name_routing.h"],
+)
+
+krnlmon_cc_library(
+    name = "switch_pd_routing",
+    srcs = ["switch_pd_routing.c"],
+    deps = [
+        "//switchapi:switch_base_types",
+        "//switchapi:switch_handle",
+        "//switchapi:switch_l3",
+        "//switchapi:switch_nhop",
+        "//switchapi:switch_nhop_int",
+        "//switchapi:switch_rmac_int",
+        "//switchapi/es2k:switch_pd_p4_name_mapping",
+        "//switchapi/es2k:switch_pd_routing_hdr",
+        "//switchapi/es2k:switch_pd_utils",
+    ],
+)

--- a/switchapi/es2k/lnw_v2/switch_pd_lag.h
+++ b/switchapi/es2k/lnw_v2/switch_pd_lag.h
@@ -1,5 +1,6 @@
 /*
- * Copyright 2023 Intel Corporation.
+ * Copyright 2023-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/switchapi/es2k/lnw_v2/switch_pd_p4_name_routing.h
+++ b/switchapi/es2k/lnw_v2/switch_pd_p4_name_routing.h
@@ -1,7 +1,6 @@
 /*
  * Copyright (c) 2013-2021 Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
- *
+ * Copyright 2022-2024 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,10 +18,6 @@
 
 #ifndef __SWITCH_PD_P4_NAME_ROUTING_MAPPING__
 #define __SWITCH_PD_P4_NAME_ROUTING_MAPPING__
-
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
 
 #define LNW_KEY_MATCH_PRIORITY "$MATCH_PRIORITY"
 /* List of tables and corresponding actions */
@@ -158,9 +153,5 @@ extern "C" {
 
 #define LNW_IPV6_TABLE_ACTION_ECMP_V6_HASH_ACTION \
   "linux_networking_control.ecmp_v6_hash_action"
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* __SWITCH_PD_P4_NAME_ROUTING_MAPPING__ */

--- a/switchapi/es2k/lnw_v3/BUILD.bazel
+++ b/switchapi/es2k/lnw_v3/BUILD.bazel
@@ -1,0 +1,49 @@
+# //switchapi/es2k/lnw_v3/BUILD.bazel
+
+# Copyright 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+load("//bazel:rules.bzl", "krnlmon_cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+krnlmon_cc_library(
+    name = "switch_pd_lag_hdr",
+    hdrs = ["switch_pd_lag.h"],
+)
+
+krnlmon_cc_library(
+    name = "switch_pd_lag",
+    srcs = ["switch_pd_lag.c"],
+    deps = [
+        ":switch_pd_lag_hdr",
+        "//switchapi:switch_device",
+        "//switchapi:switch_handle",
+        "//switchapi:switch_internal",
+        "//switchapi:switch_lag",
+        "//switchapi/es2k:switch_pd_p4_name_mapping",
+        "//switchapi/es2k:switch_pd_utils",
+        "@local_es2k_bin//:sde_hdrs",
+    ],
+)
+
+krnlmon_cc_library(
+    name = "switch_pd_p4_name_routing",
+    hdrs = ["switch_pd_p4_name_routing.h"],
+)
+
+krnlmon_cc_library(
+    name = "switch_pd_routing",
+    srcs = ["switch_pd_routing.c"],
+    deps = [
+        "//switchapi:switch_base_types",
+        "//switchapi:switch_handle",
+        "//switchapi:switch_l3",
+        "//switchapi:switch_nhop",
+        "//switchapi:switch_nhop_int",
+        "//switchapi:switch_rmac_int",
+        "//switchapi/es2k:switch_pd_p4_name_mapping",
+        "//switchapi/es2k:switch_pd_routing_hdr",
+        "//switchapi/es2k:switch_pd_utils",
+    ],
+)

--- a/switchapi/es2k/lnw_v3/switch_pd_lag.c
+++ b/switchapi/es2k/lnw_v3/switch_pd_lag.c
@@ -66,7 +66,6 @@ switch_status_t switch_pd_tx_lag_table_entry(switch_device_t device,
   uint32_t lag_list = 0;
   uint8_t port_count = 0;
 
-  switch_node_t* node = NULL;
   switch_lag_member_info_t* lag_member = NULL;
   switch_handle_t lag_h = SWITCH_API_INVALID_HANDLE;
   switch_handle_t lag_member_h = SWITCH_API_INVALID_HANDLE;
@@ -409,7 +408,6 @@ switch_status_t switch_pd_rx_lag_table_entry(switch_device_t device,
     }
 
     if (entry_add) {
-      uint32_t active_port_id = 0;
       switch_lag_member_info_t* active_lag_member_info = NULL;
       status = switch_lag_member_get(device, lag_info->active_lag_member,
                                      &active_lag_member_info);

--- a/switchapi/es2k/lnw_v3/switch_pd_routing.c
+++ b/switchapi/es2k/lnw_v3/switch_pd_routing.c
@@ -98,7 +98,6 @@ switch_status_t switch_pd_rmac_table_entry(switch_device_t device,
 switch_status_t switch_pd_nexthop_table_entry(
     switch_device_t device, const switch_pd_routing_info_t* api_nexthop_pd_info,
     bool entry_add) {
-  // New function in lnw_v3
   tdi_status_t status;
 
   tdi_id_t field_id = 0;
@@ -120,6 +119,7 @@ switch_status_t switch_pd_nexthop_table_entry(
   uint16_t lag_id = 0;
 
   krnlmon_log_debug("%s", __func__);
+
   status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
   if (status != TDI_SUCCESS) {
     krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
@@ -149,6 +149,7 @@ switch_status_t switch_pd_nexthop_table_entry(
     krnlmon_log_error("Failed to create tdi session, error: %d", status);
     goto dealloc_resources;
   }
+
   status = tdi_table_from_name_get(info_hdl, LNW_NEXTHOP_TABLE, &table_hdl);
   if (status != TDI_SUCCESS || !table_hdl) {
     krnlmon_log_error("Unable to get table handle for: %s, error: %d",
@@ -179,6 +180,7 @@ switch_status_t switch_pd_nexthop_table_entry(
                       LNW_NEXTHOP_TABLE_KEY_NEXTHOP_ID, status);
     goto dealloc_resources;
   }
+
 #if NEXTHOP_TABLE_TERNARY_MATCH
   // When Nexthop table is of type ternary Match
   status = tdi_key_field_set_value_and_mask(
@@ -475,7 +477,6 @@ switch_status_t switch_pd_ecmp_nexthop_table_entry(
   const tdi_table_hdl* table_hdl = NULL;
   const tdi_table_info_hdl* table_info_hdl = NULL;
   uint16_t network_byte_order_rif_id = 0;
-  uint16_t lag_id = 0;
 
   krnlmon_log_debug("%s", __func__);
   status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);

--- a/switchapi/es2k/switch_pd_lag.h
+++ b/switchapi/es2k/switch_pd_lag.h
@@ -27,11 +27,11 @@
 #define __SWITCH_PD_LAG_WRAPPER_H__
 
 #if defined(LNW_V2)
-#include "lnw_v2/switch_pd_lag.h"
+#include "switchapi/es2k/lnw_v2/switch_pd_lag.h"
 #elif defined(LNW_V3)
-#include "lnw_v3/switch_pd_lag.h"
+#include "switchapi/es2k/lnw_v3/switch_pd_lag.h"
 #else
-#error "Undefined or missing LNW conditional!"
+#error "ASSERT: Unknown LNW version!"
 #endif
 
 #endif  // __SWITCH_PD_LAG_WRAPPER_H__

--- a/switchapi/es2k/switch_pd_routing.h
+++ b/switchapi/es2k/switch_pd_routing.h
@@ -20,9 +20,11 @@
 #define __SWITCH_PD_ROUTING_H__
 
 #if defined(LNW_V2)
-#include "lnw_v2/switch_pd_p4_name_routing.h"
+#include "switchapi/es2k/lnw_v2/switch_pd_p4_name_routing.h"
 #elif defined(LNW_V3)
-#include "lnw_v3/switch_pd_p4_name_routing.h"
+#include "switchapi/es2k/lnw_v3/switch_pd_p4_name_routing.h"
+#else
+#error "ASSERT: Unknown LNW version!"
 #endif
 
 #include "switchapi/switch_base_types.h"

--- a/switchapi/switch_pd_routing.h
+++ b/switchapi/switch_pd_routing.h
@@ -27,9 +27,11 @@
 #define __SWITCH_PD_ROUTING_WRAPPER_H__
 
 #if defined(DPDK_TARGET)
-#include "dpdk/switch_pd_routing.h"
+#include "switchapi/dpdk/switch_pd_routing.h"
 #elif defined(ES2K_TARGET)
-#include "es2k/switch_pd_routing.h"
+#include "switchapi/es2k/switch_pd_routing.h"
+#else
+#error "ASSERT: Unknown TARGET type!"
 #endif
 
 #endif  // __SWITCH_PD_ROUTING_WRAPPER_H__


### PR DESCRIPTION
- Revised the codebase and Bazel buildsystem to allow krnlmon to be built for ES2K with support for Linux Networking V2 or V3. A new --//flags:lnw_version command-line flag specifies the version to be enabled.