### PR TITLE
Fix switchlink_link_test failures

### DIFF
--- a/krnlmon_options.h
+++ b/krnlmon_options.h
@@ -13,6 +13,17 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * ---------------------------------------------------------------------
+ * This header file maps compile-time symbol definitions (such as
+ * ES2K_TARGET) to internal symbol definitions that specify which
+ * features the compile-time symbols enable (such as LAG_OPTION).
+ *
+ * This is infinitely better than leaving the reader scratching
+ * their head, trying to figure out why some random piece of code
+ * is wrapped in an "#if !defined(OVSP4RT_SUPPORT)" conditional
+ * (which the original author didn't bother to comment).
+ * ---------------------------------------------------------------------
  */
 
 #ifndef KRNLMON_OPTIONS_H_
@@ -20,13 +31,15 @@
 
 #if defined(DPDK_TARGET)
 // DPDK options
-
 #elif defined(ES2K_TARGET)
 // ES2K options
 #define LAG_OPTION 1
-
 #else
 #error "ASSERT: Unknown TARGET type!"
+#endif
+
+#if !defined(OVSP4RT_SUPPORT)
+#define VXLAN_OPTION 1
 #endif
 
 #endif  // KRNLMON_OPTIONS_H_

--- a/switchlink/switchlink_link.c
+++ b/switchlink/switchlink_link.c
@@ -331,7 +331,7 @@ void switchlink_process_link_msg(const struct nlmsghdr* nlmsg, int msgtype) {
       case SWITCHLINK_LINK_TYPE_ETH:
         break;
 
-#if !defined(OVSP4RT_SUPPORT)
+#ifdef VXLAN_OPTION
       case SWITCHLINK_LINK_TYPE_VXLAN: {
         switchlink_db_tunnel_interface_info_t tnl_intf_info = {0};
         snprintf(tnl_intf_info.ifname, sizeof(tnl_intf_info.ifname), "%s",
@@ -405,7 +405,7 @@ void switchlink_process_link_msg(const struct nlmsghdr* nlmsg, int msgtype) {
   } else {
     krnlmon_assert(msgtype == RTM_DELLINK);
 
-#if !defined(OVSP4RT_SUPPORT)
+#ifdef VXLAN_OPTION
     if (link_type == SWITCHLINK_LINK_TYPE_VXLAN) {
       switchlink_delete_tunnel_interface(ifmsg->ifi_index);
       return;

--- a/switchlink/switchlink_link_test.cc
+++ b/switchlink/switchlink_link_test.cc
@@ -221,6 +221,8 @@ TEST_F(SwitchlinkTest, can_create_generic_link) {
       0);
 }
 
+#ifdef VXLAN_OPTION
+
 /**
  * Creates a vxlan link.
  *
@@ -300,6 +302,8 @@ TEST_F(SwitchlinkTest, can_create_vxlan_link) {
   EXPECT_EQ(results[0].tunnel_info.ttl, vxlan_ttl);
 }
 
+#endif  // VXLAN_OPTION
+
 /**
  * Attempts to create a bridge link.
  *
@@ -362,6 +366,8 @@ TEST_F(SwitchlinkTest, does_not_create_bridge_link) {
   ASSERT_EQ(results.size(), 0);
 }
 
+#ifdef VXLAN_OPTION
+
 /**
  * Deletes a vxlan link.
  *
@@ -410,6 +416,8 @@ TEST_F(SwitchlinkTest, can_delete_vxlan_link) {
   EXPECT_EQ(results[0].handler, DELETE_TUNNEL_INTERFACE);
   EXPECT_EQ(results[0].ifindex, hdr.ifi_index);
 }
+
+#endif  // VXLAN_OPTION
 
 /**
  * Deletes a tunnel ("tun") link.


### PR DESCRIPTION
The switchlink_link unit test fails when run with the command:

```bash
bazel test --define target=dpdk --//flags:ovs=true //switchlink:all
```

- Addressed the issue by conditionalizing out the two VxLAN test cases when OVSP4RT support is enabled.

- Introduced an internal VXLAN_OPTION conditional to indicate whether VxLAN support is enabled.