### PR TITLE
Address clang-tidy issues

### DIFF
--- a/switchlink/switchlink_db.c
+++ b/switchlink/switchlink_db.c
@@ -1122,7 +1122,7 @@ switchlink_db_status_t switchlink_db_delete_lag_member(
     switchlink_db_lag_member_obj_t* obj = node->data;
     krnlmon_assert(obj != NULL);
     node = node->next;
-    if ((obj->lag_member_info.ifindex == lag_member_info->ifindex)) {
+    if (obj->lag_member_info.ifindex == lag_member_info->ifindex) {
       tommy_list_remove_existing(&switchlink_db_lag_member_obj_list,
                                  &obj->list_node);
       switchlink_free(obj);
@@ -1150,7 +1150,7 @@ uint32_t switchlink_db_delete_lacp_member(switchlink_handle_t lag_h) {
     switchlink_db_lag_member_obj_t* obj = node->data;
     krnlmon_assert(obj != NULL);
     node = node->next;
-    if ((obj->lag_member_info.lag_h == lag_h)) {
+    if (obj->lag_member_info.lag_h == lag_h) {
       return obj->lag_member_info.ifindex;
     }
   }
@@ -1176,7 +1176,7 @@ switchlink_db_status_t switchlink_db_update_lag_member_oper_state(
     switchlink_db_lag_member_obj_t* obj = node->data;
     krnlmon_assert(obj != NULL);
     node = node->next;
-    if ((lag_member_info->ifindex == obj->lag_member_info.ifindex)) {
+    if (lag_member_info->ifindex == obj->lag_member_info.ifindex) {
       obj->lag_member_info.oper_state = lag_member_info->oper_state;
       return SWITCHLINK_DB_STATUS_SUCCESS;
     }
@@ -1204,7 +1204,7 @@ switchlink_db_status_t switchlink_db_get_lag_member_info(
     switchlink_db_lag_member_obj_t* obj = node->data;
     krnlmon_assert(obj != NULL);
     node = node->next;
-    if ((obj->lag_member_info.ifindex == lag_member_info->ifindex)) {
+    if (obj->lag_member_info.ifindex == lag_member_info->ifindex) {
       memcpy(lag_member_info, &(obj->lag_member_info),
              sizeof(switchlink_db_lag_member_info_t));
       return SWITCHLINK_DB_STATUS_SUCCESS;

--- a/switchlink/switchlink_link.c
+++ b/switchlink/switchlink_link.c
@@ -216,7 +216,6 @@ void switchlink_process_link_msg(const struct nlmsghdr* nlmsg, int msgtype) {
   int linkinfo_attr_type;
 
   switchlink_db_interface_info_t intf_info = {0};
-  switchlink_db_tunnel_interface_info_t tnl_intf_info = {0};
   struct link_attrs attrs = {0};
 #ifdef LAG_OPTION
   bool create_lag_member = false;
@@ -334,6 +333,7 @@ void switchlink_process_link_msg(const struct nlmsghdr* nlmsg, int msgtype) {
 
 #if !defined(OVSP4RT_SUPPORT)
       case SWITCHLINK_LINK_TYPE_VXLAN: {
+        switchlink_db_tunnel_interface_info_t tnl_intf_info = {0};
         snprintf(tnl_intf_info.ifname, sizeof(tnl_intf_info.ifname), "%s",
                  attrs.ifname);
         tnl_intf_info.dst_ip = attrs.remote_ip_addr;

--- a/switchlink/switchlink_neigh.c
+++ b/switchlink/switchlink_neigh.c
@@ -123,11 +123,6 @@ void switchlink_process_neigh_msg(const struct nlmsghdr* nlmsg, int msgtype) {
   } else {
     intf_h = ifinfo.intf_h;
   }
-  switchlink_handle_t bridge_h = g_default_bridge_h;
-  if (ifinfo.intf_type == SWITCHLINK_INTF_TYPE_L2_ACCESS) {
-    bridge_h = ifinfo.bridge_h;
-    krnlmon_assert(bridge_h != 0);
-  }
 
   if (msgtype == RTM_NEWNEIGH) {
     if (ipaddr_valid) {


### PR DESCRIPTION
- Deal with a couple of unreferenced variables.

- Remove gratuitous parentheses.