### PR TITLE
LNW nexthop changes for LAG scenario

### DIFF
--- a/switchapi/es2k/lnw_v3/lnw_nexthop_table.h
+++ b/switchapi/es2k/lnw_v3/lnw_nexthop_table.h
@@ -22,8 +22,8 @@
 
 #define LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP_LAG \
   "linux_networking_control.set_nexthop_lag"
-//MEVTS1.7 this param removed from set_nexthop_lag action
-//#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_RIF "router_interface_id"
+// MEVTS1.7 this param removed from set_nexthop_lag action
+// #define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_RIF "router_interface_id"
 #define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_DMAC_HIGH "dmac_high"
 #define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_DMAC_LOW "dmac_low"
 #define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_LAG_ID "lag_group_id"

--- a/switchapi/es2k/lnw_v3/lnw_nexthop_table.h
+++ b/switchapi/es2k/lnw_v3/lnw_nexthop_table.h
@@ -22,7 +22,8 @@
 
 #define LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP_LAG \
   "linux_networking_control.set_nexthop_lag"
-#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_RIF "router_interface_id"
+//MEVTS1.7 this param removed from set_nexthop_lag action
+//#define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_RIF "router_interface_id"
 #define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_DMAC_HIGH "dmac_high"
 #define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_DMAC_LOW "dmac_low"
 #define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_LAG_ID "lag_group_id"

--- a/switchapi/es2k/lnw_v3/lnw_nexthop_table.h
+++ b/switchapi/es2k/lnw_v3/lnw_nexthop_table.h
@@ -22,8 +22,6 @@
 
 #define LNW_NEXTHOP_TABLE_ACTION_SET_NEXTHOP_LAG \
   "linux_networking_control.set_nexthop_lag"
-// MEVTS1.7 this param removed from set_nexthop_lag action
-// #define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_RIF "router_interface_id"
 #define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_DMAC_HIGH "dmac_high"
 #define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_DMAC_LOW "dmac_low"
 #define LNW_ACTION_SET_NEXTHOP_LAG_PARAM_LAG_ID "lag_group_id"

