### PR TITLE
Pin workflow scripts to Ubuntu-22.04

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -37,7 +37,7 @@ jobs:
   # 1 - dpdk_build_check
   #---------------------------------------------------------------------
   dpdk_build_check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out networking-recipe
@@ -83,7 +83,7 @@ jobs:
   # 2 - dpdk_unit_tests
   #---------------------------------------------------------------------
   dpdk_unit_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out networking-recipe
@@ -129,7 +129,7 @@ jobs:
   # check_clang_format
   #---------------------------------------------------------------------
   check_clang_format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out krnlmon repository

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -26,8 +26,8 @@ env:
   SDE_INSTALL_DIR: /opt/p4dev/dpdk-sde
 
   DEPS_REPOSITORY: ipdk-io/stratum-deps
-  DEPS_TAG: v1.2.1
-  DEPS_FILENAME: deps-ubuntu-latest-x86_64.tar.gz
+  DEPS_TAG: v1.3.4
+  DEPS_FILENAME: deps-ubuntu-1.3.4-x86_64.tar.gz
   DEPS_INSTALL_DIR: /opt/p4dev/x86deps
 
   PREREQS: libbsd-dev libnl-3-dev libnl-route-3-dev libnl-genl-3-dev

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   #---------------------------------------------------------------------
-  # 1 - dpdk_build_check
+  # 1 - dpdk_build_and_test
   #---------------------------------------------------------------------
   dpdk_build_check:
     runs-on: ubuntu-22.04
@@ -72,61 +72,22 @@ jobs:
           sudo apt install $PREREQS
 
       - name: Build krnlmon
-        working-directory: recipe
+        working-directory: recipe/krnlmon/krnlmon
         run: |
           export DEPEND_INSTALL=$DEPS_INSTALL_DIR
           export SDE_INSTALL=$SDE_INSTALL_DIR
-          ./make-all.sh --target=dpdk --rpath --no-ovs --no-build
-          cmake --build build -j4 --target krnlmon
+          cmake -B build -C dpdk.cmake
+          cmake --build build -j4 --target dummy_krnlmon
 
-  #---------------------------------------------------------------------
-  # 2 - dpdk_unit_tests
-  #---------------------------------------------------------------------
-  dpdk_unit_tests:
-    runs-on: ubuntu-22.04
-
-    steps:
-      - name: Check out networking-recipe
-        uses: actions/checkout@v4
-        with:
-          repository: ipdk-io/networking-recipe
-          submodules: recursive
-          path: recipe
-
-      - name: Install dpdk-sde
-        uses: robinraju/release-downloader@v1.11
-        with:
-          repository: ${{ env.SDE_REPOSITORY }}
-          tag: ${{ env.SDE_TAG }}
-          fileName: ${{ env.SDE_FILENAME }}
-      - run: |
-          sudo tar -xzf $SDE_FILENAME -C /
-          rm $SDE_FILENAME
-
-      - name: Install stratum-deps
-        uses: robinraju/release-downloader@v1.11
-        with:
-          repository: ${{ env.DEPS_REPOSITORY }}
-          tag: ${{ env.DEPS_TAG }}
-          fileName: ${{ env.DEPS_FILENAME }}
-      - run: |
-          sudo tar -xzf $DEPS_FILENAME -C /
-          rm $DEPS_FILENAME
-
-      - name: Install prerequisites
-        run: |
-          sudo apt install $PREREQS
-
-      - name: Run dpdk unit tests
-        working-directory: recipe
+      - name: Run unit tests
+        working-directory: recipe/krnlmon/krnlmon
         run: |
           export DEPEND_INSTALL=$DEPS_INSTALL_DIR
           export SDE_INSTALL=$SDE_INSTALL_DIR
-          ./make-all.sh --target=dpdk --no-ovs --no-build
-          cmake --build build --target krnlmon-test
+          cmake --build build -j4 --target krnlmon-test
 
   #---------------------------------------------------------------------
-  # check_clang_format
+  # 2 - check_clang_format
   #---------------------------------------------------------------------
   check_clang_format:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
1. Changed `ubuntu-latest` to `ubuntu-22.04` in the pipeline, in preparation for GitHub bumping ubuntu-latest to 24.04.
2. Modified to build krnlmon in isolation, instead of building it from the networking-recipe folder.
3. Modified to build the dummy application in addition to the library, to check for link errors.
4. Combined the build and unit test jobs into a single build-and-test job.

The first change is in response to the following warning from GitHub Actions:
```text
ubuntu-latest pipelines will use ubuntu-24.04 soon. For more details, see https://github.com/actions/runner- 
images/issues/10636
```