### PR TITLE
Revert L2 fwd table action name

### DIFF
--- a/switchapi/es2k/switch_pd_p4_name_mapping.h
+++ b/switchapi/es2k/switch_pd_p4_name_mapping.h
@@ -135,7 +135,7 @@
 #define LNW_L2_FWD_TX_TABLE_KEY_BRIDGE_ID "user_meta.pmeta.bridge_id"
 #define LNW_L2_FWD_TX_TABLE_KEY_DST_MAC "dst_mac"
 
-#define LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD "linux_networking_control.l2_fwd_tx"
+#define LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD "linux_networking_control.l2_fwd"
 
 #define LNW_L2_FWD_TX_TABLE_ACTION_L2_FWD_LAG \
   "linux_networking_control.l2_fwd_lag"


### PR DESCRIPTION
Reverting a table action name that was changed for debug purposes during LNWv3 development, since it was never reverted back

See #84 