### PR TITLE
Krnlmon maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,12 @@
 # Bazel
 /bazel-*
-.bazelrc
 MODULE.bazel
 MODULE.bazel.lock
 
 # CMake
-/build/
-/install/
+build/
+coverage/
+install/
 CMakeUserPresets.json
 
 # VS Code

--- a/scripts/cmake-check-dpdk.sh
+++ b/scripts/cmake-check-dpdk.sh
@@ -10,7 +10,7 @@ cmake --build build -j4 --target install
 echo ""
 echo "===== Test DPDK with OVS ====="
 set +e
-(cd build; ctest)
+(cd build; ctest -L krnlmon --output-on-failure)
 
 echo ""
 echo "===== Build DPDK without OVS ====="
@@ -22,4 +22,4 @@ cmake --build build -j4 --target install
 echo ""
 echo "===== Test DPDK without OVS ====="
 set +e
-(cd build; ctest)
+(cd build; ctest -L krnlmon --output-on-failure)

--- a/scripts/cmake-check-es2k.sh
+++ b/scripts/cmake-check-es2k.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
+rm -fr build install
+
 echo ""
 echo "===== Build ES2K with OVS ====="
-rm -fr build install
 set -e
 cmake -B build -C es2k.cmake -DWITH_OVSP4RT=ON
 cmake --build build -j4 --target install
@@ -10,11 +11,12 @@ cmake --build build -j4 --target install
 echo ""
 echo "===== Test ES2K with OVS ====="
 set +e
-(cd build; ctest)
+(cd build; ctest -L krnlmon --output-on-failure)
+
+rm -fr build install
 
 echo ""
 echo "===== Build ES2K without OVS ====="
-rm -fr build install
 set -e
 cmake -B build -C es2k.cmake -DWITH_OVSP4RT=OFF
 cmake --build build -j4 --target install
@@ -22,4 +24,4 @@ cmake --build build -j4 --target install
 echo ""
 echo "===== Test ES2K without OVS ====="
 set +e
-(cd build; ctest)
+(cd build; ctest -L krnlmon --output-on-failure)

--- a/switchlink/switchlink_link.c
+++ b/switchlink/switchlink_link.c
@@ -243,9 +243,7 @@ static void process_linkinfo_attr(const struct nlattr* attr,
         break;
       case IFLA_INFO_SLAVE_DATA:
         if (*slave_link_type == SWITCHLINK_LINK_TYPE_BOND) {
-#ifdef LAG_OPTION
           *create_lag_member = true;
-#endif
           nla_for_each_nested(infoslavedata, linkinfo, attrlen) {
             process_info_lag_member_data_attr(infoslavedata, attrs);
           }
@@ -277,9 +275,7 @@ void switchlink_process_link_msg(const struct nlmsghdr* nlmsg, int msgtype) {
 
   switchlink_db_interface_info_t intf_info = {0};
   struct link_attrs attrs = {0};
-#ifdef LAG_OPTION
   bool create_lag_member = false;
-#endif
 
   krnlmon_assert((msgtype == RTM_NEWLINK) || (msgtype == RTM_DELLINK));
   ifmsg = nlmsg_data(nlmsg);


### PR DESCRIPTION
- Modified cmake check scripts to specify -L krnlmon and --output-on-failure when running ctest.

- Fixed a compile error in switchlink_link.c caused by the IFLA_LINKINFO refactoring. The create_lag_member must always be defined now, even if LAG_OPTION is undefined, because it's a parameter to process_linkinfo_attr().

- Updated .gitignore file.