### PR TITLE
Rename build-krnlmon-tests to krnlmon-unit-tests

### DIFF
--- a/cmake/testing.cmake
+++ b/cmake/testing.cmake
@@ -72,11 +72,11 @@ add_custom_target(krnlmon-test
 
 set_target_properties(krnlmon-test PROPERTIES EXCLUDE_FROM_ALL TRUE)
 
-#######################
-# build-krnlmon-tests #
-#######################
+######################
+# krnlmon-unit-tests #
+######################
 
-add_custom_target(build-krnlmon-tests
+add_custom_target(krnlmon-unit-tests
   DEPENDS ${test_targets}
 )
 


### PR DESCRIPTION
1. Target names should generally be nouns.
2. This name parallels ovsp4rt-unit-tests.