### PR TITLE
Extract ES2K ECMP_HASH_TABLE definitions

### DIFF
--- a/switchapi/es2k/lnw_v2/CMakeLists.txt
+++ b/switchapi/es2k/lnw_v2/CMakeLists.txt
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache 2.0
 
 target_sources(switchapi_o PRIVATE
+  lnw_ecmp_hash_table.h
   switch_pd_p4_name_routing.h
   switch_pd_routing.c
   switch_pd_lag.c

--- a/switchapi/es2k/lnw_v2/lnw_ecmp_hash_table.h
+++ b/switchapi/es2k/lnw_v2/lnw_ecmp_hash_table.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * ECMP_HASH_TABLE for Linux Networking V2.
+ */
+
+#ifndef __LNW_ECMP_HASH_TABLE_H__
+#define __LNW_ECMP_HASH_TABLE_H__
+
+#define LNW_ECMP_HASH_TABLE "linux_networking_control.ecmp_hash_table"
+
+#define LNW_ECMP_HASH_TABLE_KEY_HOST_INFO_TX_EXT_FLEX \
+  "user_meta.cmeta.flex[15:0]"
+#define LNW_ECMP_HASH_TABLE_KEY_META_COMMON_HASH "vmeta.common.hash[2:0]"
+#define LNW_ECMP_HASH_TABLE_KEY_ZERO_PADDING "zero_padding"
+
+#define LNW_ECMP_HASH_TABLE_ACTION_SET_NEXTHOP_ID \
+  "linux_networking_control.set_nexthop_id"
+
+#define LNW_ECMP_HASH_SIZE 65536
+
+/* Only 3 bits are allocated for hash size per group in LNW.p4
+ * check LNW_ECMP_HASH_TABLE_KEY_META_COMMON_HASH */
+#define LNW_ECMP_PER_GROUP_HASH_SIZE 8
+
+#endif /* __LNW_ECMP_HASH_TABLE_H__ */

--- a/switchapi/es2k/lnw_v2/switch_pd_p4_name_routing.h
+++ b/switchapi/es2k/lnw_v2/switch_pd_p4_name_routing.h
@@ -84,23 +84,6 @@
 #define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_NEIGHBOR_ID "neighbor_id"
 #define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_LAG_ID "lag_group_id"
 
-/* ECMP_HASH_TABLE */
-#define LNW_ECMP_HASH_TABLE "linux_networking_control.ecmp_hash_table"
-
-#define LNW_ECMP_HASH_TABLE_KEY_HOST_INFO_TX_EXT_FLEX \
-  "user_meta.cmeta.flex[15:0]"
-#define LNW_ECMP_HASH_TABLE_KEY_META_COMMON_HASH "vmeta.common.hash[2:0]"
-#define LNW_ECMP_HASH_TABLE_KEY_ZERO_PADDING "zero_padding"
-
-#define LNW_ECMP_HASH_TABLE_ACTION_SET_NEXTHOP_ID \
-  "linux_networking_control.set_nexthop_id"
-
-#define LNW_ECMP_HASH_SIZE 65536
-
-/* Only 3 bits is allocated for hash size per group in LNW.p4
- * check LNW_ECMP_HASH_TABLE_KEY_META_COMMON_HASH */
-#define LNW_ECMP_PER_GROUP_HASH_SIZE 8
-
 /* TX_LAG_TABLE */
 #define LNW_TX_LAG_TABLE "linux_networking_control.tx_lag_table"
 

--- a/switchapi/es2k/lnw_v2/switch_pd_routing.c
+++ b/switchapi/es2k/lnw_v2/switch_pd_routing.c
@@ -18,6 +18,7 @@
 
 #include "switchapi/es2k/switch_pd_routing.h"
 
+#include "switchapi/es2k/lnw_v2/lnw_ecmp_hash_table.h"
 #include "switchapi/es2k/switch_pd_p4_name_mapping.h"
 #include "switchapi/es2k/switch_pd_utils.h"
 #include "switchapi/switch_base_types.h"

--- a/switchapi/es2k/lnw_v3/CMakeLists.txt
+++ b/switchapi/es2k/lnw_v3/CMakeLists.txt
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache 2.0
 
 target_sources(switchapi_o PRIVATE
+  lnw_ecmp_hash_table.h
   switch_pd_p4_name_routing.h
   switch_pd_routing.c
   switch_pd_lag.c

--- a/switchapi/es2k/lnw_v3/lnw_ecmp_hash_table.h
+++ b/switchapi/es2k/lnw_v3/lnw_ecmp_hash_table.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * ECMP_HASH_TABLE for Linux Networking V3.
+ */
+
+#ifndef __LNW_ECMP_HASH_TABLE_H__
+#define __LNW_ECMP_HASH_TABLE_H__
+
+#define LNW_ECMP_HASH_TABLE "linux_networking_control.ecmp_hash_table"
+
+#define LNW_ECMP_HASH_TABLE_KEY_HOST_INFO_TX_EXT_FLEX "flex"
+#define LNW_ECMP_HASH_TABLE_KEY_META_COMMON_HASH "hash"
+#define LNW_ECMP_HASH_TABLE_KEY_ZERO_PADDING "zero_padding"
+
+#define LNW_ECMP_HASH_TABLE_ACTION_SET_NEXTHOP_ID \
+  "linux_networking_control.set_nexthop_id"
+
+#define LNW_ECMP_HASH_SIZE 65536
+
+/* Only 3 bits are allocated for hash size per group in LNW.p4
+ * check LNW_ECMP_HASH_TABLE_KEY_META_COMMON_HASH */
+#define LNW_ECMP_PER_GROUP_HASH_SIZE 8
+
+#endif /* __LNW_ECMP_HASH_TABLE_H__ */

--- a/switchapi/es2k/lnw_v3/switch_pd_p4_name_routing.h
+++ b/switchapi/es2k/lnw_v3/switch_pd_p4_name_routing.h
@@ -89,22 +89,6 @@
 #define LNW_ACTION_SET_ECMP_NEXTHOP_PARAM_DMAC_LOW "dmac_low"
 #define LNW_ACTION_SET_ECMP_NEXTHOP_PARAM_EGRESS_PORT "egress_port"
 
-/* ECMP_HASH_TABLE */
-#define LNW_ECMP_HASH_TABLE "linux_networking_control.ecmp_hash_table"
-
-#define LNW_ECMP_HASH_TABLE_KEY_HOST_INFO_TX_EXT_FLEX "flex"
-#define LNW_ECMP_HASH_TABLE_KEY_META_COMMON_HASH "hash"
-#define LNW_ECMP_HASH_TABLE_KEY_ZERO_PADDING "zero_padding"
-
-#define LNW_ECMP_HASH_TABLE_ACTION_SET_NEXTHOP_ID \
-  "linux_networking_control.set_nexthop_id"
-
-#define LNW_ECMP_HASH_SIZE 65536
-
-/* Only 3 bits is allocated for hash size per group in LNW.p4
- * check LNW_ECMP_HASH_TABLE_KEY_META_COMMON_HASH */
-#define LNW_ECMP_PER_GROUP_HASH_SIZE 8
-
 /* TX_LAG_TABLE */
 #define LNW_TX_LAG_TABLE "linux_networking_control.tx_lag_table"
 

--- a/switchapi/es2k/lnw_v3/switch_pd_routing.c
+++ b/switchapi/es2k/lnw_v3/switch_pd_routing.c
@@ -18,6 +18,7 @@
 
 #include "switchapi/es2k/switch_pd_routing.h"
 
+#include "switchapi/es2k/lnw_v3/lnw_ecmp_hash_table.h"
 #include "switchapi/es2k/switch_pd_p4_name_mapping.h"
 #include "switchapi/es2k/switch_pd_utils.h"
 #include "switchapi/switch_base_types.h"

--- a/switchapi/es2k/switch_pd_p4_name_mapping.h
+++ b/switchapi/es2k/switch_pd_p4_name_mapping.h
@@ -164,28 +164,6 @@
 #define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_NEIGHBOR_ID "neighbor_id"
 #define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_LAG_ID "lag_group_id"
 
-/* ECMP_HASH_TABLE */
-#define LNW_ECMP_HASH_TABLE "linux_networking_control.ecmp_hash_table"
-
-#if defined(LNW_V2)
-#define LNW_ECMP_HASH_TABLE_KEY_HOST_INFO_TX_EXT_FLEX \
-  "user_meta.cmeta.flex[15:0]"
-#define LNW_ECMP_HASH_TABLE_KEY_META_COMMON_HASH "vmeta.common.hash[2:0]"
-#elif defined(LNW_V3)
-#define LNW_ECMP_HASH_TABLE_KEY_HOST_INFO_TX_EXT_FLEX "flex"
-#define LNW_ECMP_HASH_TABLE_KEY_META_COMMON_HASH "hash"
-#endif
-#define LNW_ECMP_HASH_TABLE_KEY_ZERO_PADDING "zero_padding"
-
-#define LNW_ECMP_HASH_TABLE_ACTION_SET_NEXTHOP_ID \
-  "linux_networking_control.set_nexthop_id"
-
-#define LNW_ECMP_HASH_SIZE 65536
-
-/* Only 3 bits is allocated for hash size per group in LNW.p4
- * check LNW_ECMP_HASH_TABLE_KEY_META_COMMON_HASH */
-#define LNW_ECMP_PER_GROUP_HASH_SIZE 8
-
 /* TX_LAG_TABLE */
 #define LNW_TX_LAG_TABLE "linux_networking_control.tx_lag_table"
 


### PR DESCRIPTION
- Extracted the LNWv2 and LWNv3 ECMP_HASH_TABLE definitions into individual header files.