### PR TITLE
Set label on krnlmon unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,9 @@ add_compile_options(-Werror)
 
 include_directories(.)
 
+# Set the "krnlmon" label on all tests in this directory.
+set_property(DIRECTORY PROPERTY LABELS krnlmon)
+
 if(BUILD_TESTING)
   include(cmake/testing.cmake)
 endif()


### PR DESCRIPTION
- The label can be used with ctest to select the tests to be run or excluded.

```text
dfoster@dgfoster-mobl1:~/work/ovsp4rt$ (cd build; ctest -L krnlmon)
Test project /home/dfoster/work/ovsp4rt/build
    Start 1: switchlink_link_test
1/5 Test #1: switchlink_link_test .............   Passed    0.00 sec
    Start 2: switchlink_address_test
2/5 Test #2: switchlink_address_test ..........   Passed    0.00 sec
    Start 3: switchlink_neighbor_test
3/5 Test #3: switchlink_neighbor_test .........   Passed    0.00 sec
    Start 4: switchlink_route_test
4/5 Test #4: switchlink_route_test ............   Passed    0.00 sec
    Start 5: switchsde_es2k_test
5/5 Test #5: switchsde_es2k_test ..............   Passed    0.00 sec

100% tests passed, 0 tests failed out of 5

Label Time Summary:
krnlmon    =   0.01 sec*proc (5 tests)

Total Test time (real) =   0.02 sec
```