### PR TITLE
Extract ES2K NEIGHBOR_MOD_TABLE definitions (3/5)

### DIFF
--- a/switchapi/es2k/lnw_v2/CMakeLists.txt
+++ b/switchapi/es2k/lnw_v2/CMakeLists.txt
@@ -5,9 +5,10 @@
 
 target_sources(switchapi_o PRIVATE
   lnw_ecmp_hash_table.h
+  lnw_neighbor_mod_table.h
   lnw_nexthop_table.h
-  switch_pd_p4_name_routing.h
-  switch_pd_routing.c
   switch_pd_lag.c
   switch_pd_lag.h
+  switch_pd_p4_name_routing.h
+  switch_pd_routing.c
 )

--- a/switchapi/es2k/lnw_v2/lnw_neighbor_mod_table.h
+++ b/switchapi/es2k/lnw_v2/lnw_neighbor_mod_table.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * NEIGHBOR_MOD_TABLE for Linux Networking v2.
+ */
+
+#ifndef __LNW_NEIGHBOR_MOD_TABLE_H__
+#define __LNW_NEIGHBOR_MOD_TABLE_H__
+
+#define LNW_NEIGHBOR_MOD_TABLE "linux_networking_control.neighbor_mod_table"
+
+#define LNW_NEIGHBOR_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR \
+  "vmeta.common.mod_blob_ptr"
+
+#define LNW_NEIGHBOR_MOD_TABLE_ACTION_SET_OUTER_MAC \
+  "linux_networking_control.set_outer_mac"
+#define LNW_ACTION_SET_OUTER_MAC_PARAM_DST_MAC_ADDR "dst_mac_addr"
+
+#endif /* __LNW_NEIGHBOR_MOD_TABLE_H__ */

--- a/switchapi/es2k/lnw_v2/switch_pd_p4_name_routing.h
+++ b/switchapi/es2k/lnw_v2/switch_pd_p4_name_routing.h
@@ -47,16 +47,6 @@
 
 #define LNW_ACTION_SET_SRC_MAC_PARAM_SRC_MAC_ADDR "arg"
 
-/* NEIGHBOR_MOD_TABLE */
-#define LNW_NEIGHBOR_MOD_TABLE "linux_networking_control.neighbor_mod_table"
-
-#define LNW_NEIGHBOR_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR \
-  "vmeta.common.mod_blob_ptr"
-
-#define LNW_NEIGHBOR_MOD_TABLE_ACTION_SET_OUTER_MAC \
-  "linux_networking_control.set_outer_mac"
-#define LNW_ACTION_SET_OUTER_MAC_PARAM_DST_MAC_ADDR "dst_mac_addr"
-
 /* RX_LAG_TABLE */
 #define LNW_RX_LAG_TABLE "linux_networking_control.rx_lag_table"
 

--- a/switchapi/es2k/lnw_v2/switch_pd_routing.c
+++ b/switchapi/es2k/lnw_v2/switch_pd_routing.c
@@ -19,6 +19,7 @@
 #include "switchapi/es2k/switch_pd_routing.h"
 
 #include "switchapi/es2k/lnw_v2/lnw_ecmp_hash_table.h"
+#include "switchapi/es2k/lnw_v2/lnw_neighbor_mod_table.h"
 #include "switchapi/es2k/lnw_v2/lnw_nexthop_table.h"
 #include "switchapi/es2k/switch_pd_p4_name_mapping.h"
 #include "switchapi/es2k/switch_pd_utils.h"

--- a/switchapi/es2k/switch_pd_p4_name_mapping.h
+++ b/switchapi/es2k/switch_pd_p4_name_mapping.h
@@ -72,16 +72,6 @@
 
 #define LNW_ACTION_SET_SRC_MAC_PARAM_SRC_MAC_ADDR "arg"
 
-/* NEIGHBOR_MOD_TABLE */
-#define LNW_NEIGHBOR_MOD_TABLE "linux_networking_control.neighbor_mod_table"
-
-#define LNW_NEIGHBOR_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR \
-  "vmeta.common.mod_blob_ptr"
-
-#define LNW_NEIGHBOR_MOD_TABLE_ACTION_SET_OUTER_MAC \
-  "linux_networking_control.set_outer_mac"
-#define LNW_ACTION_SET_OUTER_MAC_PARAM_DST_MAC_ADDR "dst_mac_addr"
-
 /* IPV4_TUNNEL_TERM_TABLE */
 // Verified for MEV
 #define LNW_IPV4_TUNNEL_TERM_TABLE \


### PR DESCRIPTION
- Extracted the LNWv3 NEIGHBOR_MOD_TABLE definitions into a separate header file.