--- a/switchapi/es2k/lnw_v3/switch_pd_lag.c
+++ b/switchapi/es2k/lnw_v3/switch_pd_lag.c
@@ -470,6 +470,7 @@ switch_status_t switch_pd_tx_lacp_lag_table_entry(
   tdi_id_t field_id_hash = 0;
   tdi_id_t action_id = 0;
   tdi_id_t data_field_id = 0;
+  tdi_id_t rif_data_field_id = 0;
 
   tdi_dev_id_t dev_id = device;
 
@@ -581,6 +582,15 @@ switch_status_t switch_pd_tx_lacp_lag_table_entry(
   }
 
   status = tdi_data_field_id_with_action_get(
+      table_info_hdl, ACTION_SET_EGRESS_PORT_PARAM_ROUTER_INTF_ID, action_id,
+      &rif_data_field_id);
+  if (status != TDI_SUCCESS) {
+    krnlmon_log_error("Unable to get data field id param for: %s, error: %d",
+                      ACTION_SET_EGRESS_PORT_PARAM_EGRESS_PORT, status);
+    goto dealloc_resources;
+  }
+
+  status = tdi_data_field_id_with_action_get(
       table_info_hdl, ACTION_SET_EGRESS_PORT_PARAM_EGRESS_PORT, action_id,
       &data_field_id);
   if (status != TDI_SUCCESS) {
@@ -625,6 +635,13 @@ switch_status_t switch_pd_tx_lacp_lag_table_entry(
       }
 
       if (entry_add) {
+        status = tdi_data_field_set_value(data_hdl, rif_data_field_id, lag_id);
+        if (status != TDI_SUCCESS) {
+          krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
+                            data_field_id, status);
+          goto dealloc_resources;
+        }
+
         status = tdi_data_field_set_value(data_hdl, data_field_id, egress_port);
         if (status != TDI_SUCCESS) {
           krnlmon_log_error("Unable to set action value for ID: %d, error: %d",

--- a/switchapi/es2k/lnw_v3/switch_pd_routing.c
+++ b/switchapi/es2k/lnw_v3/switch_pd_routing.c
@@ -348,6 +348,10 @@ switch_status_t switch_pd_nexthop_table_entry(
       goto dealloc_resources;
     }
 
+    lag_id = api_nexthop_pd_info->rif_handle &
+             ~(SWITCH_HANDLE_TYPE_LAG << SWITCH_HANDLE_TYPE_SHIFT);
+    // The RIF param is removed from P4 with 1.7
+#if 0
     status = tdi_data_field_id_with_action_get(
         table_info_hdl, LNW_ACTION_SET_NEXTHOP_LAG_PARAM_RIF, action_id,
         &data_field_id);
@@ -359,15 +363,13 @@ switch_status_t switch_pd_nexthop_table_entry(
       goto dealloc_resources;
     }
 
-    lag_id = api_nexthop_pd_info->rif_handle &
-             ~(SWITCH_HANDLE_TYPE_LAG << SWITCH_HANDLE_TYPE_SHIFT);
-
     status = tdi_data_field_set_value(data_hdl, data_field_id, lag_id);
     if (status != TDI_SUCCESS) {
       krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
                         data_field_id, status);
       goto dealloc_resources;
     }
+#endif
 
     status = tdi_data_field_id_with_action_get(
         table_info_hdl, LNW_ACTION_SET_NEXTHOP_LAG_PARAM_DMAC_HIGH, action_id,

--- a/switchapi/es2k/lnw_v3/switch_pd_routing.c
+++ b/switchapi/es2k/lnw_v3/switch_pd_routing.c
@@ -350,26 +350,6 @@ switch_status_t switch_pd_nexthop_table_entry(
 
     lag_id = api_nexthop_pd_info->rif_handle &
              ~(SWITCH_HANDLE_TYPE_LAG << SWITCH_HANDLE_TYPE_SHIFT);
-    // The RIF param is removed from P4 with 1.7
-#if 0
-    status = tdi_data_field_id_with_action_get(
-        table_info_hdl, LNW_ACTION_SET_NEXTHOP_LAG_PARAM_RIF, action_id,
-        &data_field_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error(
-          "Unable to get data field id param for: %s, "
-          "error: %d",
-          LNW_ACTION_SET_NEXTHOP_LAG_PARAM_RIF, status);
-      goto dealloc_resources;
-    }
-
-    status = tdi_data_field_set_value(data_hdl, data_field_id, lag_id);
-    if (status != TDI_SUCCESS) {
-      krnlmon_log_error("Unable to set action value for ID: %d, error: %d",
-                        data_field_id, status);
-      goto dealloc_resources;
-    }
-#endif
 
     status = tdi_data_field_id_with_action_get(
         table_info_hdl, LNW_ACTION_SET_NEXTHOP_LAG_PARAM_DMAC_HIGH, action_id,

--- a/switchapi/es2k/switch_pd_p4_name_routing.h
+++ b/switchapi/es2k/switch_pd_p4_name_routing.h
@@ -70,6 +70,7 @@
 #define LNW_TX_LAG_TABLE_ACTION_SET_EGRESS_PORT \
   "linux_networking_control.set_egress_port"
 
+#define ACTION_SET_EGRESS_PORT_PARAM_ROUTER_INTF_ID "router_interface_id"
 #define ACTION_SET_EGRESS_PORT_PARAM_EGRESS_PORT "egress_port"
 
 #define LNW_LAG_HASH_SIZE 65536


### PR DESCRIPTION
- Removed unused `router_interface_id` argument from `set_nexthop_lag` action in `nexthop_table`.
- Added `router_interface_id` with `set_egress_port` action for `tx_lag_table` to resolve source MAC address population for LAG scenario.

This aligns with recent changes in the P4 program to address a LAG bug.
 