### PR TITLE
Rename local functions for clarity

### DIFF
--- a/switchlink/switchlink_link.c
+++ b/switchlink/switchlink_link.c
@@ -261,8 +261,7 @@ void switchlink_process_link_msg(const struct nlmsghdr* nlmsg, int msgtype) {
                 nla_for_each_nested(infodata, linkinfo, attrlen) {
                   process_info_data_attr(infodata, &attrs);
                 }
-              }
-              if (link_type == SWITCHLINK_LINK_TYPE_BOND) {
+              } else if (link_type == SWITCHLINK_LINK_TYPE_BOND) {
                 nla_for_each_nested(infodata, linkinfo, attrlen) {
                   process_info_lag_data_attr(infodata, &attrs);
                 }


### PR DESCRIPTION
- Renamed functions in `switchlink_main.c` that begin with `nl_`. The `nl_` prefix identifies symbols imported from the Netlink library, and should not be used for any other purpose.
- Changed the conditional on the second of two mutually-exclusive code blocks from `if` to `else if`.