### PR TITLE
Respect BUILD_TESTING variable

### DIFF
--- a/switchlink/CMakeLists.txt
+++ b/switchlink/CMakeLists.txt
@@ -46,6 +46,8 @@ target_include_directories(switchlink_o PRIVATE
     ${SAI_INCLUDE_DIR}
 )
 
+if(BUILD_TESTING)
+
 ########################
 # switchlink_link_test #
 ########################
@@ -96,3 +98,5 @@ add_executable(switchlink_route_test
 )
 
 define_unit_test(switchlink_route_test)
+
+endif(BUILD_TESTING)

--- a/switchsde/CMakeLists.txt
+++ b/switchsde/CMakeLists.txt
@@ -23,6 +23,8 @@ endif()
 
 target_include_directories(switchsde_o PUBLIC ${SDE_INSTALL_DIR}/include)
 
+if(BUILD_TESTING)
+
 if(DPDK_TARGET)
 #######################
 # switchsde_dpdk_test #
@@ -58,3 +60,5 @@ target_include_directories(switchsde_es2k_test PRIVATE
 
 define_unit_test(switchsde_es2k_test)
 endif(ES2K_TARGET)
+
+endif(BUILD_TESTING)


### PR DESCRIPTION
- Modified krnlmon to suppress unit test definitions if the BUILD_TESTING variable is false.