### PR TITLE
Fix error in standalone cmake build

### DIFF
--- a/cmake/standalone.cmake
+++ b/cmake/standalone.cmake
@@ -114,3 +114,8 @@ include(CompilerSettings)
 set_basic_compiler_options()
 set_legacy_security_options()
 #set_extended_security_options()
+
+#-----------------------------------------------------------------------
+# set_install_rpath()
+#-----------------------------------------------------------------------
+include(SetInstallRpath)


### PR DESCRIPTION
The krnlmon_unit_tests workflow fails with the following message:

  CMake Error at CMakeLists.txt:69 (set_install_rpath):
    Unknown CMake command "set_install_rpath".

This is because set_install_rpath() is defined in the top-level networking-recipe CMakeLists.txt file, which is not executed in standalone build mode.

Addressed the issue by moving the function definition to its own file (SetInstallPath.cmake) and including it from standalone.cmake in the krnlmon build.

This commit is associated with https://github.com/ipdk-io/networking-recipe/pull/541.