### PR TITLE
Update Linux Networking P4 program name 

### DIFF
--- a/switchapi/es2k/switch_pd_utils.h
+++ b/switchapi/es2k/switch_pd_utils.h
@@ -29,7 +29,7 @@
 extern "C" {
 #endif
 
-#define PROGRAM_NAME "fxp-net_linux-networking-v3"
+#define PROGRAM_NAME "fxp-net_linux-networking"
 
 // Currently this value is picked from dpdk_port_config.pb.txt
 #define MAX_NO_OF_PORTS 312


### PR DESCRIPTION
Update LNW name change after P4 program has been updated to remove the `-v3` from name