### PR TITLE
Set correct RMAC handle when bridge MAC address is modified

### DIFF
--- a/switchapi/es2k/switch_rif.c
+++ b/switchapi/es2k/switch_rif.c
@@ -16,12 +16,7 @@
  * limitations under the License.
  */
 
-// We disable format checking for this file because of a bug in clang-format
-// that causes it to fail (without explanation) with:
-//   error: code should be clang-formatted [-Wclang-format-violations]
-// The file was clang-formatted before being pushed.
-
-// clang-format off
+#include "switchapi/switch_rif.h"
 
 #include <net/if.h>
 
@@ -29,7 +24,6 @@
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_device.h"
 #include "switchapi/switch_internal.h"
-#include "switchapi/switch_rif.h"
 #include "switchapi/switch_rif_int.h"
 #include "switchapi/switch_status.h"
 #include "switchutils/switch_log.h"

--- a/switchapi/es2k/switch_rif.c
+++ b/switchapi/es2k/switch_rif.c
@@ -104,6 +104,34 @@ switch_status_t switch_api_rif_attribute_get(
   return status;
 }
 
+switch_status_t switch_api_update_rif_rmac_handle(
+    const switch_device_t device, const switch_handle_t rif_handle,
+    const switch_handle_t rmac_handle) {
+  switch_rif_info_t* rif_info = NULL;
+  switch_status_t status = SWITCH_STATUS_SUCCESS;
+
+  if (!SWITCH_RIF_HANDLE(rif_handle)) {
+    status = SWITCH_STATUS_INVALID_PARAMETER;
+    krnlmon_log_error(
+        "rif attribute get: Invalid rif handle on device %d, "
+        "rif handle 0x%lx: "
+        "error: %s\n",
+        device, rif_handle, switch_error_to_string(status));
+    return status;
+  }
+
+  status = switch_rif_get(device, rif_handle, &rif_info);
+  CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
+
+  /* just get all attributes? */
+  rif_info->api_rif_info.rmac_handle = rmac_handle;
+
+  /* Update port_id for RIF for the new RMAC */
+  switch_pd_to_get_port_id(&rif_info->api_rif_info);
+
+  return status;
+}
+
 switch_status_t switch_api_rif_create(switch_device_t device,
                                       switch_api_rif_info_t* api_rif_info,
                                       switch_handle_t* rif_handle) {

--- a/switchapi/switch_rif.h
+++ b/switchapi/switch_rif.h
@@ -57,6 +57,10 @@ switch_status_t switch_api_rif_attribute_get(
     const switch_device_t device, const switch_handle_t rif_handle,
     const switch_uint64_t rif_flags, switch_api_rif_info_t* api_rif_info);
 
+switch_status_t switch_api_update_rif_rmac_handle(
+    const switch_device_t device, const switch_handle_t rif_handle,
+    const switch_handle_t rmac_handle);
+
 switch_status_t switch_api_rif_create(switch_device_t device,
                                       switch_api_rif_info_t* api_rif_info,
                                       switch_handle_t* rif_handle);

--- a/switchapi/switch_rif.h
+++ b/switchapi/switch_rif.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,9 +57,11 @@ switch_status_t switch_api_rif_attribute_get(
     const switch_device_t device, const switch_handle_t rif_handle,
     const switch_uint64_t rif_flags, switch_api_rif_info_t* api_rif_info);
 
+#if defined(ES2K_TARGET)
 switch_status_t switch_api_update_rif_rmac_handle(
     const switch_device_t device, const switch_handle_t rif_handle,
     const switch_handle_t rmac_handle);
+#endif
 
 switch_status_t switch_api_rif_create(switch_device_t device,
                                       switch_api_rif_info_t* api_rif_info,

--- a/switchsai/sairouterinterface.c
+++ b/switchsai/sairouterinterface.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -156,6 +156,7 @@ static sai_status_t sai_create_router_interface(
       return status;
     }
 
+#if defined(ES2K_TARGET)
     status =
         switch_api_update_rif_rmac_handle(switch_id, intf_handle, rmac_handle);
     if (status != SAI_STATUS_SUCCESS) {
@@ -163,6 +164,7 @@ static sai_status_t sai_create_router_interface(
                         sai_status_to_string(status));
       return status;
     }
+#endif
   } else {
     *rif_id = SAI_NULL_OBJECT_ID;
 

--- a/switchsai/sairouterinterface.c
+++ b/switchsai/sairouterinterface.c
@@ -155,6 +155,14 @@ static sai_status_t sai_create_router_interface(
                         sai_status_to_string(status));
       return status;
     }
+
+    status =
+        switch_api_update_rif_rmac_handle(switch_id, intf_handle, rmac_handle);
+    if (status != SAI_STATUS_SUCCESS) {
+      krnlmon_log_error("Failed to update RMAC handle, error: %s",
+                        sai_status_to_string(status));
+      return status;
+    }
   } else {
     *rif_id = SAI_NULL_OBJECT_ID;
 


### PR DESCRIPTION
1. When an OvS bridge is created, it is assigned MAC address A.
2. When an IDPF interface is added to the OvS bridge, the MAC address is changed from A to B.
3. MAC address B is the same as the IDPF MAC address.
4. P4CP should use this new B MAC address to derive port_id, which will eventually be used when underlay ARP & nexthop are programmed to fetch physical_port_id.
5. Currently, krnlmon handles the MAC change, but it doesn't populate port_id for the new MAC B.
6. This PR fixes the problem.