### PR TITLE
Extract ES2K NEXTHOP_TABLE definitions (2/5)

### DIFF
--- a/switchapi/es2k/lnw_v2/CMakeLists.txt
+++ b/switchapi/es2k/lnw_v2/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 target_sources(switchapi_o PRIVATE
   lnw_ecmp_hash_table.h
+  lnw_nexthop_table.h
   switch_pd_p4_name_routing.h
   switch_pd_routing.c
   switch_pd_lag.c

--- a/switchapi/es2k/lnw_v2/lnw_nexthop_table.h
+++ b/switchapi/es2k/lnw_v2/lnw_nexthop_table.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * NEXT_HOP_TABLE for Linux Networking v2.
+ */
+
+#ifndef __LNW_NEXTHOP_TABLE_H__
+#define __LNW_NEXTHOP_TABLE_H__
+
+#define LNW_NEXTHOP_TABLE "linux_networking_control.nexthop_table"
+
+#define LNW_NEXTHOP_TABLE_KEY_NEXTHOP_ID "user_meta.cmeta.nexthop_id"
+
+#define LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP \
+  "linux_networking_control.set_nexthop"
+#define LNW_ACTION_SET_NEXTHOP_PARAM_RIF "router_interface_id"
+#define LNW_ACTION_SET_NEXTHOP_PARAM_NEIGHBOR_ID "neighbor_id"
+#define LNW_ACTION_SET_NEXTHOP_PARAM_EGRESS_PORT "egress_port"
+
+#define LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP_LAG \
+  "linux_networking_control.set_nexthop_lag"
+#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_RIF "router_interface_id"
+#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_NEIGHBOR_ID "neighbor_id"
+#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_LAG_ID "lag_group_id"
+
+#endif /* __LNW_NEXTHOP_TABLE_H__ */

--- a/switchapi/es2k/lnw_v2/switch_pd_p4_name_routing.h
+++ b/switchapi/es2k/lnw_v2/switch_pd_p4_name_routing.h
@@ -66,24 +66,6 @@
 #define LNW_RX_LAG_TABLE_ACTION_FWD_TO_VSI "linux_networking_control.fwd_to_vsi"
 #define LNW_ACTION_FWD_TO_VSI_PARAM_PORT "port"
 
-/* NEXTHOP_TABLE */
-// Verified for ES2K
-#define LNW_NEXTHOP_TABLE "linux_networking_control.nexthop_table"
-
-#define LNW_NEXTHOP_TABLE_KEY_NEXTHOP_ID "user_meta.cmeta.nexthop_id"
-
-#define LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP \
-  "linux_networking_control.set_nexthop"
-#define LNW_ACTION_SET_NEXTHOP_PARAM_RIF "router_interface_id"
-#define LNW_ACTION_SET_NEXTHOP_PARAM_NEIGHBOR_ID "neighbor_id"
-#define LNW_ACTION_SET_NEXTHOP_PARAM_EGRESS_PORT "egress_port"
-
-#define LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP_LAG \
-  "linux_networking_control.set_nexthop_lag"
-#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_RIF "router_interface_id"
-#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_NEIGHBOR_ID "neighbor_id"
-#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_LAG_ID "lag_group_id"
-
 /* TX_LAG_TABLE */
 #define LNW_TX_LAG_TABLE "linux_networking_control.tx_lag_table"
 

--- a/switchapi/es2k/lnw_v2/switch_pd_routing.c
+++ b/switchapi/es2k/lnw_v2/switch_pd_routing.c
@@ -19,6 +19,7 @@
 #include "switchapi/es2k/switch_pd_routing.h"
 
 #include "switchapi/es2k/lnw_v2/lnw_ecmp_hash_table.h"
+#include "switchapi/es2k/lnw_v2/lnw_nexthop_table.h"
 #include "switchapi/es2k/switch_pd_p4_name_mapping.h"
 #include "switchapi/es2k/switch_pd_utils.h"
 #include "switchapi/switch_base_types.h"

--- a/switchapi/es2k/lnw_v3/CMakeLists.txt
+++ b/switchapi/es2k/lnw_v3/CMakeLists.txt
@@ -5,8 +5,10 @@
 
 target_sources(switchapi_o PRIVATE
   lnw_ecmp_hash_table.h
-  switch_pd_p4_name_routing.h
-  switch_pd_routing.c
+  lnw_ecmp_nexthop_table.h
+  lnw_nexthop_table.h
   switch_pd_lag.c
   switch_pd_lag.h
+  switch_pd_p4_name_routing.h
+  switch_pd_routing.c
 )

--- a/switchapi/es2k/lnw_v3/lnw_ecmp_nexthop_table.h
+++ b/switchapi/es2k/lnw_v3/lnw_ecmp_nexthop_table.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * ECMP_NEXTHOP_TABLE for Linux Networking v3.
+ */
+
+#ifndef __LNW_ECMP_NEXTHOP_TABLE_H__
+#define __LNW_ECMP_NEXTHOP_TABLE_H__
+
+// Verified for ES2K
+#define LNW_ECMP_NEXTHOP_TABLE "linux_networking_control.ecmp_nexthop_table"
+
+#define LNW_ECMP_NEXTHOP_TABLE_KEY_ECMP_NEXTHOP_ID "user_meta.cmeta.nexthop_id"
+
+#define LNW_ECMP_NEXTHOP_TABLE_ACTION_SET_ECMP_NEXTHOP_INFO_DMAC \
+  "linux_networking_control.ecmp_set_nexthop_info_dmac"
+#define LNW_ACTION_SET_ECMP_NEXTHOP_PARAM_RIF "router_interface_id"
+#define LNW_ACTION_SET_ECMP_NEXTHOP_PARAM_DMAC_HIGH "dmac_high"
+#define LNW_ACTION_SET_ECMP_NEXTHOP_PARAM_DMAC_LOW "dmac_low"
+#define LNW_ACTION_SET_ECMP_NEXTHOP_PARAM_EGRESS_PORT "egress_port"
+
+#endif /* __LNW_ECMP_NEXTHOP_TABLE_H__ */

--- a/switchapi/es2k/lnw_v3/lnw_nexthop_table.h
+++ b/switchapi/es2k/lnw_v3/lnw_nexthop_table.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * NEXT_HOP_TABLE for Linux Networking v3.
+ */
+
+#ifndef __LNW_NEXTHOP_TABLE_H__
+#define __LNW_NEXTHOP_TABLE_H__
+
+// Verified for ES2K
+#define LNW_NEXTHOP_TABLE "linux_networking_control.nexthop_table"
+
+#define LNW_NEXTHOP_TABLE_KEY_NEXTHOP_ID "user_meta.cmeta.nexthop_id"
+
+#define LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP_INFO \
+  "linux_networking_control.set_nexthop_info_dmac"
+#define LNW_ACTION_SET_NEXTHOP_PARAM_RIF "router_interface_id"
+#define LNW_ACTION_SET_NEXTHOP_PARAM_EGRESS_PORT "egress_port"
+#define LNW_ACTION_SET_NEXTHOP_PARAM_DMAC_HIGH "dmac_high"
+#define LNW_ACTION_SET_NEXTHOP_PARAM_DMAC_LOW "dmac_low"
+
+#define LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP_LAG \
+  "linux_networking_control.set_nexthop_lag"
+#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_RIF "router_interface_id"
+#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_DMAC_HIGH "dmac_high"
+#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_DMAC_LOW "dmac_low"
+#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_LAG_ID "lag_group_id"
+
+#endif /* __LNW_NEXTHOP_TABLE_H__ */

--- a/switchapi/es2k/lnw_v3/switch_pd_p4_name_routing.h
+++ b/switchapi/es2k/lnw_v3/switch_pd_p4_name_routing.h
@@ -56,39 +56,6 @@
 #define LNW_RX_LAG_TABLE_ACTION_FWD_TO_VSI "linux_networking_control.fwd_to_vsi"
 #define LNW_ACTION_FWD_TO_VSI_PARAM_PORT "port"
 
-/* NEXTHOP_TABLE */
-// Verified for ES2K
-#define LNW_NEXTHOP_TABLE "linux_networking_control.nexthop_table"
-
-#define LNW_NEXTHOP_TABLE_KEY_NEXTHOP_ID "user_meta.cmeta.nexthop_id"
-
-#define LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP_INFO \
-  "linux_networking_control.set_nexthop_info_dmac"
-#define LNW_ACTION_SET_NEXTHOP_PARAM_RIF "router_interface_id"
-#define LNW_ACTION_SET_NEXTHOP_PARAM_EGRESS_PORT "egress_port"
-#define LNW_ACTION_SET_NEXTHOP_PARAM_DMAC_HIGH "dmac_high"
-#define LNW_ACTION_SET_NEXTHOP_PARAM_DMAC_LOW "dmac_low"
-
-#define LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP_LAG \
-  "linux_networking_control.set_nexthop_lag"
-#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_RIF "router_interface_id"
-#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_DMAC_HIGH "dmac_high"
-#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_DMAC_LOW "dmac_low"
-#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_LAG_ID "lag_group_id"
-
-/* ECMP_NEXTHOP_TABLE */
-// Verified for ES2K
-#define LNW_ECMP_NEXTHOP_TABLE "linux_networking_control.ecmp_nexthop_table"
-
-#define LNW_ECMP_NEXTHOP_TABLE_KEY_ECMP_NEXTHOP_ID "user_meta.cmeta.nexthop_id"
-
-#define LNW_ECMP_NEXTHOP_TABLE_ACTION_SET_ECMP_NEXTHOP_INFO_DMAC \
-  "linux_networking_control.ecmp_set_nexthop_info_dmac"
-#define LNW_ACTION_SET_ECMP_NEXTHOP_PARAM_RIF "router_interface_id"
-#define LNW_ACTION_SET_ECMP_NEXTHOP_PARAM_DMAC_HIGH "dmac_high"
-#define LNW_ACTION_SET_ECMP_NEXTHOP_PARAM_DMAC_LOW "dmac_low"
-#define LNW_ACTION_SET_ECMP_NEXTHOP_PARAM_EGRESS_PORT "egress_port"
-
 /* TX_LAG_TABLE */
 #define LNW_TX_LAG_TABLE "linux_networking_control.tx_lag_table"
 

--- a/switchapi/es2k/lnw_v3/switch_pd_routing.c
+++ b/switchapi/es2k/lnw_v3/switch_pd_routing.c
@@ -19,6 +19,8 @@
 #include "switchapi/es2k/switch_pd_routing.h"
 
 #include "switchapi/es2k/lnw_v3/lnw_ecmp_hash_table.h"
+#include "switchapi/es2k/lnw_v3/lnw_ecmp_nexthop_table.h"
+#include "switchapi/es2k/lnw_v3/lnw_nexthop_table.h"
 #include "switchapi/es2k/switch_pd_p4_name_mapping.h"
 #include "switchapi/es2k/switch_pd_utils.h"
 #include "switchapi/switch_base_types.h"

--- a/switchapi/es2k/switch_pd_p4_name_mapping.h
+++ b/switchapi/es2k/switch_pd_p4_name_mapping.h
@@ -146,24 +146,6 @@
 #define LNW_ACTION_SET_TUNNEL_PARAM_TUNNEL_ID "tunnel_id"
 #define LNW_ACTION_SET_TUNNEL_PARAM_DST_ADDR "dst_addr"
 
-/* NEXTHOP_TABLE */
-// Verified for MEV
-#define LNW_NEXTHOP_TABLE "linux_networking_control.nexthop_table"
-
-#define LNW_NEXTHOP_TABLE_KEY_NEXTHOP_ID "user_meta.cmeta.nexthop_id"
-
-#define LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP \
-  "linux_networking_control.set_nexthop"
-#define LNW_ACTION_SET_NEXTHOP_PARAM_RIF "router_interface_id"
-#define LNW_ACTION_SET_NEXTHOP_PARAM_NEIGHBOR_ID "neighbor_id"
-#define LNW_ACTION_SET_NEXTHOP_PARAM_EGRESS_PORT "egress_port"
-
-#define LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP_LAG \
-  "linux_networking_control.set_nexthop_lag"
-#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_RIF "router_interface_id"
-#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_NEIGHBOR_ID "neighbor_id"
-#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_LAG_ID "lag_group_id"
-
 /* TX_LAG_TABLE */
 #define LNW_TX_LAG_TABLE "linux_networking_control.tx_lag_table"
 


### PR DESCRIPTION
- Extracted the LNWv2 and LNWv3 NEXTHOP_TABLE and ECMP_NEXTHOP_TABLE definitions into individual header files.