### PR TITLE
Fix DPDK build issue in PR

### DIFF
--- a/switchapi/es2k/switch_rif.c
+++ b/switchapi/es2k/switch_rif.c
@@ -16,12 +16,7 @@
  * limitations under the License.
  */
 
-// We disable format checking for this file because of a bug in clang-format
-// that causes it to fail (without explanation) with:
-//   error: code should be clang-formatted [-Wclang-format-violations]
-// The file was clang-formatted before being pushed.
-
-// clang-format off
+#include "switchapi/switch_rif.h"
 
 #include <net/if.h>
 
@@ -29,7 +24,6 @@
 #include "switchapi/switch_base_types.h"
 #include "switchapi/switch_device.h"
 #include "switchapi/switch_internal.h"
-#include "switchapi/switch_rif.h"
 #include "switchapi/switch_rif_int.h"
 #include "switchapi/switch_status.h"
 #include "switchutils/switch_log.h"

--- a/switchapi/switch_rif.h
+++ b/switchapi/switch_rif.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,9 +57,11 @@ switch_status_t switch_api_rif_attribute_get(
     const switch_device_t device, const switch_handle_t rif_handle,
     const switch_uint64_t rif_flags, switch_api_rif_info_t* api_rif_info);
 
+#if defined(ES2K_TARGET)
 switch_status_t switch_api_update_rif_rmac_handle(
     const switch_device_t device, const switch_handle_t rif_handle,
     const switch_handle_t rmac_handle);
+#endif
 
 switch_status_t switch_api_rif_create(switch_device_t device,
                                       switch_api_rif_info_t* api_rif_info,

--- a/switchsai/sairouterinterface.c
+++ b/switchsai/sairouterinterface.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-present Barefoot Networks, Inc.
- * Copyright 2022-2023 Intel Corporation.
+ * Copyright 2022-2024 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -156,6 +156,7 @@ static sai_status_t sai_create_router_interface(
       return status;
     }
 
+#if defined(ES2K_TARGET)
     status =
         switch_api_update_rif_rmac_handle(switch_id, intf_handle, rmac_handle);
     if (status != SAI_STATUS_SUCCESS) {
@@ -163,6 +164,7 @@ static sai_status_t sai_create_router_interface(
                         sai_status_to_string(status));
       return status;
     }
+#endif
   } else {
     *rif_id = SAI_NULL_OBJECT_ID;
 


### PR DESCRIPTION
The following DPDK builds were failing:

1. Standalone krnlmon Bazel build
2. Full cmake build

The standalone krnlmon cmake build succeeds, for some unknown reason.

Addressed the issue by conditionalizing the call to `switch_api_update_rif_rmac_handle` in common code.

Updated copyright dates.

Also resolved an old clang-format issue (I hope).