### PR TITLE
Update ECMP hash table update for keys used

### DIFF
--- a/switchapi/es2k/lnw_v3/switch_pd_p4_name_routing.h
+++ b/switchapi/es2k/lnw_v3/switch_pd_p4_name_routing.h
@@ -93,8 +93,8 @@
 #define LNW_ECMP_HASH_TABLE "linux_networking_control.ecmp_hash_table"
 
 #define LNW_ECMP_HASH_TABLE_KEY_HOST_INFO_TX_EXT_FLEX \
-  "user_meta.cmeta.flex[15:0]"
-#define LNW_ECMP_HASH_TABLE_KEY_META_COMMON_HASH "vmeta.common.hash[2:0]"
+  "flex"
+#define LNW_ECMP_HASH_TABLE_KEY_META_COMMON_HASH "hash"
 #define LNW_ECMP_HASH_TABLE_KEY_ZERO_PADDING "zero_padding"
 
 #define LNW_ECMP_HASH_TABLE_ACTION_SET_NEXTHOP_ID \

--- a/switchapi/es2k/lnw_v3/switch_pd_p4_name_routing.h
+++ b/switchapi/es2k/lnw_v3/switch_pd_p4_name_routing.h
@@ -92,8 +92,7 @@
 /* ECMP_HASH_TABLE */
 #define LNW_ECMP_HASH_TABLE "linux_networking_control.ecmp_hash_table"
 
-#define LNW_ECMP_HASH_TABLE_KEY_HOST_INFO_TX_EXT_FLEX \
-  "flex"
+#define LNW_ECMP_HASH_TABLE_KEY_HOST_INFO_TX_EXT_FLEX "flex"
 #define LNW_ECMP_HASH_TABLE_KEY_META_COMMON_HASH "hash"
 #define LNW_ECMP_HASH_TABLE_KEY_ZERO_PADDING "zero_padding"
 

--- a/switchapi/es2k/lnw_v3/switch_pd_routing.c
+++ b/switchapi/es2k/lnw_v3/switch_pd_routing.c
@@ -1735,6 +1735,7 @@ switch_status_t switch_pd_ecmp_hash_table_entry(
     goto dealloc_resources;
   }
 
+  /* LNWv3 does not have this parameter
   status =
       tdi_key_field_id_get(table_info_hdl, LNW_ECMP_HASH_TABLE_KEY_ZERO_PADDING,
                            &field_id_meta_bit32_zero);
@@ -1743,6 +1744,7 @@ switch_status_t switch_pd_ecmp_hash_table_entry(
                       LNW_ECMP_HASH_TABLE_KEY_ZERO_PADDING, status);
     goto dealloc_resources;
   }
+  */
 
   status = tdi_action_name_to_id(
       table_info_hdl, LNW_ECMP_HASH_TABLE_ACTION_SET_NEXTHOP_ID, &action_id);

--- a/switchapi/es2k/lnw_v3/switch_pd_routing.c
+++ b/switchapi/es2k/lnw_v3/switch_pd_routing.c
@@ -1735,7 +1735,7 @@ switch_status_t switch_pd_ecmp_hash_table_entry(
     goto dealloc_resources;
   }
 
-#if 0 // LNWv3 does not have this parameter
+#if 0  // LNWv3 does not have this parameter
   status =
       tdi_key_field_id_get(table_info_hdl, LNW_ECMP_HASH_TABLE_KEY_ZERO_PADDING,
                            &field_id_meta_bit32_zero);

--- a/switchapi/es2k/lnw_v3/switch_pd_routing.c
+++ b/switchapi/es2k/lnw_v3/switch_pd_routing.c
@@ -1735,7 +1735,7 @@ switch_status_t switch_pd_ecmp_hash_table_entry(
     goto dealloc_resources;
   }
 
-  /* LNWv3 does not have this parameter
+#if 0 // LNWv3 does not have this parameter
   status =
       tdi_key_field_id_get(table_info_hdl, LNW_ECMP_HASH_TABLE_KEY_ZERO_PADDING,
                            &field_id_meta_bit32_zero);
@@ -1744,7 +1744,7 @@ switch_status_t switch_pd_ecmp_hash_table_entry(
                       LNW_ECMP_HASH_TABLE_KEY_ZERO_PADDING, status);
     goto dealloc_resources;
   }
-  */
+#endif
 
   status = tdi_action_name_to_id(
       table_info_hdl, LNW_ECMP_HASH_TABLE_ACTION_SET_NEXTHOP_ID, &action_id);


### PR DESCRIPTION
The P4Compiler has changed the generated key names in p4info.txt for ECMP hash tables (the table types have changed in LNWv3 to WCM table). Due to the change, retrieving this table was resulting in an infrap4d crash.

Generated table keys are shown below:

```
tables {
  preamble {
    id: 49661222
    name: "linux_networking_control.ecmp_hash_table"
    alias: "ecmp_hash_table"
  }
  match_fields {
    id: 1
    name: "flex" ## --> this should be matched in our code
    bitwidth: 16
    match_type: TERNARY
  }
  match_fields {
    id: 2
    name: "hash" ## --> this should be matched in our code
    bitwidth: 3
    match_type: TERNARY
  }
```

Also, in LNWv3, we do not have the zero_padding, so commenting the section out for `ecmp_hash_table`