### PR TITLE
Define cmake presets for krnlmon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ MODULE.bazel.lock
 # CMake
 /build/
 /install/
+CMakeUserPresets.json
 
 # VS Code
 /.vscode/

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -39,6 +39,21 @@
             "cacheVariables": {
                 "TDI_TARGET": "es2k"
             }
+        },
+        {
+            "name": "install-path-presets",
+            "description": "Presets for install paths",
+            "hidden": true,
+            "cacheVariables": {
+                "DEPEND_INSTALL_DIR": {
+                    "type": "PATH",
+                    "value": "$env{DEPEND_INSTALL}"
+                },
+                "SDE_INSTALL_DIR": {
+                    "type": "PATH",
+                    "value": "$env{SDE_INSTALL}"
+                }
+            }
         }
     ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,44 @@
+{
+    "version": 4,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 23,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "common-target",
+            "description": "Common presets for all targets",
+            "hidden": true,
+            "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/build",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": true,
+                "CMAKE_INSTALL_PREFIX": {
+                    "type": "PATH",
+                    "value": "${sourceDir}/install"
+                },
+                "SET_RPATH": true
+            }
+        },
+        {
+            "name": "base-dpdk-target",
+            "description": "Base presets for DPDK target",
+            "hidden": true,
+            "inherits": ["common-target"],
+            "cacheVariables": {
+                "TDI_TARGET": "dpdk"
+            }
+        },
+        {
+            "name": "base-es2k-target",
+            "description": "Base presets for ES2K target",
+            "hidden": true,
+            "inherits": ["common-target"],
+            "cacheVariables": {
+                "TDI_TARGET": "es2k"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
- Created a `CMakePresets.json` file for krnlmon.
- Added `CMakeUserPresets.json` to the `.gitignore` file.

Supports standalone cmake builds, for use during development.