### PR TITLE
Fix issues with LACP and nexthop LAG action

### DIFF
--- a/switchapi/es2k/lnw_v3/switch_pd_lag.c
+++ b/switchapi/es2k/lnw_v3/switch_pd_lag.c
@@ -190,7 +190,7 @@ switch_status_t switch_pd_tx_lag_table_entry(switch_device_t device,
     }
 
     status = tdi_key_field_set_value_and_mask(key_hdl, field_id_hash,
-                                              lag_list + port_count, 0x3);
+                                              lag_list + port_count, 0x7);
     if (status != TDI_SUCCESS) {
       krnlmon_log_error(
           "Unable to set value for key ID: %d for tx_lag_table"
@@ -604,7 +604,8 @@ switch_status_t switch_pd_tx_lacp_lag_table_entry(
       CHECK_RET(status != SWITCH_STATUS_SUCCESS, status);
       status = switch_pd_get_physical_port_id(
           device, lag_member_info->api_lag_member_info.port_id, &egress_port);
-      status = tdi_key_field_set_value(key_hdl, field_id_lag_id, lag_id);
+      status = tdi_key_field_set_value_and_mask(key_hdl, field_id_lag_id,
+                                                lag_id, 0xFF);
       if (status != TDI_SUCCESS) {
         krnlmon_log_error(
             "Unable to set value for key ID: %d for tx_lag_table"
@@ -613,8 +614,8 @@ switch_status_t switch_pd_tx_lacp_lag_table_entry(
         goto dealloc_resources;
       }
 
-      status = tdi_key_field_set_value(key_hdl, field_id_hash,
-                                       lag_list + port_count);
+      status = tdi_key_field_set_value_and_mask(key_hdl, field_id_hash,
+                                                lag_list + port_count, 0x7);
       if (status != TDI_SUCCESS) {
         krnlmon_log_error(
             "Unable to set value for key ID: %d for tx_lag_table"

--- a/switchapi/es2k/lnw_v3/switch_pd_routing.c
+++ b/switchapi/es2k/lnw_v3/switch_pd_routing.c
@@ -33,7 +33,7 @@
 #define MAC_BASE 0
 #define MAC_LOW_BYTES 4
 #define MAC_HIGH_BYTES 2
-#define MAC_HIGH_OFFSET MAC_BASE + MAC_HIGH_BYTES
+#define MAC_LOW_OFFSET MAC_BASE + MAC_HIGH_BYTES
 
 switch_status_t switch_routing_table_entry(
     switch_device_t device, const switch_pd_routing_info_t* api_routing_info,
@@ -290,7 +290,7 @@ switch_status_t switch_pd_nexthop_table_entry(
     status = tdi_data_field_set_value_ptr(
         data_hdl, data_field_id,
         (const uint8_t*)&api_nexthop_pd_info->dst_mac_addr.mac_addr +
-            MAC_HIGH_OFFSET,
+            MAC_LOW_OFFSET,
         MAC_LOW_BYTES);
     if (status != TDI_SUCCESS) {
       krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
@@ -380,8 +380,7 @@ switch_status_t switch_pd_nexthop_table_entry(
 
     status = tdi_data_field_set_value_ptr(
         data_hdl, data_field_id,
-        (const uint8_t*)&api_nexthop_pd_info->dst_mac_addr.mac_addr +
-            MAC_HIGH_OFFSET,
+        (const uint8_t*)&api_nexthop_pd_info->dst_mac_addr.mac_addr + MAC_BASE,
         MAC_HIGH_BYTES);
     if (status != TDI_SUCCESS) {
       krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
@@ -400,7 +399,8 @@ switch_status_t switch_pd_nexthop_table_entry(
 
     status = tdi_data_field_set_value_ptr(
         data_hdl, data_field_id,
-        (const uint8_t*)&api_nexthop_pd_info->dst_mac_addr.mac_addr + MAC_BASE,
+        (const uint8_t*)&api_nexthop_pd_info->dst_mac_addr.mac_addr +
+            MAC_LOW_OFFSET,
         MAC_LOW_BYTES);
     if (status != TDI_SUCCESS) {
       krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
@@ -473,6 +473,12 @@ switch_status_t switch_pd_ecmp_nexthop_table_entry(
   uint16_t network_byte_order_rif_id = 0;
 
   krnlmon_log_debug("%s", __func__);
+
+  if (SWITCH_LAG_HANDLE(api_nexthop_pd_info->rif_handle)) {
+    // ECMP and LAG are mutually exclusive, we don't need to handle LAG case.
+    return SWITCH_STATUS_SUCCESS;
+  }
+
   status = tdi_info_get(dev_id, PROGRAM_NAME, &info_hdl);
   if (status != TDI_SUCCESS) {
     krnlmon_log_error("Failed to get tdi info handle, error: %d", status);
@@ -612,8 +618,7 @@ switch_status_t switch_pd_ecmp_nexthop_table_entry(
     }
     status = tdi_data_field_set_value_ptr(
         data_hdl, data_field_id,
-        (const uint8_t*)&api_nexthop_pd_info->dst_mac_addr.mac_addr +
-            MAC_HIGH_OFFSET,
+        (const uint8_t*)&api_nexthop_pd_info->dst_mac_addr.mac_addr + MAC_BASE,
         MAC_HIGH_BYTES);
     if (status != TDI_SUCCESS) {
       krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
@@ -632,7 +637,8 @@ switch_status_t switch_pd_ecmp_nexthop_table_entry(
 
     status = tdi_data_field_set_value_ptr(
         data_hdl, data_field_id,
-        (const uint8_t*)&api_nexthop_pd_info->dst_mac_addr.mac_addr + MAC_BASE,
+        (const uint8_t*)&api_nexthop_pd_info->dst_mac_addr.mac_addr +
+            MAC_LOW_OFFSET,
         MAC_LOW_BYTES);
     if (status != TDI_SUCCESS) {
       krnlmon_log_error("Unable to set action value for ID: %d, error: %d",

--- a/switchapi/switch_lag.h
+++ b/switchapi/switch_lag.h
@@ -138,6 +138,11 @@ switch_status_t switch_api_lag_attribute_get(
     const switch_device_t device, const switch_handle_t lag_handle,
     switch_api_lag_info_t* api_lag_info);
 
+// Switchapi method to update RMAC handle for a LAG
+switch_status_t switch_api_lag_update_rmac_handle(const switch_device_t device,
+                                                  const switch_handle_t lag_h,
+                                                  const switch_handle_t rmac_h);
+
 // Switchapi method to program LAG tables in HW
 switch_status_t switch_api_program_lag_hw(const switch_device_t device,
                                           switch_handle_t lag_handle,

--- a/switchlink/switchlink_db.c
+++ b/switchlink/switchlink_db.c
@@ -1134,6 +1134,31 @@ switchlink_db_status_t switchlink_db_delete_lag_member(
 
 /**
  * Routine Description:
+ *    Lookup through LAG members and fetch the lag member which points to valid
+ *    LACP lag_h
+ *
+ * Arguments:
+ *    [in] lag_h - LACP LAG handle
+ *
+ * Return Values:
+ *    LAG member ifindex on success
+ *    -1 otherwise
+ */
+uint32_t switchlink_db_delete_lacp_member(switchlink_handle_t lag_h) {
+  tommy_node* node = tommy_list_head(&switchlink_db_lag_member_obj_list);
+  while (node) {
+    switchlink_db_lag_member_obj_t* obj = node->data;
+    krnlmon_assert(obj != NULL);
+    node = node->next;
+    if ((obj->lag_member_info.lag_h == lag_h)) {
+      return obj->lag_member_info.ifindex;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Routine Description:
  *    Updates oper_state of lag member in switchlink database
  *
  * Arguments:

--- a/switchlink/switchlink_db.h
+++ b/switchlink/switchlink_db.h
@@ -266,4 +266,6 @@ extern switchlink_db_status_t switchlink_db_update_lag_member_oper_state(
 extern switchlink_db_status_t switchlink_db_get_lag_member_info(
     switchlink_db_lag_member_info_t* lag_member_info);
 
+extern uint32_t switchlink_db_delete_lacp_member(switchlink_handle_t lag_h);
+
 #endif /* __SWITCHLINK_DB_H__ */

--- a/switchlink/switchlink_link.c
+++ b/switchlink/switchlink_link.c
@@ -415,8 +415,6 @@ void switchlink_process_link_msg(const struct nlmsghdr* nlmsg, int msgtype) {
     if (link_type == SWITCHLINK_LINK_TYPE_TUN ||
         link_type == SWITCHLINK_LINK_TYPE_RIF) {
       switchlink_delete_interface(ifmsg->ifi_index);
-    } else {
-      krnlmon_log_debug("Unhandled link type");
     }
 #ifdef LAG_OPTION
     if (link_type == SWITCHLINK_LINK_TYPE_BOND) {

--- a/switchsai/sailag.c
+++ b/switchsai/sailag.c
@@ -185,6 +185,15 @@ static sai_status_t sai_create_lag(_Out_ sai_object_id_t* lag_id,
                         sai_status_to_string(status));
       return status;
     }
+#if defined(ES2K_TARGET)
+    status = switch_api_lag_update_rmac_handle(switch_id, lag_h, rmac_handle);
+    if (status != SAI_STATUS_SUCCESS) {
+      krnlmon_log_error("Failed to update RMAC handle, error: %s",
+                        sai_status_to_string(status));
+      return status;
+    }
+#endif
+
   } else {
     *lag_id = SAI_NULL_OBJECT_ID;
 


### PR DESCRIPTION
Issues fixed are:

- Populate tx_lag_table, modify exact to ternary match for this table.
- Populate RIF tables
- Populate correct dmac_high and dmac_low fields correctly
- Handle LACP bond interface delete and re-add